### PR TITLE
Clean up function parsing and bind function symbols

### DIFF
--- a/include/AllSyntax.h
+++ b/include/AllSyntax.h
@@ -5448,15 +5448,84 @@ protected:
     }
 };
 
+struct FunctionPortSyntax : public SyntaxNode {
+    SyntaxList<AttributeInstanceSyntax> attributes;
+    Token constKeyword;
+    Token direction;
+    Token varKeyword;
+    DataTypeSyntax* dataType;
+    VariableDeclaratorSyntax* declarator;
+
+    FunctionPortSyntax(SyntaxList<AttributeInstanceSyntax> attributes, Token constKeyword, Token direction, Token varKeyword, DataTypeSyntax* dataType, VariableDeclaratorSyntax* declarator) :
+        SyntaxNode(SyntaxKind::FunctionPort), attributes(attributes), constKeyword(constKeyword), direction(direction), varKeyword(varKeyword), dataType(dataType), declarator(declarator)
+    {
+        childCount += 6;
+    }
+
+protected:
+    TokenOrSyntax getChild(uint32_t index) override final {
+        switch (index) {
+            case 0: return &attributes;
+            case 1: return constKeyword;
+            case 2: return direction;
+            case 3: return varKeyword;
+            case 4: return dataType;
+            case 5: return declarator;
+            default: return nullptr;
+        }
+    }
+
+    void replaceChild(uint32_t index, Token token) override final {
+        switch (index) {
+            case 0: ASSERT(false); break;
+            case 1: constKeyword = token; break;
+            case 2: direction = token; break;
+            case 3: varKeyword = token; break;
+            case 4: ASSERT(false); break;
+            case 5: ASSERT(false); break;
+        }
+    }
+};
+
+struct FunctionPortListSyntax : public SyntaxNode {
+    Token openParen;
+    SeparatedSyntaxList<FunctionPortSyntax> ports;
+    Token closeParen;
+
+    FunctionPortListSyntax(Token openParen, SeparatedSyntaxList<FunctionPortSyntax> ports, Token closeParen) :
+        SyntaxNode(SyntaxKind::FunctionPortList), openParen(openParen), ports(ports), closeParen(closeParen)
+    {
+        childCount += 3;
+    }
+
+protected:
+    TokenOrSyntax getChild(uint32_t index) override final {
+        switch (index) {
+            case 0: return openParen;
+            case 1: return &ports;
+            case 2: return closeParen;
+            default: return nullptr;
+        }
+    }
+
+    void replaceChild(uint32_t index, Token token) override final {
+        switch (index) {
+            case 0: openParen = token; break;
+            case 1: ASSERT(false); break;
+            case 2: closeParen = token; break;
+        }
+    }
+};
+
 struct FunctionPrototypeSyntax : public SyntaxNode {
     Token keyword;
     Token lifetime;
     DataTypeSyntax* returnType;
     NameSyntax* name;
-    AnsiPortListSyntax* portList;
+    FunctionPortListSyntax* portList;
     Token semi;
 
-    FunctionPrototypeSyntax(Token keyword, Token lifetime, DataTypeSyntax* returnType, NameSyntax* name, AnsiPortListSyntax* portList, Token semi) :
+    FunctionPrototypeSyntax(Token keyword, Token lifetime, DataTypeSyntax* returnType, NameSyntax* name, FunctionPortListSyntax* portList, Token semi) :
         SyntaxNode(SyntaxKind::FunctionPrototype), keyword(keyword), lifetime(lifetime), returnType(returnType), name(name), portList(portList), semi(semi)
     {
         childCount += 6;

--- a/include/Diagnostics.h
+++ b/include/Diagnostics.h
@@ -88,6 +88,7 @@ enum class DiagCode : uint8_t {
     ExpectedParameterPort,
     ExpectedNonAnsiPort,
     ExpectedAnsiPort,
+    ExpectedFunctionPort,
     ExpectedForInitializer,
     ExpectedExpression,
     ExpectedOpenRangeElement,
@@ -110,6 +111,7 @@ enum class DiagCode : uint8_t {
     AttributesNotSupported,
     InvalidGenvarIterExpression,
     ExpectedGenvarIterVar,
+    ConstFunctionPortRequiresRef,
 
     // declarations
     DuplicateDefinition,

--- a/include/Parser.h
+++ b/include/Parser.h
@@ -120,6 +120,7 @@ private:
     HierarchyInstantiationSyntax* parseHierarchyInstantiation(ArrayRef<AttributeInstanceSyntax*> attributes);
     HierarchicalInstanceSyntax* parseHierarchicalInstance();
     PortConnectionSyntax* parsePortConnection();
+    FunctionPortSyntax* parseFunctionPort();
     FunctionPrototypeSyntax* parseFunctionPrototype();
     FunctionDeclarationSyntax* parseFunctionDeclaration(ArrayRef<AttributeInstanceSyntax*> attributes, SyntaxKind functionKind, TokenKind endKind);
     Token parseLifetime();

--- a/include/SemanticModel.h
+++ b/include/SemanticModel.h
@@ -39,8 +39,8 @@ public:
     SemanticModel(BumpAllocator& alloc, Diagnostics& diagnostics, DeclarationTable& declTable);
 
     InstanceSymbol* makeImplicitInstance(const ModuleDeclarationSyntax* syntax);
-
     const TypeSymbol* makeTypeSymbol(const DataTypeSyntax* syntax, const Scope* scope);
+    const SubroutineSymbol* makeSubroutine(const FunctionDeclarationSyntax* syntax, const Scope* scope);
 
     /// Utilities for getting various common type symbols.
     const TypeSymbol* getErrorType() const { return getKnownType(SyntaxKind::Unknown); }

--- a/include/Symbol.h
+++ b/include/Symbol.h
@@ -27,7 +27,22 @@ enum class SymbolKind {
     GenerateBlock,
     LocalVariable,
     ProceduralBlock,
-    Variable
+    Variable,
+    FormalArgument,
+    Subroutine
+};
+
+enum class VariableLifetime {
+    Automatic,
+    Static
+};
+
+enum class FormalArgumentDirection {
+    In,
+    Out,
+    InOut,
+    Ref,
+    ConstRef
 };
 
 class Symbol {
@@ -253,6 +268,29 @@ public:
 
     ProceduralBlock(ArrayRef<const Symbol*> children, Kind kind, const Scope *scope)
         : children(children), kind(kind), scope(scope) {}
+};
+
+class FormalArgumentSymbol : public Symbol {
+public:
+    const TypeSymbol* type;
+    FormalArgumentDirection direction;
+
+    FormalArgumentSymbol(Token name, const TypeSymbol* type, FormalArgumentDirection direction) :
+        Symbol(SymbolKind::FormalArgument, name.valueText(), name.location()),
+        type(type), direction(direction) {}
+};
+
+class SubroutineSymbol : public Symbol {
+public:
+    const TypeSymbol* returnType;
+    ArrayRef<const FormalArgumentSymbol*> arguments;
+    VariableLifetime defaultLifetime;
+    bool isTask;
+
+    SubroutineSymbol(Token name, const TypeSymbol* returnType, ArrayRef<const FormalArgumentSymbol*> arguments,
+                     VariableLifetime defaultLifetime, bool isTask) :
+        Symbol(SymbolKind::Subroutine, name.valueText(), name.location()),
+        returnType(returnType), arguments(arguments), defaultLifetime(defaultLifetime), isTask(isTask) {}
 };
 
 }

--- a/include/SyntaxNode.h
+++ b/include/SyntaxNode.h
@@ -399,6 +399,8 @@ enum class SyntaxKind : uint16_t {
     WildcardPortConnection,
     HierarchicalInstance,
     HierarchyInstantiation,
+    FunctionPort,
+    FunctionPortList,
     FunctionPrototype,
     FunctionDeclaration,
     TaskDeclaration,
@@ -492,6 +494,7 @@ bool isNotInPortReference(TokenKind kind);
 bool isNotInConcatenationExpr(TokenKind kind);
 bool isPossibleAnsiPort(TokenKind kind);
 bool isPossibleNonAnsiPort(TokenKind kind);
+bool isPossibleFunctionPort(TokenKind kind);
 bool isPossibleParameter(TokenKind kind);
 bool isPossiblePortConnection(TokenKind kind);
 bool isPossibleVectorDigit(TokenKind kind);

--- a/source/Diagnostics.cpp
+++ b/source/Diagnostics.cpp
@@ -119,6 +119,7 @@ DiagnosticWriter::DiagnosticWriter(SourceManager& sourceManager) :
     descriptors[DiagCode::ExpectedParameterPort] = { "expected parameter declaration", DiagnosticSeverity::Error };
     descriptors[DiagCode::ExpectedNonAnsiPort] = { "expected non-ansi port declaration", DiagnosticSeverity::Error };
     descriptors[DiagCode::ExpectedAnsiPort] = { "expected ansi port declaration", DiagnosticSeverity::Error };
+    descriptors[DiagCode::ExpectedFunctionPort] = { "expected function port declaration", DiagnosticSeverity::Error };
     descriptors[DiagCode::ExpectedForInitializer] = { "expected for loop initializer", DiagnosticSeverity::Error };
     descriptors[DiagCode::ExpectedExpression] = { "expected expression", DiagnosticSeverity::Error };
     descriptors[DiagCode::ExpectedOpenRangeElement] = { "expected open range element", DiagnosticSeverity::Error };
@@ -141,6 +142,7 @@ DiagnosticWriter::DiagnosticWriter(SourceManager& sourceManager) :
     descriptors[DiagCode::AttributesNotSupported] = { "attributes are not allowed to be attached to {}", DiagnosticSeverity::Error };
     descriptors[DiagCode::InvalidGenvarIterExpression] = { "invalid genvar iteration expression", DiagnosticSeverity::Error };
     descriptors[DiagCode::ExpectedGenvarIterVar] = { "expected genvar iteration variable", DiagnosticSeverity::Error };
+    descriptors[DiagCode::ConstFunctionPortRequiresRef] = { "'const' in function formal port requires 'ref' direction specifier", DiagnosticSeverity::Error };
 
     // declarations
     descriptors[DiagCode::DuplicateDefinition] = { "duplicate {} definition '{}'", DiagnosticSeverity::Error };

--- a/source/SemanticModel.cpp
+++ b/source/SemanticModel.cpp
@@ -97,7 +97,12 @@ const ModuleSymbol* SemanticModel::makeModule(const ModuleDeclarationSyntax* syn
             case SyntaxKind::AlwaysFFBlock:
             case SyntaxKind::AlwaysLatchBlock:
             case SyntaxKind::DataDeclaration:
+            case SyntaxKind::FunctionDeclaration:
+            case SyntaxKind::TaskDeclaration:
                 handleGenerateItem(member, children, scope);
+                break;
+            default:
+                break;
         }
     }
     // TODO: cache this shit
@@ -183,7 +188,7 @@ const TypeSymbol* SemanticModel::makeTypeSymbol(const DataTypeSyntax* syntax, co
 
     // TODO: consider Void Type
 
-    return nullptr;
+    return getErrorType();
 }
 
 const SubroutineSymbol* SemanticModel::makeSubroutine(const FunctionDeclarationSyntax* syntax, const Scope* scope) {
@@ -521,6 +526,10 @@ void SemanticModel::handleGenerateItem(const MemberSyntax* syntax, SmallVector<c
             break;
         case SyntaxKind::DataDeclaration:
             handleDataDeclaration(syntax->as<DataDeclarationSyntax>(), results, scope);
+            break;
+        case SyntaxKind::FunctionDeclaration:
+        case SyntaxKind::TaskDeclaration:
+            results.append(makeSubroutine(syntax->as<FunctionDeclarationSyntax>(), scope));
             break;
     }
 }

--- a/source/SyntaxFacts.cpp
+++ b/source/SyntaxFacts.cpp
@@ -577,9 +577,27 @@ bool isPossibleAnsiPort(TokenKind kind) {
         case TokenKind::InOutKeyword:
         case TokenKind::RefKeyword:
         case TokenKind::VarKeyword:
+        case TokenKind::OpenParenthesisStar:
             return true;
         default:
             return isNetType(kind) || isPossibleDataType(kind);
+    }
+}
+
+bool isPossibleFunctionPort(TokenKind kind) {
+    switch (kind) {
+        case TokenKind::Identifier:
+        case TokenKind::Comma:
+        case TokenKind::InputKeyword:
+        case TokenKind::OutputKeyword:
+        case TokenKind::InOutKeyword:
+        case TokenKind::RefKeyword:
+        case TokenKind::VarKeyword:
+        case TokenKind::ConstKeyword:
+        case TokenKind::OpenParenthesisStar:
+            return true;
+        default:
+            return isPossibleDataType(kind);
     }
 }
 

--- a/tools/syntax.txt
+++ b/tools/syntax.txt
@@ -944,12 +944,25 @@ ParameterValueAssignmentSyntax parameters
 separated_list<HierarchicalInstanceSyntax> instances
 token semi
 
+FunctionPortSyntax kind=FunctionPort
+list<AttributeInstanceSyntax> attributes
+token constKeyword
+token direction
+token varKeyword
+DataTypeSyntax dataType
+VariableDeclaratorSyntax declarator
+
+FunctionPortListSyntax kind=FunctionPortList
+token openParen
+separated_list<FunctionPortSyntax> ports
+token closeParen
+
 FunctionPrototypeSyntax kind=FunctionPrototype
 token keyword
 token lifetime
 DataTypeSyntax returnType
 NameSyntax name
-AnsiPortListSyntax portList
+FunctionPortListSyntax portList
 token semi
 
 FunctionDeclarationSyntax base=MemberSyntax


### PR DESCRIPTION
This binds function and task definitions (though not their bodies yet; that'll be my next step).

The parser code for function ports was being lazy and reusing module port parsing, but they're actually fairly different so I added proper parsing support there.