### PR TITLE
Split out constant evaluation into its own file

### DIFF
--- a/build/linux/optional
+++ b/build/linux/optional
@@ -1,0 +1,1049 @@
+// Copyright (C) 2011 - 2012 Andrzej Krzemienski.
+//
+// Use, modification, and distribution is subject to the Boost Software
+// License, Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+//
+// The idea and interface is based on Boost.Optional library
+// authored by Fernando Luis Cacciola Carballal
+
+# ifndef ___OPTIONAL_HPP___
+# define ___OPTIONAL_HPP___
+
+# include <utility>
+# include <type_traits>
+# include <initializer_list>
+# include <cassert>
+# include <functional>
+# include <string>
+# include <stdexcept>
+
+# define TR2_OPTIONAL_REQUIRES(...) typename enable_if<__VA_ARGS__::value, bool>::type = false
+
+# if defined __GNUC__ // NOTE: GNUC is also defined for Clang
+#   if (__GNUC__ == 4) && (__GNUC_MINOR__ >= 8)
+#     define TR2_OPTIONAL_GCC_4_8_AND_HIGHER___
+#   elif (__GNUC__ > 4)
+#     define TR2_OPTIONAL_GCC_4_8_AND_HIGHER___
+#   endif
+#
+#   if (__GNUC__ == 4) && (__GNUC_MINOR__ >= 7)
+#     define TR2_OPTIONAL_GCC_4_7_AND_HIGHER___
+#   elif (__GNUC__ > 4)
+#     define TR2_OPTIONAL_GCC_4_7_AND_HIGHER___
+#   endif
+#
+#   if (__GNUC__ == 4) && (__GNUC_MINOR__ == 8) && (__GNUC_PATCHLEVEL__ >= 1)
+#     define TR2_OPTIONAL_GCC_4_8_1_AND_HIGHER___
+#   elif (__GNUC__ == 4) && (__GNUC_MINOR__ >= 9)
+#     define TR2_OPTIONAL_GCC_4_8_1_AND_HIGHER___
+#   elif (__GNUC__ > 4)
+#     define TR2_OPTIONAL_GCC_4_8_1_AND_HIGHER___
+#   endif
+# endif
+#
+# if defined __clang_major__
+#   if (__clang_major__ == 3 && __clang_minor__ >= 5)
+#     define TR2_OPTIONAL_CLANG_3_5_AND_HIGHTER_
+#   elif (__clang_major__ > 3)
+#     define TR2_OPTIONAL_CLANG_3_5_AND_HIGHTER_
+#   endif
+#   if defined TR2_OPTIONAL_CLANG_3_5_AND_HIGHTER_
+#     define TR2_OPTIONAL_CLANG_3_4_2_AND_HIGHER_
+#   elif (__clang_major__ == 3 && __clang_minor__ == 4 && __clang_patchlevel__ >= 2)
+#     define TR2_OPTIONAL_CLANG_3_4_2_AND_HIGHER_
+#   endif
+# endif
+#
+# if defined _MSC_VER
+#   if (_MSC_VER >= 1900)
+#     define TR2_OPTIONAL_MSVC_2015_AND_HIGHER___
+#   endif
+# endif
+
+# if defined __clang__
+#   if (__clang_major__ > 2) || (__clang_major__ == 2) && (__clang_minor__ >= 9)
+#     define OPTIONAL_HAS_THIS_RVALUE_REFS 1
+#   else
+#     define OPTIONAL_HAS_THIS_RVALUE_REFS 0
+#   endif
+# elif defined TR2_OPTIONAL_GCC_4_8_1_AND_HIGHER___
+#   define OPTIONAL_HAS_THIS_RVALUE_REFS 1
+# elif defined TR2_OPTIONAL_MSVC_2015_AND_HIGHER___
+#   define OPTIONAL_HAS_THIS_RVALUE_REFS 1
+# else
+#   define OPTIONAL_HAS_THIS_RVALUE_REFS 0
+# endif
+
+
+# if defined TR2_OPTIONAL_GCC_4_8_1_AND_HIGHER___
+#   define OPTIONAL_HAS_CONSTEXPR_INIT_LIST 1
+#   define OPTIONAL_CONSTEXPR_INIT_LIST constexpr
+# else
+#   define OPTIONAL_HAS_CONSTEXPR_INIT_LIST 0
+#   define OPTIONAL_CONSTEXPR_INIT_LIST
+# endif
+
+# if defined TR2_OPTIONAL_CLANG_3_5_AND_HIGHTER_ && (defined __cplusplus) && (__cplusplus != 201103L)
+#   define OPTIONAL_HAS_MOVE_ACCESSORS 1
+# else
+#   define OPTIONAL_HAS_MOVE_ACCESSORS 0
+# endif
+
+# // In C++11 constexpr implies const, so we need to make non-const members also non-constexpr
+# if (defined __cplusplus) && (__cplusplus == 201103L)
+#   define OPTIONAL_MUTABLE_CONSTEXPR
+# else
+#   define OPTIONAL_MUTABLE_CONSTEXPR constexpr
+# endif
+
+namespace std{
+
+// BEGIN workaround for missing is_trivially_destructible
+# if defined TR2_OPTIONAL_GCC_4_8_AND_HIGHER___
+    // leave it: it is already there
+# elif defined TR2_OPTIONAL_CLANG_3_4_2_AND_HIGHER_
+    // leave it: it is already there
+# elif defined TR2_OPTIONAL_MSVC_2015_AND_HIGHER___
+    // leave it: it is already there
+# elif defined TR2_OPTIONAL_DISABLE_EMULATION_OF_TYPE_TRAITS
+    // leave it: the user doesn't want it
+# else
+	template <typename T>
+	using is_trivially_destructible = std::has_trivial_destructor<T>;
+# endif
+// END workaround for missing is_trivially_destructible
+
+# if (defined TR2_OPTIONAL_GCC_4_7_AND_HIGHER___)
+    // leave it; our metafunctions are already defined.
+# elif defined TR2_OPTIONAL_CLANG_3_4_2_AND_HIGHER_
+    // leave it; our metafunctions are already defined.
+# elif defined TR2_OPTIONAL_MSVC_2015_AND_HIGHER___
+    // leave it: it is already there
+# elif defined TR2_OPTIONAL_DISABLE_EMULATION_OF_TYPE_TRAITS
+    // leave it: the user doesn't want it
+# else
+
+
+// workaround for missing traits in GCC and CLANG
+template <class T>
+struct is_nothrow_move_constructible
+{
+  constexpr static bool value = std::is_nothrow_constructible<T, T&&>::value;
+};
+
+
+template <class T, class U>
+struct is_assignable
+{
+  template <class X, class Y>
+  constexpr static bool has_assign(...) { return false; }
+
+  template <class X, class Y, size_t S = sizeof((std::declval<X>() = std::declval<Y>(), true)) >
+  // the comma operator is necessary for the cases where operator= returns void
+  constexpr static bool has_assign(bool) { return true; }
+
+  constexpr static bool value = has_assign<T, U>(true);
+};
+
+
+template <class T>
+struct is_nothrow_move_assignable
+{
+  template <class X, bool has_any_move_assign>
+  struct has_nothrow_move_assign {
+    constexpr static bool value = false;
+  };
+
+  template <class X>
+  struct has_nothrow_move_assign<X, true> {
+    constexpr static bool value = noexcept( std::declval<X&>() = std::declval<X&&>() );
+  };
+
+  constexpr static bool value = has_nothrow_move_assign<T, is_assignable<T&, T&&>::value>::value;
+};
+// end workaround
+
+
+# endif
+
+
+
+// 20.5.4, optional for object types
+template <class T> class optional;
+
+// 20.5.5, optional for lvalue reference types
+template <class T> class optional<T&>;
+
+
+// workaround: std utility functions aren't constexpr yet
+template <class T> inline constexpr T&& constexpr_forward(typename std::remove_reference<T>::type& t) noexcept
+{
+  return static_cast<T&&>(t);
+}
+
+template <class T> inline constexpr T&& constexpr_forward(typename std::remove_reference<T>::type&& t) noexcept
+{
+    static_assert(!std::is_lvalue_reference<T>::value, "!!");
+    return static_cast<T&&>(t);
+}
+
+template <class T> inline constexpr typename std::remove_reference<T>::type&& constexpr_move(T&& t) noexcept
+{
+    return static_cast<typename std::remove_reference<T>::type&&>(t);
+}
+
+
+#if defined NDEBUG
+# define TR2_OPTIONAL_ASSERTED_EXPRESSION(CHECK, EXPR) (EXPR)
+#else
+# define TR2_OPTIONAL_ASSERTED_EXPRESSION(CHECK, EXPR) ((CHECK) ? (EXPR) : ([]{assert(!#CHECK);}(), (EXPR)))
+#endif
+
+
+namespace detail_
+{
+
+// static_addressof: a constexpr version of addressof
+template <typename T>
+struct has_overloaded_addressof
+{
+  template <class X>
+  constexpr static bool has_overload(...) { return false; }
+
+  template <class X, size_t S = sizeof(std::declval<X&>().operator&()) >
+  constexpr static bool has_overload(bool) { return true; }
+
+  constexpr static bool value = has_overload<T>(true);
+};
+
+template <typename T, TR2_OPTIONAL_REQUIRES(!has_overloaded_addressof<T>)>
+constexpr T* static_addressof(T& ref)
+{
+  return &ref;
+}
+
+template <typename T, TR2_OPTIONAL_REQUIRES(has_overloaded_addressof<T>)>
+T* static_addressof(T& ref)
+{
+  return std::addressof(ref);
+}
+
+
+// the call to convert<A>(b) has return type A and converts b to type A iff b decltype(b) is implicitly convertible to A
+template <class U>
+constexpr U convert(U v) { return v; }
+
+} // namespace detail
+
+
+constexpr struct trivial_init_t{} trivial_init{};
+
+
+// 20.5.6, In-place construction
+constexpr struct in_place_t{} in_place{};
+
+
+// 20.5.7, Disengaged state indicator
+struct nullopt_t
+{
+  struct init{};
+  constexpr explicit nullopt_t(init){}
+};
+constexpr nullopt_t nullopt{nullopt_t::init()};
+
+
+// 20.5.8, class bad_optional_access
+class bad_optional_access : public logic_error {
+public:
+  explicit bad_optional_access(const string& what_arg) : logic_error{what_arg} {}
+  explicit bad_optional_access(const char* what_arg) : logic_error{what_arg} {}
+};
+
+
+template <class T>
+union storage_t
+{
+  unsigned char dummy_;
+  T value_;
+
+  constexpr storage_t( trivial_init_t ) noexcept : dummy_() {};
+
+  template <class... Args>
+  constexpr storage_t( Args&&... args ) : value_(constexpr_forward<Args>(args)...) {}
+
+  ~storage_t(){}
+};
+
+
+template <class T>
+union constexpr_storage_t
+{
+    unsigned char dummy_;
+    T value_;
+
+    constexpr constexpr_storage_t( trivial_init_t ) noexcept : dummy_() {};
+
+    template <class... Args>
+    constexpr constexpr_storage_t( Args&&... args ) : value_(constexpr_forward<Args>(args)...) {}
+
+    ~constexpr_storage_t() = default;
+};
+
+
+template <class T>
+struct optional_base
+{
+    bool init_;
+    storage_t<T> storage_;
+
+    constexpr optional_base() noexcept : init_(false), storage_(trivial_init) {};
+
+    explicit constexpr optional_base(const T& v) : init_(true), storage_(v) {}
+
+    explicit constexpr optional_base(T&& v) : init_(true), storage_(constexpr_move(v)) {}
+
+    template <class... Args> explicit optional_base(in_place_t, Args&&... args)
+        : init_(true), storage_(constexpr_forward<Args>(args)...) {}
+
+    template <class U, class... Args, TR2_OPTIONAL_REQUIRES(is_constructible<T, std::initializer_list<U>>)>
+    explicit optional_base(in_place_t, std::initializer_list<U> il, Args&&... args)
+        : init_(true), storage_(il, std::forward<Args>(args)...) {}
+
+    ~optional_base() { if (init_) storage_.value_.T::~T(); }
+};
+
+
+template <class T>
+struct constexpr_optional_base
+{
+    bool init_;
+    constexpr_storage_t<T> storage_;
+
+    constexpr constexpr_optional_base() noexcept : init_(false), storage_(trivial_init) {};
+
+    explicit constexpr constexpr_optional_base(const T& v) : init_(true), storage_(v) {}
+
+    explicit constexpr constexpr_optional_base(T&& v) : init_(true), storage_(constexpr_move(v)) {}
+
+    template <class... Args> explicit constexpr constexpr_optional_base(in_place_t, Args&&... args)
+      : init_(true), storage_(constexpr_forward<Args>(args)...) {}
+
+    template <class U, class... Args, TR2_OPTIONAL_REQUIRES(is_constructible<T, std::initializer_list<U>>)>
+    OPTIONAL_CONSTEXPR_INIT_LIST explicit constexpr_optional_base(in_place_t, std::initializer_list<U> il, Args&&... args)
+      : init_(true), storage_(il, std::forward<Args>(args)...) {}
+
+    ~constexpr_optional_base() = default;
+};
+
+template <class T>
+using OptionalBase = typename std::conditional<
+    is_trivially_destructible<T>::value,                          // if possible
+    constexpr_optional_base<typename std::remove_const<T>::type>, // use base with trivial destructor
+    optional_base<typename std::remove_const<T>::type>
+>::type;
+
+
+
+template <class T>
+class optional : private OptionalBase<T>
+{
+  static_assert( !std::is_same<typename std::decay<T>::type, nullopt_t>::value, "bad T" );
+  static_assert( !std::is_same<typename std::decay<T>::type, in_place_t>::value, "bad T" );
+
+
+  constexpr bool initialized() const noexcept { return OptionalBase<T>::init_; }
+  typename std::remove_const<T>::type* dataptr() {  return std::addressof(OptionalBase<T>::storage_.value_); }
+  constexpr const T* dataptr() const { return detail_::static_addressof(OptionalBase<T>::storage_.value_); }
+
+# if OPTIONAL_HAS_THIS_RVALUE_REFS == 1
+  constexpr const T& contained_val() const& { return OptionalBase<T>::storage_.value_; }
+#   if OPTIONAL_HAS_MOVE_ACCESSORS == 1
+  OPTIONAL_MUTABLE_CONSTEXPR T&& contained_val() && { return std::move(OptionalBase<T>::storage_.value_); }
+  OPTIONAL_MUTABLE_CONSTEXPR T& contained_val() & { return OptionalBase<T>::storage_.value_; }
+#   else
+  T& contained_val() & { return OptionalBase<T>::storage_.value_; }
+  T&& contained_val() && { return std::move(OptionalBase<T>::storage_.value_); }
+#   endif
+# else
+  constexpr const T& contained_val() const { return OptionalBase<T>::storage_.value_; }
+  T& contained_val() { return OptionalBase<T>::storage_.value_; }
+# endif
+
+  void clear() noexcept {
+    if (initialized()) dataptr()->T::~T();
+    OptionalBase<T>::init_ = false;
+  }
+
+  template <class... Args>
+  void initialize(Args&&... args) noexcept(noexcept(T(std::forward<Args>(args)...)))
+  {
+    assert(!OptionalBase<T>::init_);
+    ::new (static_cast<void*>(dataptr())) T(std::forward<Args>(args)...);
+    OptionalBase<T>::init_ = true;
+  }
+
+  template <class U, class... Args>
+  void initialize(std::initializer_list<U> il, Args&&... args) noexcept(noexcept(T(il, std::forward<Args>(args)...)))
+  {
+    assert(!OptionalBase<T>::init_);
+    ::new (static_cast<void*>(dataptr())) T(il, std::forward<Args>(args)...);
+    OptionalBase<T>::init_ = true;
+  }
+
+public:
+  typedef T value_type;
+
+  // 20.5.5.1, constructors
+  constexpr optional() noexcept : OptionalBase<T>()  {};
+  constexpr optional(nullopt_t) noexcept : OptionalBase<T>() {};
+
+  optional(const optional& rhs)
+  : OptionalBase<T>()
+  {
+    if (rhs.initialized()) {
+        ::new (static_cast<void*>(dataptr())) T(*rhs);
+        OptionalBase<T>::init_ = true;
+    }
+  }
+
+  optional(optional&& rhs) noexcept(is_nothrow_move_constructible<T>::value)
+  : OptionalBase<T>()
+  {
+    if (rhs.initialized()) {
+        ::new (static_cast<void*>(dataptr())) T(std::move(*rhs));
+        OptionalBase<T>::init_ = true;
+    }
+  }
+
+  constexpr optional(const T& v) : OptionalBase<T>(v) {}
+
+  constexpr optional(T&& v) : OptionalBase<T>(constexpr_move(v)) {}
+
+  template <class... Args>
+  explicit constexpr optional(in_place_t, Args&&... args)
+  : OptionalBase<T>(in_place_t{}, constexpr_forward<Args>(args)...) {}
+
+  template <class U, class... Args, TR2_OPTIONAL_REQUIRES(is_constructible<T, std::initializer_list<U>>)>
+  OPTIONAL_CONSTEXPR_INIT_LIST explicit optional(in_place_t, std::initializer_list<U> il, Args&&... args)
+  : OptionalBase<T>(in_place_t{}, il, constexpr_forward<Args>(args)...) {}
+
+  // 20.5.4.2, Destructor
+  ~optional() = default;
+
+  // 20.5.4.3, assignment
+  optional& operator=(nullopt_t) noexcept
+  {
+    clear();
+    return *this;
+  }
+
+  optional& operator=(const optional& rhs)
+  {
+    if      (initialized() == true  && rhs.initialized() == false) clear();
+    else if (initialized() == false && rhs.initialized() == true)  initialize(*rhs);
+    else if (initialized() == true  && rhs.initialized() == true)  contained_val() = *rhs;
+    return *this;
+  }
+
+  optional& operator=(optional&& rhs)
+  noexcept(is_nothrow_move_assignable<T>::value && is_nothrow_move_constructible<T>::value)
+  {
+    if      (initialized() == true  && rhs.initialized() == false) clear();
+    else if (initialized() == false && rhs.initialized() == true)  initialize(std::move(*rhs));
+    else if (initialized() == true  && rhs.initialized() == true)  contained_val() = std::move(*rhs);
+    return *this;
+  }
+
+  template <class U>
+  auto operator=(U&& v)
+  -> typename enable_if
+  <
+    is_same<typename decay<U>::type, T>::value,
+    optional&
+  >::type
+  {
+    if (initialized()) { contained_val() = std::forward<U>(v); }
+    else               { initialize(std::forward<U>(v));  }
+    return *this;
+  }
+
+
+  template <class... Args>
+  void emplace(Args&&... args)
+  {
+    clear();
+    initialize(std::forward<Args>(args)...);
+  }
+
+  template <class U, class... Args>
+  void emplace(initializer_list<U> il, Args&&... args)
+  {
+    clear();
+    initialize<U, Args...>(il, std::forward<Args>(args)...);
+  }
+
+  // 20.5.4.4, Swap
+  void swap(optional<T>& rhs) noexcept(is_nothrow_move_constructible<T>::value && noexcept(swap(declval<T&>(), declval<T&>())))
+  {
+    if      (initialized() == true  && rhs.initialized() == false) { rhs.initialize(std::move(**this)); clear(); }
+    else if (initialized() == false && rhs.initialized() == true)  { initialize(std::move(*rhs)); rhs.clear(); }
+    else if (initialized() == true  && rhs.initialized() == true)  { using std::swap; swap(**this, *rhs); }
+  }
+
+  // 20.5.4.5, Observers
+
+  explicit constexpr operator bool() const noexcept { return initialized(); }
+  constexpr bool has_value() const noexcept { return initialized(); }
+
+  constexpr T const* operator ->() const {
+    return TR2_OPTIONAL_ASSERTED_EXPRESSION(initialized(), dataptr());
+  }
+
+# if OPTIONAL_HAS_MOVE_ACCESSORS == 1
+
+  OPTIONAL_MUTABLE_CONSTEXPR T* operator ->() {
+    assert (initialized());
+    return dataptr();
+  }
+
+  constexpr T const& operator *() const& {
+    return TR2_OPTIONAL_ASSERTED_EXPRESSION(initialized(), contained_val());
+  }
+
+  OPTIONAL_MUTABLE_CONSTEXPR T& operator *() & {
+    assert (initialized());
+    return contained_val();
+  }
+
+  OPTIONAL_MUTABLE_CONSTEXPR T&& operator *() && {
+    assert (initialized());
+    return constexpr_move(contained_val());
+  }
+
+  constexpr T const& value() const& {
+    return initialized() ? contained_val() : (throw bad_optional_access("bad optional access"), contained_val());
+  }
+
+  OPTIONAL_MUTABLE_CONSTEXPR T& value() & {
+    return initialized() ? contained_val() : (throw bad_optional_access("bad optional access"), contained_val());
+  }
+
+  OPTIONAL_MUTABLE_CONSTEXPR T&& value() && {
+    if (!initialized()) throw bad_optional_access("bad optional access");
+	return std::move(contained_val());
+  }
+
+# else
+
+  T* operator ->() {
+    assert (initialized());
+    return dataptr();
+  }
+
+  constexpr T const& operator *() const {
+    return TR2_OPTIONAL_ASSERTED_EXPRESSION(initialized(), contained_val());
+  }
+
+  T& operator *() {
+    assert (initialized());
+    return contained_val();
+  }
+
+  constexpr T const& value() const {
+    return initialized() ? contained_val() : (throw bad_optional_access("bad optional access"), contained_val());
+  }
+
+  T& value() {
+    return initialized() ? contained_val() : (throw bad_optional_access("bad optional access"), contained_val());
+  }
+
+# endif
+
+# if OPTIONAL_HAS_THIS_RVALUE_REFS == 1
+
+  template <class V>
+  constexpr T value_or(V&& v) const&
+  {
+    return *this ? **this : detail_::convert<T>(constexpr_forward<V>(v));
+  }
+
+#   if OPTIONAL_HAS_MOVE_ACCESSORS == 1
+
+  template <class V>
+  OPTIONAL_MUTABLE_CONSTEXPR T value_or(V&& v) &&
+  {
+    return *this ? constexpr_move(const_cast<optional<T>&>(*this).contained_val()) : detail_::convert<T>(constexpr_forward<V>(v));
+  }
+
+#   else
+
+  template <class V>
+  T value_or(V&& v) &&
+  {
+    return *this ? constexpr_move(const_cast<optional<T>&>(*this).contained_val()) : detail_::convert<T>(constexpr_forward<V>(v));
+  }
+
+#   endif
+
+# else
+
+  template <class V>
+  constexpr T value_or(V&& v) const
+  {
+    return *this ? **this : detail_::convert<T>(constexpr_forward<V>(v));
+  }
+
+# endif
+
+  // 20.6.3.6, modifiers
+  void reset() noexcept { clear(); }
+};
+
+
+template <class T>
+class optional<T&>
+{
+  static_assert( !std::is_same<T, nullopt_t>::value, "bad T" );
+  static_assert( !std::is_same<T, in_place_t>::value, "bad T" );
+  T* ref;
+
+public:
+
+  // 20.5.5.1, construction/destruction
+  constexpr optional() noexcept : ref(nullptr) {}
+
+  constexpr optional(nullopt_t) noexcept : ref(nullptr) {}
+
+  constexpr optional(T& v) noexcept : ref(detail_::static_addressof(v)) {}
+
+  optional(T&&) = delete;
+
+  constexpr optional(const optional& rhs) noexcept : ref(rhs.ref) {}
+
+  explicit constexpr optional(in_place_t, T& v) noexcept : ref(detail_::static_addressof(v)) {}
+
+  explicit optional(in_place_t, T&&) = delete;
+
+  ~optional() = default;
+
+  // 20.5.5.2, mutation
+  optional& operator=(nullopt_t) noexcept {
+    ref = nullptr;
+    return *this;
+  }
+
+  // optional& operator=(const optional& rhs) noexcept {
+    // ref = rhs.ref;
+    // return *this;
+  // }
+
+  // optional& operator=(optional&& rhs) noexcept {
+    // ref = rhs.ref;
+    // return *this;
+  // }
+
+  template <typename U>
+  auto operator=(U&& rhs) noexcept
+  -> typename enable_if
+  <
+    is_same<typename decay<U>::type, optional<T&>>::value,
+    optional&
+  >::type
+  {
+    ref = rhs.ref;
+    return *this;
+  }
+
+  template <typename U>
+  auto operator=(U&& rhs) noexcept
+  -> typename enable_if
+  <
+    !is_same<typename decay<U>::type, optional<T&>>::value,
+    optional&
+  >::type
+  = delete;
+
+  void emplace(T& v) noexcept {
+    ref = detail_::static_addressof(v);
+  }
+
+  void emplace(T&&) = delete;
+
+
+  void swap(optional<T&>& rhs) noexcept
+  {
+    std::swap(ref, rhs.ref);
+  }
+
+  // 20.5.5.3, observers
+  constexpr T* operator->() const {
+    return TR2_OPTIONAL_ASSERTED_EXPRESSION(ref, ref);
+  }
+
+  constexpr T& operator*() const {
+    return TR2_OPTIONAL_ASSERTED_EXPRESSION(ref, *ref);
+  }
+
+  constexpr T& value() const {
+    return ref ? *ref : (throw bad_optional_access("bad optional access"), *ref);
+  }
+
+  explicit constexpr operator bool() const noexcept {
+    return ref != nullptr;
+  }
+
+  constexpr bool has_value() const noexcept {
+    return ref != nullptr;
+  }
+
+  template <class V>
+  constexpr typename decay<T>::type value_or(V&& v) const
+  {
+    return *this ? **this : detail_::convert<typename decay<T>::type>(constexpr_forward<V>(v));
+  }
+
+  // x.x.x.x, modifiers
+  void reset() noexcept { ref = nullptr; }
+};
+
+
+template <class T>
+class optional<T&&>
+{
+  static_assert( sizeof(T) == 0, "optional rvalue references disallowed" );
+};
+
+
+// 20.5.8, Relational operators
+template <class T> constexpr bool operator==(const optional<T>& x, const optional<T>& y)
+{
+  return bool(x) != bool(y) ? false : bool(x) == false ? true : *x == *y;
+}
+
+template <class T> constexpr bool operator!=(const optional<T>& x, const optional<T>& y)
+{
+  return !(x == y);
+}
+
+template <class T> constexpr bool operator<(const optional<T>& x, const optional<T>& y)
+{
+  return (!y) ? false : (!x) ? true : *x < *y;
+}
+
+template <class T> constexpr bool operator>(const optional<T>& x, const optional<T>& y)
+{
+  return (y < x);
+}
+
+template <class T> constexpr bool operator<=(const optional<T>& x, const optional<T>& y)
+{
+  return !(y < x);
+}
+
+template <class T> constexpr bool operator>=(const optional<T>& x, const optional<T>& y)
+{
+  return !(x < y);
+}
+
+
+// 20.5.9, Comparison with nullopt
+template <class T> constexpr bool operator==(const optional<T>& x, nullopt_t) noexcept
+{
+  return (!x);
+}
+
+template <class T> constexpr bool operator==(nullopt_t, const optional<T>& x) noexcept
+{
+  return (!x);
+}
+
+template <class T> constexpr bool operator!=(const optional<T>& x, nullopt_t) noexcept
+{
+  return bool(x);
+}
+
+template <class T> constexpr bool operator!=(nullopt_t, const optional<T>& x) noexcept
+{
+  return bool(x);
+}
+
+template <class T> constexpr bool operator<(const optional<T>&, nullopt_t) noexcept
+{
+  return false;
+}
+
+template <class T> constexpr bool operator<(nullopt_t, const optional<T>& x) noexcept
+{
+  return bool(x);
+}
+
+template <class T> constexpr bool operator<=(const optional<T>& x, nullopt_t) noexcept
+{
+  return (!x);
+}
+
+template <class T> constexpr bool operator<=(nullopt_t, const optional<T>&) noexcept
+{
+  return true;
+}
+
+template <class T> constexpr bool operator>(const optional<T>& x, nullopt_t) noexcept
+{
+  return bool(x);
+}
+
+template <class T> constexpr bool operator>(nullopt_t, const optional<T>&) noexcept
+{
+  return false;
+}
+
+template <class T> constexpr bool operator>=(const optional<T>&, nullopt_t) noexcept
+{
+  return true;
+}
+
+template <class T> constexpr bool operator>=(nullopt_t, const optional<T>& x) noexcept
+{
+  return (!x);
+}
+
+
+
+// 20.5.10, Comparison with T
+template <class T> constexpr bool operator==(const optional<T>& x, const T& v)
+{
+  return bool(x) ? *x == v : false;
+}
+
+template <class T> constexpr bool operator==(const T& v, const optional<T>& x)
+{
+  return bool(x) ? v == *x : false;
+}
+
+template <class T> constexpr bool operator!=(const optional<T>& x, const T& v)
+{
+  return bool(x) ? *x != v : true;
+}
+
+template <class T> constexpr bool operator!=(const T& v, const optional<T>& x)
+{
+  return bool(x) ? v != *x : true;
+}
+
+template <class T> constexpr bool operator<(const optional<T>& x, const T& v)
+{
+  return bool(x) ? *x < v : true;
+}
+
+template <class T> constexpr bool operator>(const T& v, const optional<T>& x)
+{
+  return bool(x) ? v > *x : true;
+}
+
+template <class T> constexpr bool operator>(const optional<T>& x, const T& v)
+{
+  return bool(x) ? *x > v : false;
+}
+
+template <class T> constexpr bool operator<(const T& v, const optional<T>& x)
+{
+  return bool(x) ? v < *x : false;
+}
+
+template <class T> constexpr bool operator>=(const optional<T>& x, const T& v)
+{
+  return bool(x) ? *x >= v : false;
+}
+
+template <class T> constexpr bool operator<=(const T& v, const optional<T>& x)
+{
+  return bool(x) ? v <= *x : false;
+}
+
+template <class T> constexpr bool operator<=(const optional<T>& x, const T& v)
+{
+  return bool(x) ? *x <= v : true;
+}
+
+template <class T> constexpr bool operator>=(const T& v, const optional<T>& x)
+{
+  return bool(x) ? v >= *x : true;
+}
+
+
+// Comparison of optional<T&> with T
+template <class T> constexpr bool operator==(const optional<T&>& x, const T& v)
+{
+  return bool(x) ? *x == v : false;
+}
+
+template <class T> constexpr bool operator==(const T& v, const optional<T&>& x)
+{
+  return bool(x) ? v == *x : false;
+}
+
+template <class T> constexpr bool operator!=(const optional<T&>& x, const T& v)
+{
+  return bool(x) ? *x != v : true;
+}
+
+template <class T> constexpr bool operator!=(const T& v, const optional<T&>& x)
+{
+  return bool(x) ? v != *x : true;
+}
+
+template <class T> constexpr bool operator<(const optional<T&>& x, const T& v)
+{
+  return bool(x) ? *x < v : true;
+}
+
+template <class T> constexpr bool operator>(const T& v, const optional<T&>& x)
+{
+  return bool(x) ? v > *x : true;
+}
+
+template <class T> constexpr bool operator>(const optional<T&>& x, const T& v)
+{
+  return bool(x) ? *x > v : false;
+}
+
+template <class T> constexpr bool operator<(const T& v, const optional<T&>& x)
+{
+  return bool(x) ? v < *x : false;
+}
+
+template <class T> constexpr bool operator>=(const optional<T&>& x, const T& v)
+{
+  return bool(x) ? *x >= v : false;
+}
+
+template <class T> constexpr bool operator<=(const T& v, const optional<T&>& x)
+{
+  return bool(x) ? v <= *x : false;
+}
+
+template <class T> constexpr bool operator<=(const optional<T&>& x, const T& v)
+{
+  return bool(x) ? *x <= v : true;
+}
+
+template <class T> constexpr bool operator>=(const T& v, const optional<T&>& x)
+{
+  return bool(x) ? v >= *x : true;
+}
+
+// Comparison of optional<T const&> with T
+template <class T> constexpr bool operator==(const optional<const T&>& x, const T& v)
+{
+  return bool(x) ? *x == v : false;
+}
+
+template <class T> constexpr bool operator==(const T& v, const optional<const T&>& x)
+{
+  return bool(x) ? v == *x : false;
+}
+
+template <class T> constexpr bool operator!=(const optional<const T&>& x, const T& v)
+{
+  return bool(x) ? *x != v : true;
+}
+
+template <class T> constexpr bool operator!=(const T& v, const optional<const T&>& x)
+{
+  return bool(x) ? v != *x : true;
+}
+
+template <class T> constexpr bool operator<(const optional<const T&>& x, const T& v)
+{
+  return bool(x) ? *x < v : true;
+}
+
+template <class T> constexpr bool operator>(const T& v, const optional<const T&>& x)
+{
+  return bool(x) ? v > *x : true;
+}
+
+template <class T> constexpr bool operator>(const optional<const T&>& x, const T& v)
+{
+  return bool(x) ? *x > v : false;
+}
+
+template <class T> constexpr bool operator<(const T& v, const optional<const T&>& x)
+{
+  return bool(x) ? v < *x : false;
+}
+
+template <class T> constexpr bool operator>=(const optional<const T&>& x, const T& v)
+{
+  return bool(x) ? *x >= v : false;
+}
+
+template <class T> constexpr bool operator<=(const T& v, const optional<const T&>& x)
+{
+  return bool(x) ? v <= *x : false;
+}
+
+template <class T> constexpr bool operator<=(const optional<const T&>& x, const T& v)
+{
+  return bool(x) ? *x <= v : true;
+}
+
+template <class T> constexpr bool operator>=(const T& v, const optional<const T&>& x)
+{
+  return bool(x) ? v >= *x : true;
+}
+
+
+// 20.5.12, Specialized algorithms
+template <class T>
+void swap(optional<T>& x, optional<T>& y) noexcept(noexcept(x.swap(y)))
+{
+  x.swap(y);
+}
+
+
+template <class T>
+constexpr optional<typename decay<T>::type> make_optional(T&& v)
+{
+  return optional<typename decay<T>::type>(constexpr_forward<T>(v));
+}
+
+template <class X>
+constexpr optional<X&> make_optional(reference_wrapper<X> v)
+{
+  return optional<X&>(v.get());
+}
+
+
+} // namespace std
+
+namespace std
+{
+  template <typename T>
+  struct hash<std::optional<T>>
+  {
+    typedef typename hash<T>::result_type result_type;
+    typedef std::optional<T> argument_type;
+
+    constexpr result_type operator()(argument_type const& arg) const {
+      return arg ? std::hash<T>{}(*arg) : result_type{};
+    }
+  };
+
+  template <typename T>
+  struct hash<std::optional<T&>>
+  {
+    typedef typename hash<T>::result_type result_type;
+    typedef std::optional<T&> argument_type;
+
+    constexpr result_type operator()(argument_type const& arg) const {
+      return arg ? std::hash<T>{}(*arg) : result_type{};
+    }
+  };
+}
+
+# undef TR2_OPTIONAL_REQUIRES
+# undef TR2_OPTIONAL_ASSERTED_EXPRESSION
+
+# endif //___OPTIONAL_HPP___

--- a/build/linux/variant
+++ b/build/linux/variant
@@ -4,4 +4,5 @@ namespace std {
 	using mpark::variant;
 	using mpark::get;
 	using mpark::get_if;
+    using mpark::monostate;
 }

--- a/include/BoundNodes.h
+++ b/include/BoundNodes.h
@@ -28,7 +28,6 @@ class BoundExpression : public BoundNode {
 public:
     const ExpressionSyntax* syntax;
     const TypeSymbol* type;
-    ConstantValue constantValue;
     bool bad;
 
     BoundExpression(BoundNodeKind kind, const ExpressionSyntax* syntax, const TypeSymbol* type, bool bad) :
@@ -47,6 +46,8 @@ public:
 
 class BoundLiteral : public BoundExpression {
 public:
+    ConstantValue value;
+
     BoundLiteral(const ExpressionSyntax* syntax, const TypeSymbol* type, bool bad) :
         BoundExpression(BoundNodeKind::Literal, syntax, type, bad)
     {

--- a/include/ConstantEvaluator.h
+++ b/include/ConstantEvaluator.h
@@ -1,0 +1,28 @@
+//------------------------------------------------------------------------------
+// ConstantEvaluator.h
+// Compile-time constant evaluation.
+//
+// File is under the MIT license:
+//------------------------------------------------------------------------------
+#pragma once
+
+#include <optional>
+
+#include "AllSyntax.h"
+#include "BoundNodes.h"
+#include "Diagnostics.h"
+
+namespace slang {
+
+class SemanticModel;
+class Scope;
+
+/// The ConstantEvaluator takes a bound tree and evaluates it to determine its
+/// constant value. If the tree is not constant, appropriately diagnostics will
+/// be emitted to allow the user to track down what went wrong.
+class ConstantEvaluator {
+public:
+    ConstantValue evaluate(const BoundNode* tree);
+};
+
+}

--- a/include/ConstantEvaluator.h
+++ b/include/ConstantEvaluator.h
@@ -23,6 +23,12 @@ class Scope;
 class ConstantEvaluator {
 public:
     ConstantValue evaluate(const BoundNode* tree);
+
+private:
+    ConstantValue evaluateLiteral(const BoundLiteral* expr);
+    ConstantValue evaluateParameter(const BoundParameter* expr);
+    ConstantValue evaluateUnary(const BoundUnaryExpression* expr);
+    ConstantValue evaluateBinary(const BoundBinaryExpression* expr);
 };
 
 }

--- a/include/ConstantValue.h
+++ b/include/ConstantValue.h
@@ -1,0 +1,45 @@
+//------------------------------------------------------------------------------
+// ConstantValue.h
+// Compile-time constant representation.
+//
+// File is under the MIT license:
+//------------------------------------------------------------------------------
+#pragma once
+
+#include <variant>
+
+#include "SVInt.h"
+
+namespace slang {
+
+using ConstantValueBase = std::variant<std::monostate, SVInt, double>;
+
+struct ConstantValue : ConstantValueBase {
+    ConstantValue() : ConstantValueBase() {}
+    ConstantValue(std::nullptr_t) : ConstantValueBase() {}
+
+    ConstantValue(const SVInt& integer) : ConstantValueBase(integer) {}
+    ConstantValue(SVInt&& integer) : ConstantValueBase(std::move(integer)) {}
+    ConstantValue(double real) : ConstantValueBase(real) {}
+
+    ConstantValue(const ConstantValue& other) : ConstantValueBase(other) {}
+    ConstantValue(ConstantValue&& other) noexcept : ConstantValueBase(std::move(other)) {}
+
+    ConstantValue& operator=(const ConstantValue& other) {
+        ConstantValueBase::operator=(other);
+        return *this;
+    }
+
+    ConstantValue& operator=(ConstantValue&& other) noexcept {
+        ConstantValueBase::operator=(std::move(other));
+        return *this;
+    }
+
+    bool bad() const { return index() == 0; }
+    explicit operator bool() const { return !bad(); }
+
+    const SVInt& integer() const { return std::get<1>(*this); }
+    double real() const { return std::get<2>(*this); }
+};
+
+}

--- a/include/ExpressionBinder.h
+++ b/include/ExpressionBinder.h
@@ -1,7 +1,6 @@
 //------------------------------------------------------------------------------
 // ExpressionBinder.h
-// Centralized code for convert expressions into AST trees
-// (also includes constant folding).
+// Centralized code for convert expressions into an AST.
 //
 // File is under the MIT license:
 //------------------------------------------------------------------------------
@@ -40,17 +39,8 @@ private:
     bool checkOperatorApplicability(SyntaxKind op, SourceLocation location, BoundExpression** operand);
     bool checkOperatorApplicability(SyntaxKind op, SourceLocation location, BoundExpression** lhs, BoundExpression** rhs);
 
-    // propagates the type of the expression back down to its operands
-    // and folds constants on the way back up
-    void propagateAndFold(BoundExpression* expression, const TypeSymbol* type);
-    void propagateAndFoldLiteral(BoundLiteral* expression, const TypeSymbol* type);
-    void propagateAndFoldParameter(BoundParameter* expression, const TypeSymbol* type);
-    void propagateAndFoldUnaryArithmeticOperator(BoundUnaryExpression* expression, const TypeSymbol* type);
-    void propagateAndFoldUnaryReductionOperator(BoundUnaryExpression* expression, const TypeSymbol* type);
-    void propagateAndFoldArithmeticOperator(BoundBinaryExpression* expression, const TypeSymbol* type);
-    void propagateAndFoldComparisonOperator(BoundBinaryExpression* expression, const TypeSymbol* type);
-    void propagateAndFoldRelationalOperator(BoundBinaryExpression* expression, const TypeSymbol* type);
-    void propagateAndFoldShiftOrPowerOperator(BoundBinaryExpression* expression, const TypeSymbol* type);
+    // Propagates the type of the expression back down to its operands.
+    void propagate(BoundExpression* expression, const TypeSymbol* type);
 
     SemanticModel& sem;
     BumpAllocator& alloc;

--- a/include/ExpressionBinder.h
+++ b/include/ExpressionBinder.h
@@ -42,6 +42,8 @@ private:
     // Propagates the type of the expression back down to its operands.
     void propagate(BoundExpression* expression, const TypeSymbol* type);
 
+    BadBoundExpression* makeBad(BoundExpression* expr);
+
     SemanticModel& sem;
     BumpAllocator& alloc;
     const Scope* scope;

--- a/include/SemanticModel.h
+++ b/include/SemanticModel.h
@@ -97,6 +97,7 @@ private:
 
     bool evaluateConstantDims(const SyntaxList<VariableDimensionSyntax>& dimensions, SmallVector<ConstantRange>& results, const Scope* scope);
 
+    static ConstantValue evaluateConstant(const BoundNode* tree);
 
     BumpAllocator& alloc;
     Diagnostics& diagnostics;

--- a/include/Symbol.h
+++ b/include/Symbol.h
@@ -2,12 +2,11 @@
 
 #include "AllSyntax.h"
 #include "ArrayRef.h"
+#include "ConstantValue.h"
 #include "SourceLocation.h"
 #include "StringRef.h"
 
 namespace slang {
-
-using ConstantValue = std::variant<SVInt, double>;
 
 enum class SymbolKind {
     Unknown,

--- a/source/ConstantEvaluator.cpp
+++ b/source/ConstantEvaluator.cpp
@@ -1,11 +1,10 @@
 //------------------------------------------------------------------------------
-// ExpressionBinder.cpp
-// Centralized code for convert expressions into AST trees
-// (also includes constant folding).
+// ConstantEvaluator.cpp
+// Compile-time constant evaluation.
 //
 // File is under the MIT license:
 //------------------------------------------------------------------------------
-#include "ExpressionBinder.h"
+#include "ConstantEvaluator.h"
 
 #include <algorithm>
 

--- a/source/ConstantEvaluator.cpp
+++ b/source/ConstantEvaluator.cpp
@@ -12,347 +12,74 @@
 
 namespace slang {
 
-ExpressionBinder::ExpressionBinder(SemanticModel& sem, const Scope* scope) :
-    sem(sem), alloc(sem.getAllocator()), scope(scope)
-{
-    ASSERT(scope);
-}
+ConstantValue ConstantEvaluator::evaluate(const BoundNode* tree) {
+    ASSERT(tree);
+    if (tree->bad())
+        return nullptr;
 
-BoundExpression* ExpressionBinder::bindExpression(const ExpressionSyntax* syntax) {
-    ASSERT(syntax);
-    switch (syntax->kind) {
-        case SyntaxKind::NullLiteralExpression:
-        case SyntaxKind::StringLiteralExpression:
-        case SyntaxKind::TimeLiteralExpression:
-        case SyntaxKind::WildcardLiteralExpression:
-        case SyntaxKind::OneStepLiteralExpression:
-        case SyntaxKind::UnbasedUnsizedLiteralExpression:
-            break;
-        case SyntaxKind::IdentifierName:
-            return bindSimpleName(syntax->as<IdentifierNameSyntax>());
-        case SyntaxKind::RealLiteralExpression:
-        case SyntaxKind::IntegerLiteralExpression:
-            return bindLiteral(syntax->as<LiteralExpressionSyntax>());
-        case SyntaxKind::IntegerVectorExpression:
-            return bindLiteral(syntax->as<IntegerVectorExpressionSyntax>());
-        case SyntaxKind::ParenthesizedExpression:
-            return bindExpression(syntax->as<ParenthesizedExpressionSyntax>()->expression);
-        case SyntaxKind::UnaryPlusExpression:
-        case SyntaxKind::UnaryMinusExpression:
-        case SyntaxKind::UnaryBitwiseNotExpression:
-            return bindUnaryArithmeticOperator(syntax->as<PrefixUnaryExpressionSyntax>());
-        case SyntaxKind::UnaryBitwiseAndExpression:
-        case SyntaxKind::UnaryBitwiseOrExpression:
-        case SyntaxKind::UnaryBitwiseXorExpression:
-        case SyntaxKind::UnaryBitwiseNandExpression:
-        case SyntaxKind::UnaryBitwiseNorExpression:
-        case SyntaxKind::UnaryBitwiseXnorExpression:
-        case SyntaxKind::UnaryLogicalNotExpression:
-            return bindUnaryReductionOperator(syntax->as<PrefixUnaryExpressionSyntax>());
-        case SyntaxKind::AddExpression:
-        case SyntaxKind::SubtractExpression:
-        case SyntaxKind::MultiplyExpression:
-        case SyntaxKind::DivideExpression:
-        case SyntaxKind::ModExpression:
-        case SyntaxKind::BinaryAndExpression:
-        case SyntaxKind::BinaryOrExpression:
-        case SyntaxKind::BinaryXorExpression:
-        case SyntaxKind::BinaryXnorExpression:
-            return bindArithmeticOperator(syntax->as<BinaryExpressionSyntax>());
-        case SyntaxKind::EqualityExpression:
-        case SyntaxKind::InequalityExpression:
-        case SyntaxKind::CaseEqualityExpression:
-        case SyntaxKind::CaseInequalityExpression:
-        case SyntaxKind::GreaterThanEqualExpression:
-        case SyntaxKind::GreaterThanExpression:
-        case SyntaxKind::LessThanEqualExpression:
-        case SyntaxKind::LessThanExpression:
-            return bindComparisonOperator(syntax->as<BinaryExpressionSyntax>());
-        case SyntaxKind::LogicalAndExpression:
-        case SyntaxKind::LogicalOrExpression:
-        case SyntaxKind::LogicalImplicationExpression:
-        case SyntaxKind::LogicalEquivalenceExpression:
-            return bindRelationalOperator(syntax->as<BinaryExpressionSyntax>());
-        case SyntaxKind::LogicalShiftLeftExpression:
-        case SyntaxKind::LogicalShiftRightExpression:
-        case SyntaxKind::ArithmeticShiftLeftExpression:
-        case SyntaxKind::ArithmeticShiftRightExpression:
-        case SyntaxKind::PowerExpression:
-            return bindShiftOrPowerOperator(syntax->as<BinaryExpressionSyntax>());
+    switch (tree->kind) {
+        case BoundNodeKind::Literal: return evaluateLiteral((BoundLiteral*)tree);
+        case BoundNodeKind::Parameter: return evaluateParameter((BoundParameter*)tree);
+        case BoundNodeKind::UnaryExpression: return evaluateUnary((BoundUnaryExpression*)tree);
+        case BoundNodeKind::BinaryExpression: return evaluateBinary((BoundBinaryExpression*)tree);
 
             DEFAULT_UNREACHABLE;
     }
     return nullptr;
 }
 
-BoundExpression* ExpressionBinder::bindConstantExpression(const ExpressionSyntax* syntax) {
-    return bindSelfDeterminedExpression(syntax);
+ConstantValue ConstantEvaluator::evaluateLiteral(const BoundLiteral* expr) {
+    return expr->value;
 }
 
-BoundExpression* ExpressionBinder::bindSelfDeterminedExpression(const ExpressionSyntax* syntax) {
-    BoundExpression* expr = bindExpression(syntax);
-    propagate(expr, expr->type);
-    return expr;
+ConstantValue ConstantEvaluator::evaluateParameter(const BoundParameter* expr) {
+    return expr->symbol.value;
 }
 
-BoundExpression* ExpressionBinder::bindAssignmentLikeContext(const ExpressionSyntax* syntax, SourceLocation location, const TypeSymbol* assignmentType) {
-    BoundExpression* expr = bindExpression(syntax);
-    const TypeSymbol* type = expr->type;
-    if (!assignmentType->isAssignmentCompatible(type)) {
-        DiagCode code = assignmentType->isCastCompatible(type) ? DiagCode::NoImplicitConversion : DiagCode::BadAssignment;
-        addError(code, location) << syntax->sourceRange();
-        expr->bad = true;
-    }
-    else {
-        const IntegralTypeSymbol& exprType = expr->type->as<IntegralTypeSymbol>();
-        if (exprType.width < assignmentType->as<IntegralTypeSymbol>().width)
-            propagate(expr, assignmentType);
-        else
-            propagate(expr, expr->type);
-    }
+ConstantValue ConstantEvaluator::evaluateUnary(const BoundUnaryExpression* expr) {
+    const auto& v = evaluate(expr->operand).integer();
 
-    // TODO: truncation
-    return expr;
-}
-
-BoundExpression* ExpressionBinder::bindLiteral(const LiteralExpressionSyntax* syntax) {
-    switch (syntax->kind) {
-        case SyntaxKind::IntegerLiteralExpression:
-            return alloc.emplace<BoundLiteral>(syntax, sem.getKnownType(SyntaxKind::IntType), false);
-        case SyntaxKind::RealLiteralExpression:
-            return alloc.emplace<BoundLiteral>(syntax, sem.getKnownType(SyntaxKind::RealType), false);
-        DEFAULT_UNREACHABLE;
+    switch (expr->syntax->kind) {
+        case SyntaxKind::UnaryPlusExpression: return v;
+        case SyntaxKind::UnaryMinusExpression: return -v;
+        case SyntaxKind::UnaryBitwiseNotExpression: return ~v;
+        case SyntaxKind::UnaryBitwiseAndExpression: return SVInt(v.reductionAnd());
+        case SyntaxKind::UnaryBitwiseOrExpression: return SVInt(v.reductionOr());
+        case SyntaxKind::UnaryBitwiseXorExpression: return SVInt(v.reductionXor());
+        case SyntaxKind::UnaryBitwiseNandExpression: return SVInt(!v.reductionAnd());
+        case SyntaxKind::UnaryBitwiseNorExpression: return SVInt(!v.reductionOr());
+        case SyntaxKind::UnaryBitwiseXnorExpression: return SVInt(!v.reductionXor());
+        case SyntaxKind::UnaryLogicalNotExpression: return SVInt(!v);
+            DEFAULT_UNREACHABLE;
     }
     return nullptr;
 }
 
-BoundExpression* ExpressionBinder::bindLiteral(const IntegerVectorExpressionSyntax* syntax) {
-    if (syntax->value.isMissing())
-        return alloc.emplace<BoundLiteral>(syntax, sem.getErrorType(), true);
+ConstantValue ConstantEvaluator::evaluateBinary(const BoundBinaryExpression* expr) {
+    const auto& l = evaluate(expr->left).integer();
+    const auto& r = evaluate(expr->right).integer();
 
-    const SVInt& value = std::get<SVInt>(syntax->value.numericValue());
-    const TypeSymbol* type = sem.getIntegralType(value.getBitWidth(), value.isSigned(), value.hasUnknown());
-    return alloc.emplace<BoundLiteral>(syntax, type, false);
-}
-
-BoundExpression* ExpressionBinder::bindSimpleName(const IdentifierNameSyntax* syntax) {
-    // if we have an invalid name token just give up now; the error has already been reported
-    StringRef identifier = syntax->identifier.valueText();
-    if (!identifier)
-        return alloc.emplace<BadBoundExpression>();
-
-    const Symbol* symbol = sem.lookupSymbol(identifier, scope);
-    ASSERT(symbol && symbol->kind == SymbolKind::Parameter);
-
-    return alloc.emplace<BoundParameter>(syntax, symbol->as<ParameterSymbol>(), false);
-}
-
-BoundExpression* ExpressionBinder::bindUnaryArithmeticOperator(const PrefixUnaryExpressionSyntax* syntax) {
-    // Supported for both integral and real types. Can be overloaded for others.
-    BoundExpression* operand = bindExpression(syntax->operand);
-    if (!checkOperatorApplicability(syntax->kind, syntax->operatorToken.location(), &operand))
-        return alloc.emplace<BoundUnaryExpression>(syntax, sem.getErrorType(), operand, true);
-
-    return alloc.emplace<BoundUnaryExpression>(syntax, operand->type, operand, false);
-}
-
-BoundExpression* ExpressionBinder::bindUnaryReductionOperator(const PrefixUnaryExpressionSyntax* syntax) {
-    // Result type is always a single bit. Supported on integral types.
-    BoundExpression* operand = bindSelfDeterminedExpression(syntax->operand);
-    if (!checkOperatorApplicability(syntax->kind, syntax->operatorToken.location(), &operand))
-        return alloc.emplace<BoundUnaryExpression>(syntax, sem.getErrorType(), operand, true);
-
-    return alloc.emplace<BoundUnaryExpression>(syntax, sem.getKnownType(SyntaxKind::LogicType), operand, operand->bad);
-}
-
-BoundExpression* ExpressionBinder::bindArithmeticOperator(const BinaryExpressionSyntax* syntax) {
-    BoundExpression* lhs = bindExpression(syntax->left);
-    BoundExpression* rhs = bindExpression(syntax->right);
-    if (!checkOperatorApplicability(syntax->kind, syntax->operatorToken.location(), &lhs, &rhs))
-        return alloc.emplace<BoundBinaryExpression>(syntax, sem.getErrorType(), lhs, rhs, true);
-
-    const IntegralTypeSymbol& l = lhs->type->as<IntegralTypeSymbol>();
-    const IntegralTypeSymbol& r = rhs->type->as<IntegralTypeSymbol>();
-    int width = std::max(l.width, r.width);
-    bool isSigned = l.isSigned && r.isSigned;
-    const TypeSymbol* type = sem.getIntegralType(width, isSigned);
-
-    return alloc.emplace<BoundBinaryExpression>(syntax, type, lhs, rhs, false);
-}
-
-BoundExpression* ExpressionBinder::bindComparisonOperator(const BinaryExpressionSyntax* syntax) {
-    BoundExpression* lhs = bindExpression(syntax->left);
-    BoundExpression* rhs = bindExpression(syntax->right);
-    if (!checkOperatorApplicability(syntax->kind, syntax->operatorToken.location(), &lhs, &rhs))
-        return alloc.emplace<BoundBinaryExpression>(syntax, sem.getErrorType(), lhs, rhs, true);
-
-    // result type is always a single bit
-    return alloc.emplace<BoundBinaryExpression>(syntax, sem.getKnownType(SyntaxKind::LogicType), lhs, rhs, false);
-}
-
-BoundExpression* ExpressionBinder::bindRelationalOperator(const BinaryExpressionSyntax* syntax) {
-    BoundExpression* lhs = bindSelfDeterminedExpression(syntax->left);
-    BoundExpression* rhs = bindSelfDeterminedExpression(syntax->right);
-    if (!checkOperatorApplicability(syntax->kind, syntax->operatorToken.location(), &lhs, &rhs))
-        return alloc.emplace<BoundBinaryExpression>(syntax, sem.getErrorType(), lhs, rhs, true);
-
-    // result type is always a single bit
-    return alloc.emplace<BoundBinaryExpression>(syntax, sem.getKnownType(SyntaxKind::LogicType), lhs, rhs, false);
-}
-
-BoundExpression* ExpressionBinder::bindShiftOrPowerOperator(const BinaryExpressionSyntax* syntax) {
-    // The shift and power operators are handled together here because in both cases the second
-    // operand is evaluated in a self determined context.
-    BoundExpression* lhs = bindExpression(syntax->left);
-    BoundExpression* rhs = bindSelfDeterminedExpression(syntax->right);
-    if (!checkOperatorApplicability(syntax->kind, syntax->operatorToken.location(), &lhs, &rhs))
-        return alloc.emplace<BoundBinaryExpression>(syntax, sem.getErrorType(), lhs, rhs, true);
-
-    const IntegralTypeSymbol& l = lhs->type->as<IntegralTypeSymbol>();
-    const IntegralTypeSymbol& r = rhs->type->as<IntegralTypeSymbol>();
-    int width = l.width;
-    bool isSigned = l.isSigned && r.isSigned;
-    const TypeSymbol* type = sem.getIntegralType(width, isSigned);
-
-    return alloc.emplace<BoundBinaryExpression>(syntax, type, lhs, rhs, false);
-}
-
-bool ExpressionBinder::checkOperatorApplicability(SyntaxKind op, SourceLocation location, BoundExpression** operand) {
-    if ((*operand)->bad)
-        return false;
-
-    const TypeSymbol* type = (*operand)->type;
-    bool good;
-    switch (op) {
-        case SyntaxKind::UnaryPlusExpression:
-        case SyntaxKind::UnaryMinusExpression:
-        case SyntaxKind::UnaryLogicalNotExpression:
-            good = type->kind == SymbolKind::IntegralType || type->kind == SymbolKind::RealType;
-            break;
-        default:
-            good = type->kind == SymbolKind::IntegralType;
-            break;
-    }
-    if (good)
-        return true;
-
-    auto& diag = addError(DiagCode::BadUnaryExpression, location);
-    diag << type->toString();
-    diag << (*operand)->syntax->sourceRange();
-    return false;
-}
-
-bool ExpressionBinder::checkOperatorApplicability(SyntaxKind op, SourceLocation location, BoundExpression** lhs, BoundExpression** rhs) {
-    if ((*lhs)->bad || (*rhs)->bad)
-        return false;
-
-    const TypeSymbol* lt = (*lhs)->type;
-    const TypeSymbol* rt = (*rhs)->type;
-    bool good;
-    switch (op) {
-        case SyntaxKind::AddExpression:
-        case SyntaxKind::SubtractExpression:
-        case SyntaxKind::MultiplyExpression:
-        case SyntaxKind::DivideExpression:
-        case SyntaxKind::PowerExpression:
-        case SyntaxKind::LogicalAndExpression:
-        case SyntaxKind::LogicalOrExpression:
-        case SyntaxKind::LogicalImplicationExpression:
-        case SyntaxKind::LogicalEquivalenceExpression:
-        case SyntaxKind::LessThanEqualExpression:
-        case SyntaxKind::LessThanExpression:
-        case SyntaxKind::GreaterThanEqualExpression:
-        case SyntaxKind::GreaterThanExpression:
-        case SyntaxKind::EqualityExpression:
-        case SyntaxKind::InequalityExpression:
-            good = (lt->kind == SymbolKind::IntegralType || lt->kind == SymbolKind::RealType) &&
-                   (rt->kind == SymbolKind::IntegralType || rt->kind == SymbolKind::RealType);
-            break;
-        default:
-            good = lt->kind == SymbolKind::IntegralType && rt->kind == SymbolKind::IntegralType;
-            break;
-    }
-    if (good)
-        return true;
-
-    auto& diag = addError(DiagCode::BadBinaryExpression, location);
-    diag << lt->toString() << rt->toString();
-    diag << (*lhs)->syntax->sourceRange();
-    diag << (*rhs)->syntax->sourceRange();
-    return false;
-}
-
-void ExpressionBinder::propagate(BoundExpression* expression, const TypeSymbol* type) {
-    ASSERT(expression);
-    if (expression->bad)
-        return;
-
-    // SystemVerilog rules for width propagation are subtle and very specific
-    // to each individual operator type. They also mainly only apply to
-    // expressions of integral type (which will be the majority in most designs).
-    switch (expression->syntax->kind) {
-        case SyntaxKind::UnaryPlusExpression:
-        case SyntaxKind::UnaryMinusExpression:
-        case SyntaxKind::UnaryBitwiseNotExpression:
-            expression->type = type;
-            propagate(((BoundUnaryExpression*)expression)->operand, type);
-            break;
-        case SyntaxKind::UnaryBitwiseAndExpression:
-        case SyntaxKind::UnaryBitwiseOrExpression:
-        case SyntaxKind::UnaryBitwiseXorExpression:
-        case SyntaxKind::UnaryBitwiseNandExpression:
-        case SyntaxKind::UnaryBitwiseNorExpression:
-        case SyntaxKind::UnaryBitwiseXnorExpression:
-        case SyntaxKind::UnaryLogicalNotExpression:
-            // Type is already set (always 1 bit) and operand is self determined
-            break;
-        case SyntaxKind::AddExpression:
-        case SyntaxKind::SubtractExpression:
-        case SyntaxKind::MultiplyExpression:
-        case SyntaxKind::DivideExpression:
-        case SyntaxKind::ModExpression:
-        case SyntaxKind::BinaryAndExpression:
-        case SyntaxKind::BinaryOrExpression:
-        case SyntaxKind::BinaryXorExpression:
-        case SyntaxKind::BinaryXnorExpression:
-            expression->type = type;
-            propagate(((BoundBinaryExpression*)expression)->left, type);
-            propagate(((BoundBinaryExpression*)expression)->right, type);
-            break;
-        case SyntaxKind::EqualityExpression:
-        case SyntaxKind::InequalityExpression:
-        case SyntaxKind::CaseEqualityExpression:
-        case SyntaxKind::CaseInequalityExpression:
-        case SyntaxKind::GreaterThanEqualExpression:
-        case SyntaxKind::GreaterThanExpression:
-        case SyntaxKind::LessThanEqualExpression:
-        case SyntaxKind::LessThanExpression:
-            // operands are sized to max(l,r) but the result of the operation is always 1 bit
-            propagate(((BoundBinaryExpression*)expression)->left, type);
-            propagate(((BoundBinaryExpression*)expression)->right, type);
-            break;
-        case SyntaxKind::LogicalAndExpression:
-        case SyntaxKind::LogicalOrExpression:
-        case SyntaxKind::LogicalImplicationExpression:
-        case SyntaxKind::LogicalEquivalenceExpression:
-            // Type is already set (always 1 bit) and operands are self determined
-            break;
-        case SyntaxKind::LogicalShiftLeftExpression:
-        case SyntaxKind::LogicalShiftRightExpression:
-        case SyntaxKind::ArithmeticShiftLeftExpression:
-        case SyntaxKind::ArithmeticShiftRightExpression:
-        case SyntaxKind::PowerExpression:
-            // Only the left hand side gets propagated; the rhs is self determined
-            expression->type = type;
-            propagate(((BoundBinaryExpression*)expression)->left, type);
-            break;
-
+    switch (expr->syntax->kind) {
+        case SyntaxKind::AddExpression: return l + r;
+        case SyntaxKind::SubtractExpression: return l - r;
+        case SyntaxKind::MultiplyExpression: return l * r;
+        case SyntaxKind::DivideExpression: return l / r;
+        case SyntaxKind::ModExpression: return l % r;
+        case SyntaxKind::BinaryAndExpression: return l & r;
+        case SyntaxKind::BinaryOrExpression: return l | r;
+        case SyntaxKind::BinaryXorExpression: return l ^ r;
+        case SyntaxKind::BinaryXnorExpression: return l.xnor(r);
+        case SyntaxKind::EqualityExpression: return SVInt(l == r);
+        case SyntaxKind::InequalityExpression: return SVInt(l != r);
+        case SyntaxKind::CaseEqualityExpression: return SVInt((logic_t)exactlyEqual(l, r));
+        case SyntaxKind::CaseInequalityExpression: return SVInt((logic_t)!exactlyEqual(l, r));
+        case SyntaxKind::GreaterThanEqualExpression: return SVInt(l >= r);
+        case SyntaxKind::GreaterThanExpression: return SVInt(l > r);
+        case SyntaxKind::LessThanEqualExpression: return SVInt(l <= r);
+        case SyntaxKind::LessThanExpression: return SVInt(l < r);
             DEFAULT_UNREACHABLE;
     }
-}
-
-Diagnostic& ExpressionBinder::addError(DiagCode code, SourceLocation location) {
-    return sem.getDiagnostics().add(code, location);
+    return nullptr;
 }
 
 }

--- a/source/Parser_statements.cpp
+++ b/source/Parser_statements.cpp
@@ -496,6 +496,8 @@ ConcurrentAssertionStatementSyntax* Parser::parseConcurrentAssertion(NamedLabelS
         case TokenKind::ExpectKeyword:
             kind = SyntaxKind::ExpectPropertyStatement;
             break;
+
+            DEFAULT_UNREACHABLE;
     }
 
     auto openParen = expect(TokenKind::OpenParenthesis);

--- a/source/SemanticModel.cpp
+++ b/source/SemanticModel.cpp
@@ -174,7 +174,7 @@ bool SemanticModel::evaluateConstantDims(const SyntaxList<VariableDimensionSynta
         const RangeSelectSyntax* range = selector->as<RangeSelectSyntax>();
         auto msbExpr = binder.bindConstantExpression(range->left);
         auto lsbExpr = binder.bindConstantExpression(range->right);
-        if (msbExpr->bad || lsbExpr->bad)
+        if (msbExpr->bad() || lsbExpr->bad())
             return false;
 
         // TODO: ensure integer here
@@ -297,7 +297,7 @@ void SemanticModel::handleIfGenerate(const IfGenerateSyntax* syntax, SmallVector
     // Evaluate the condition to decide if we should take the branch.
     ExpressionBinder binder { *this, scope };
     auto expr = binder.bindConstantExpression(syntax->condition);
-    if (expr->bad)
+    if (expr->bad())
         return;
 
     // TODO: don't assume the expression type here

--- a/tests/unit_tests/ExpressionBindingTests.cpp
+++ b/tests/unit_tests/ExpressionBindingTests.cpp
@@ -13,7 +13,7 @@ DiagnosticWriter diagWriter(sourceManager);
 
 SyntaxTree parse(const std::string& text) { return SyntaxTree::fromText(sourceManager, StringRef(text)); }
 
-const ParameterSymbol& testParameter(const std::string& text, int index = 0) {
+SVInt testParameter(const std::string& text, int index = 0) {
     auto tree = parse("module Top; " + text + " endmodule");
 
     Diagnostics& diagnostics = tree.diagnostics();
@@ -29,15 +29,15 @@ const ParameterSymbol& testParameter(const std::string& text, int index = 0) {
     if (!diagnostics.empty())
         WARN(diagWriter.report(diagnostics).c_str());
 
-    return *module->parameters[index];
+    return module->parameters[index]->value.integer();
 }
 
 TEST_CASE("Bind parameter", "[binding:expressions]") {
-    CHECK(std::get<SVInt>(testParameter("parameter foo = 4;").value) == 4);
-    CHECK(std::get<SVInt>(testParameter("parameter foo = 4 + 5;").value) == 9);
-    CHECK(std::get<SVInt>(testParameter("parameter bar = 9, foo = bar + 1;", 1).value) == 10);
-    CHECK(std::get<SVInt>(testParameter("parameter logic [3:0] foo = 4;").value) == 4);
-    CHECK(std::get<SVInt>(testParameter("parameter logic [3:0] foo = 4'b100;").value) == 4);
+    CHECK(testParameter("parameter foo = 4;") == 4);
+    CHECK(testParameter("parameter foo = 4 + 5;") == 9);
+    CHECK(testParameter("parameter bar = 9, foo = bar + 1;", 1) == 10);
+    CHECK(testParameter("parameter logic [3:0] foo = 4;") == 4);
+    CHECK(testParameter("parameter logic [3:0] foo = 4'b100;") == 4);
 }
 
 }


### PR DESCRIPTION
The point of this change is to make it possible to keep track of call stack and stack frames when evaluating multi-statement constants (like inside constant functions).

Right now this should be roughly equal to what we had already in terms of functionality.