### PR TITLE
Added test for escaped keyword identifiers

### DIFF
--- a/tests/unit_tests/LexerTests.cpp
+++ b/tests/unit_tests/LexerTests.cpp
@@ -549,6 +549,16 @@ TEST_CASE("Directive not on own line", "[lexer]") {
     CHECK(diagnostics.back().code == DiagCode::DirectiveNotFirstOnLine);
 }
 
+TEST_CASE("Escaped keyword identifiers", "[preprocessor]") {
+    auto& text = "\\wire";
+
+    auto token = lexToken(text);
+    CHECK(token.kind == TokenKind::Identifier);
+    CHECK(token.valueText() == "wire");
+    CHECK(token.identifierType() == IdentifierType::Escaped);
+    CHECK(diagnostics.empty());
+}
+
 void testKeyword(TokenKind kind) {
     auto text = getTokenKindText(kind);
     Token token = lexToken(text.toString());


### PR DESCRIPTION
This resolves Issue #15. The test passes without any additional work, so looks like that was a very easy issue to close.