### PR TITLE
Add support for loop generate constructs

### DIFF
--- a/include/ConstantEvaluator.h
+++ b/include/ConstantEvaluator.h
@@ -25,9 +25,13 @@ class ConstantEvaluator {
 public:
     ConstantEvaluator();
 
-    /// Evaluate a bound tree, including all side effects. If this is not a
+    /// Evaluates a bound tree, including all side effects. If this is not a
     /// constant expression diagnostics will issued to help indicate why not.
     ConstantValue evaluate(const BoundNode* tree);
+
+    /// Evaluates a bound tree and then tries to interpret the result in
+    /// a boolean context.
+    bool evaluateBool(const BoundNode* tree);
 
     /// Creates a temporary on the root stack frame. Call this before calling
     /// `evaluate` to material temporaries that don't have declarations within

--- a/include/Scope.h
+++ b/include/Scope.h
@@ -14,7 +14,8 @@ enum class SymbolKind;
 // contexts so that symbol lookup can be performed.
 class Scope {
 public:
-    Scope();
+    Scope() {}
+    explicit Scope(const Scope* parent) : parentScope(parent) {}
 
     bool add(const Symbol* symbol);
 
@@ -40,7 +41,7 @@ public:
 private:
     std::unordered_map<StringRef, const Symbol*> table;
     std::vector<const Symbol*> list;
-    const Scope* parentScope;
+    const Scope* parentScope = nullptr;
 };
 
 }

--- a/include/SemanticModel.h
+++ b/include/SemanticModel.h
@@ -94,10 +94,14 @@ private:
     const ModuleSymbol* makeModule(const ModuleDeclarationSyntax* syntax, ArrayRef<const ParameterSymbol*> parameters);
     void handleInstantiation(const HierarchyInstantiationSyntax* syntax, SmallVector<const Symbol*>& results, const Scope* instantiationScope);
     void handleIfGenerate(const IfGenerateSyntax* syntax, SmallVector<const Symbol*>& results, const Scope* scope);
+    void handleLoopGenerate(const LoopGenerateSyntax* syntax, SmallVector<const Symbol*>& results, const Scope* scope);
     void handleGenerateBlock(const MemberSyntax* syntax, SmallVector<const Symbol*>& results, const Scope* scope);
+    void handleGenvarDecl(const GenvarDeclarationSyntax* syntax, SmallVector<const Symbol*>& results, const Scope* scope);
 
     bool evaluateConstantDims(const SyntaxList<VariableDimensionSyntax>& dimensions, SmallVector<ConstantRange>& results, const Scope* scope);
 
+    BoundExpression* bindConstantExpression(const ExpressionSyntax* syntax, const Scope* scope);
+    ConstantValue evaluateConstant(const ExpressionSyntax* syntax, const Scope* scope);
     static ConstantValue evaluateConstant(const BoundNode* tree);
 
     BumpAllocator& alloc;

--- a/include/Symbol.h
+++ b/include/Symbol.h
@@ -23,6 +23,7 @@ enum class SymbolKind {
     Interface,
     Program,
     Attribute,
+    Genvar,
     GenerateBlock,
     LocalVariable
 };
@@ -160,6 +161,9 @@ class LocalVariableSymbol : public Symbol {
 public:
     const TypeSymbol* type;
 
+    LocalVariableSymbol(Token token, const TypeSymbol* type) :
+        LocalVariableSymbol(token.valueText(), token.location(), type) {}
+
     LocalVariableSymbol(StringRef name, SourceLocation location, const TypeSymbol* type) :
         Symbol(SymbolKind::LocalVariable, name, location), type(type) {}
 };
@@ -190,6 +194,12 @@ public:
     const T& getChild(uint32_t index) const { return module->children[index]->as<T>(); }
 
     static constexpr SymbolKind mykind = SymbolKind::Unknown;
+};
+
+class GenvarSymbol : public Symbol {
+public:
+    GenvarSymbol(StringRef name, SourceLocation location) :
+        Symbol(SymbolKind::Genvar, name, location) {}
 };
 
 class GenerateBlock : public Symbol {

--- a/source/ConstantEvaluator.cpp
+++ b/source/ConstantEvaluator.cpp
@@ -22,6 +22,14 @@ ConstantValue& ConstantEvaluator::createTemporary(const Symbol* key) {
     return result;
 }
 
+bool ConstantEvaluator::evaluateBool(const BoundNode* tree) {
+    auto cv = evaluate(tree);
+    if (!cv)
+        return false;
+
+    return (bool)(logic_t)cv.integer();
+}
+
 ConstantValue ConstantEvaluator::evaluate(const BoundNode* tree) {
     ASSERT(tree);
     if (tree->bad())

--- a/source/Scope.cpp
+++ b/source/Scope.cpp
@@ -6,8 +6,6 @@ namespace slang {
 static const Scope emptyScope;
 const Scope* const Scope::Empty = &emptyScope;
 
-Scope::Scope() : parentScope{nullptr} {}
-
 bool Scope::add(const Symbol *symbol) {
     ASSERT(symbol);
     if (!table.emplace(symbol->name, symbol).second) return false;

--- a/tests/file_tests/main.cpp
+++ b/tests/file_tests/main.cpp
@@ -28,8 +28,8 @@ int main() {
             printf("Parsing '%s'\n", p.str().c_str());
             printf("%s\n\n", diagWriter.report(tree.diagnostics()).c_str());
         }
-        printf("%s", ((CompilationUnitSyntax*)tree.root())->
-            toString(SyntaxToStringFlags::IncludeTrivia).c_str());
+        //printf("%s", ((CompilationUnitSyntax*)tree.root())->
+          //  toString(SyntaxToStringFlags::IncludeTrivia).c_str());
         errors += tree.diagnostics().count();
         files++;
 


### PR DESCRIPTION
This evaluates the initial, step, and stop expressions to generate blocks in a loop. Test shows it working for a simple straightforward loop, but it should work for any kind of constant expression we can evaluate.