### PR TITLE
Implemented proper type propogation rules for assignments and others

### DIFF
--- a/include/ExpressionBinder.h
+++ b/include/ExpressionBinder.h
@@ -23,6 +23,7 @@ public:
     BoundExpression* bindSelfDeterminedExpression(const ExpressionSyntax* syntax);
     BoundExpression* bindAssignmentLikeContext(const ExpressionSyntax* syntax, SourceLocation location, const TypeSymbol* assignmentType);
 
+private:
     BoundExpression* bindExpression(const ExpressionSyntax* syntax);
     BoundExpression* bindLiteral(const LiteralExpressionSyntax* syntax);
     BoundExpression* bindLiteral(const IntegerVectorExpressionSyntax* syntax);
@@ -35,7 +36,6 @@ public:
     BoundExpression* bindShiftOrPowerOperator(const BinaryExpressionSyntax* syntax);
     BoundExpression* bindAssignmentOperator(const BinaryExpressionSyntax* syntax);
 
-private:
     // functions to check whether operators are applicable to the given operand types
     bool checkOperatorApplicability(SyntaxKind op, SourceLocation location, BoundExpression** operand);
     bool checkOperatorApplicability(SyntaxKind op, SourceLocation location, BoundExpression** lhs, BoundExpression** rhs);

--- a/source/Symbol.cpp
+++ b/source/Symbol.cpp
@@ -78,7 +78,10 @@ ParameterSymbol::ParameterSymbol(StringRef name, SourceLocation location,
                                  bool isLocal) :
     Symbol(SymbolKind::Parameter, name, location),
     syntax(syntax),
-    isLocal(isLocal)
+    isLocal(isLocal),
+    // TODO: fill this in with something meaningful
+    // this is to prevent it from being uninitialized memory
+    type(new TypeSymbol(SymbolKind::Unknown,name,location))
 {
 }
 


### PR DESCRIPTION
SystemVerilog has some very complex type propagation rules for width of Integral types. This should implement all of them, and I think it also implements things correctly for Reals, but that's not terribly clearly documented.

A large part of my time getting this ready involved tracking down a bug where the ExpressionBinder got types which were pointing to uninitialized memory, I tracked the source down to the ParameterSymbol constructor, which now leaks memory creating a dummy symbol as a very temporary holdout for whatever the real solution is there.