### PR TITLE
Start adding statement binding, merge LocalVariable and Variable symbols

### DIFF
--- a/include/BoundNodes.h
+++ b/include/BoundNodes.h
@@ -11,10 +11,12 @@ enum class BoundNodeKind {
     Unknown,
     Literal,
     Parameter,
-    VarRef,
+    Variable,
     UnaryExpression,
     BinaryExpression,
-    AssignmentExpression
+    AssignmentExpression,
+    StatementList,
+    ReturnStatement
 };
 
 class BoundNode {
@@ -62,12 +64,12 @@ public:
         BoundExpression(BoundNodeKind::Parameter, syntax, symbol.type), symbol(symbol) {}
 };
 
-class BoundVarRef : public BoundExpression {
+class BoundVariable : public BoundExpression {
 public:
-    const LocalVariableSymbol* symbol;
+    const VariableSymbol* symbol;
 
-    BoundVarRef(const ExpressionSyntax* syntax, const LocalVariableSymbol* symbol) :
-        BoundExpression(BoundNodeKind::VarRef, syntax, symbol->type), symbol(symbol) {}
+    BoundVariable(const ExpressionSyntax* syntax, const VariableSymbol* symbol) :
+        BoundExpression(BoundNodeKind::Variable, syntax, symbol->type), symbol(symbol) {}
 };
 
 class BoundUnaryExpression : public BoundExpression {
@@ -94,6 +96,38 @@ public:
 
     BoundAssignmentExpression(const ExpressionSyntax* syntax, const TypeSymbol* type, BoundExpression* left, BoundExpression* right) :
         BoundExpression(BoundNodeKind::AssignmentExpression, syntax, type), left(left), right(right) {}
+};
+
+class BoundStatement : public BoundNode {
+public:
+    const StatementSyntax* syntax;
+
+    BoundStatement(BoundNodeKind kind, const StatementSyntax* syntax) :
+        BoundNode(kind), syntax(syntax) {}
+};
+
+class BadBoundStatement : public BoundStatement {
+public:
+    BoundStatement* child;
+
+    BadBoundStatement(BoundStatement* child) :
+        BoundStatement(BoundNodeKind::Unknown, nullptr), child(child) {}
+};
+
+class BoundStatementList : public BoundStatement {
+public:
+    ArrayRef<const BoundStatement*> list;
+
+    BoundStatementList(ArrayRef<const BoundStatement*> list) :
+        BoundStatement(BoundNodeKind::StatementList, nullptr), list(list) {}
+};
+
+class BoundReturnStatement : public BoundStatement {
+public:
+    const BoundExpression* expr;
+
+    BoundReturnStatement(const StatementSyntax* syntax, const BoundExpression* expr) :
+        BoundStatement(BoundNodeKind::ReturnStatement, syntax), expr(expr) {}
 };
 
 }

--- a/include/ConstantEvaluator.h
+++ b/include/ConstantEvaluator.h
@@ -59,7 +59,7 @@ private:
 
     ConstantValue evaluateLiteral(const BoundLiteral* expr);
     ConstantValue evaluateParameter(const BoundParameter* expr);
-    ConstantValue evaluateVarRef(const BoundVarRef* expr);
+    ConstantValue evaluateVariable(const BoundVariable* expr);
     ConstantValue evaluateUnary(const BoundUnaryExpression* expr);
     ConstantValue evaluateBinary(const BoundBinaryExpression* expr);
     ConstantValue evaluateAssignment(const BoundAssignmentExpression* expr);

--- a/include/Diagnostics.h
+++ b/include/Diagnostics.h
@@ -138,6 +138,10 @@ enum class DiagCode : uint8_t {
     BadBinaryExpression,
     BadAssignment,
     NoImplicitConversion,
+    UndeclaredIdentifier,
+
+    // statements
+    ReturnNotInSubroutine,
 
     MaxValue
 };

--- a/include/ExpressionBinder.h
+++ b/include/ExpressionBinder.h
@@ -18,10 +18,14 @@ class Scope;
 class ExpressionBinder {
 public:
     ExpressionBinder(SemanticModel& sem, const Scope* scope);
+    ExpressionBinder(SemanticModel& sem, const SubroutineSymbol* subroutine);
 
     BoundExpression* bindConstantExpression(const ExpressionSyntax* syntax);
     BoundExpression* bindSelfDeterminedExpression(const ExpressionSyntax* syntax);
     BoundExpression* bindAssignmentLikeContext(const ExpressionSyntax* syntax, SourceLocation location, const TypeSymbol* assignmentType);
+
+    BoundStatement* bindStatement(const StatementSyntax* syntax);
+    BoundStatementList* bindStatementList(const SyntaxList<SyntaxNode>& items);
 
 private:
     BoundExpression* bindExpression(const ExpressionSyntax* syntax);
@@ -36,6 +40,8 @@ private:
     BoundExpression* bindShiftOrPowerOperator(const BinaryExpressionSyntax* syntax);
     BoundExpression* bindAssignmentOperator(const BinaryExpressionSyntax* syntax);
 
+    BoundStatement* bindReturnStatement(const ReturnStatementSyntax* syntax);
+
     // functions to check whether operators are applicable to the given operand types
     bool checkOperatorApplicability(SyntaxKind op, SourceLocation location, BoundExpression** operand);
     bool checkOperatorApplicability(SyntaxKind op, SourceLocation location, BoundExpression** lhs, BoundExpression** rhs);
@@ -43,11 +49,13 @@ private:
     // Propagates the type of the expression back down to its operands.
     void propagate(BoundExpression* expression, const TypeSymbol* type);
 
-    BadBoundExpression* makeBad(BoundExpression* expr);
+    BadBoundExpression* badExpr(BoundExpression* expr);
+    BadBoundStatement* badStmt(BoundStatement* stmt);
 
     SemanticModel& sem;
     BumpAllocator& alloc;
     const Scope* scope;
+    const SubroutineSymbol* subroutine = nullptr;
 
     Diagnostic& addError(DiagCode code, SourceLocation location);
 };

--- a/include/SemanticModel.h
+++ b/include/SemanticModel.h
@@ -95,7 +95,7 @@ private:
     void handleInstantiation(const HierarchyInstantiationSyntax* syntax, SmallVector<const Symbol*>& results, const Scope* instantiationScope);
     void handleDataDeclaration(const DataDeclarationSyntax *syntax, SmallVector<const Symbol *>& results, Scope* scope);
     void handleProceduralBlock(const ProceduralBlockSyntax *syntax, SmallVector<const Symbol *>& results, const Scope* scope);
-    void handleVariableDeclarator(const VariableDeclaratorSyntax *syntax, SmallVector<const Symbol *>& results, Scope *scope, const VariableSymbol::VariableSymbolModifiers &modifiers, const TypeSymbol *typeSymbol);
+    void handleVariableDeclarator(const VariableDeclaratorSyntax *syntax, SmallVector<const Symbol *>& results, Scope *scope, const VariableSymbol::Modifiers &modifiers, const TypeSymbol *typeSymbol);
     void handleIfGenerate(const IfGenerateSyntax* syntax, SmallVector<const Symbol*>& results, const Scope* scope);
     void handleLoopGenerate(const LoopGenerateSyntax* syntax, SmallVector<const Symbol*>& results, const Scope* scope);
     void handleGenerateBlock(const MemberSyntax* syntax, SmallVector<const Symbol*>& results, const Scope* scope);

--- a/include/SyntaxNode.h
+++ b/include/SyntaxNode.h
@@ -500,6 +500,7 @@ bool isPossibleFunctionPort(TokenKind kind);
 bool isPossibleParameter(TokenKind kind);
 bool isPossiblePortConnection(TokenKind kind);
 bool isPossibleVectorDigit(TokenKind kind);
+bool isStatement(SyntaxKind kind);
 
 // discriminated union of Token and SyntaxNode
 struct TokenOrSyntax {

--- a/source/ConstantEvaluator.cpp
+++ b/source/ConstantEvaluator.cpp
@@ -38,7 +38,7 @@ ConstantValue ConstantEvaluator::evaluate(const BoundNode* tree) {
     switch (tree->kind) {
         case BoundNodeKind::Literal: return evaluateLiteral((BoundLiteral*)tree);
         case BoundNodeKind::Parameter: return evaluateParameter((BoundParameter*)tree);
-        case BoundNodeKind::VarRef: return evaluateVarRef((BoundVarRef*)tree);
+        case BoundNodeKind::Variable: return evaluateVariable((BoundVariable*)tree);
         case BoundNodeKind::UnaryExpression: return evaluateUnary((BoundUnaryExpression*)tree);
         case BoundNodeKind::BinaryExpression: return evaluateBinary((BoundBinaryExpression*)tree);
         case BoundNodeKind::AssignmentExpression: return evaluateAssignment((BoundAssignmentExpression*)tree);
@@ -56,7 +56,7 @@ ConstantValue ConstantEvaluator::evaluateParameter(const BoundParameter* expr) {
     return expr->symbol.value;
 }
 
-ConstantValue ConstantEvaluator::evaluateVarRef(const BoundVarRef* expr) {
+ConstantValue ConstantEvaluator::evaluateVariable(const BoundVariable* expr) {
     ConstantValue& val = currentFrame->temporaries[expr->symbol];
     ASSERT(val);
     return val;
@@ -139,8 +139,8 @@ ConstantValue ConstantEvaluator::evaluateAssignment(const BoundAssignmentExpress
 bool ConstantEvaluator::evaluateLValue(const BoundExpression* expr, LValue& lvalue) {
     // lvalues have to be one of a few kinds of expressions
     switch (expr->kind) {
-        case BoundNodeKind::VarRef:
-            lvalue.storage = &currentFrame->temporaries[((BoundVarRef*)expr)->symbol];
+        case BoundNodeKind::Variable:
+            lvalue.storage = &currentFrame->temporaries[((BoundVariable*)expr)->symbol];
             break;
 
             DEFAULT_UNREACHABLE;

--- a/source/Diagnostics.cpp
+++ b/source/Diagnostics.cpp
@@ -169,6 +169,10 @@ DiagnosticWriter::DiagnosticWriter(SourceManager& sourceManager) :
     descriptors[DiagCode::BadBinaryExpression] = { "invalid operands to binary expression ({} and {})", DiagnosticSeverity::Error };
     descriptors[DiagCode::BadAssignment] = { "type {} cannot be assigned to variable of type {}", DiagnosticSeverity::Error };
     descriptors[DiagCode::NoImplicitConversion] = { "no implicit conversion from {} to {}; explicit conversion exists, are you missing a cast?", DiagnosticSeverity::Error };
+    descriptors[DiagCode::UndeclaredIdentifier] = { "use of undeclared identifier '{}'", DiagnosticSeverity::Error };
+
+    // statements
+    descriptors[DiagCode::ReturnNotInSubroutine] = { "return statement is only valid inside task and function blocks", DiagnosticSeverity::Error };
 
     ASSERT((int)DiagCode::MaxValue == descriptors.size(), "When you add a new diagnostic code you need to update default messages");
 }

--- a/source/SemanticModel.cpp
+++ b/source/SemanticModel.cpp
@@ -184,6 +184,8 @@ const TypeSymbol* SemanticModel::makeTypeSymbol(const DataTypeSyntax* syntax, co
             auto type = makeTypeSymbol(tds->type, scope);
             return alloc.emplace<TypeAliasSymbol>(syntax, tds->name.location(), type, tds->name.valueText());
         }
+        default:
+            break;
     }
 
     // TODO: consider Void Type
@@ -477,7 +479,7 @@ static ProceduralBlock::Kind proceduralBlockKindFromKeyword(Token kindKeyword) {
         default:
             ASSERT(false, "Unknown ProceduralBlock kind keyword: %s",
                    kindKeyword.toString().c_str());
-            break;
+            return ProceduralBlock::Initial;    // silence warnings
     }
 }
 
@@ -545,6 +547,8 @@ void SemanticModel::handleGenerateItem(const MemberSyntax* syntax, SmallVector<c
         case SyntaxKind::TaskDeclaration:
             results.append(makeSubroutine(syntax->as<FunctionDeclarationSyntax>(), scope));
             break;
+
+            DEFAULT_UNREACHABLE;
     }
 }
 

--- a/source/SyntaxFacts.cpp
+++ b/source/SyntaxFacts.cpp
@@ -831,4 +831,45 @@ bool isNotInConcatenationExpr(TokenKind kind) {
     }
 }
 
+bool isStatement(SyntaxKind kind) {
+    switch (kind) {
+        case SyntaxKind::NamedLabel:
+        case SyntaxKind::EmptyStatement:
+        case SyntaxKind::ElseClause:
+        case SyntaxKind::ConditionalStatement:
+        case SyntaxKind::DefaultCaseItem:
+        case SyntaxKind::PatternCaseItem:
+        case SyntaxKind::StandardCaseItem:
+        case SyntaxKind::CaseStatement:
+        case SyntaxKind::ForeverStatement:
+        case SyntaxKind::LoopStatement:
+        case SyntaxKind::DoWhileStatement:
+        case SyntaxKind::ForVariableDeclaration:
+        case SyntaxKind::ForLoopStatement:
+        case SyntaxKind::ForeachLoopList:
+        case SyntaxKind::ForeachLoopStatement:
+        case SyntaxKind::ReturnStatement:
+        case SyntaxKind::JumpStatement:
+        case SyntaxKind::TimingControlStatement:
+        case SyntaxKind::ExpressionStatement:
+        case SyntaxKind::ProceduralAssignStatement:
+        case SyntaxKind::ProceduralForceStatement:
+        case SyntaxKind::ProceduralDeassignStatement:
+        case SyntaxKind::ProceduralReleaseStatement:
+        case SyntaxKind::DisableStatement:
+        case SyntaxKind::DisableForkStatement:
+        case SyntaxKind::NamedBlockClause:
+        case SyntaxKind::SequentialBlockStatement:
+        case SyntaxKind::ParallelBlockStatement:
+        case SyntaxKind::WaitStatement:
+        case SyntaxKind::WaitForkStatement:
+        case SyntaxKind::WaitOrderStatement:
+        case SyntaxKind::RandCaseItem:
+        case SyntaxKind::RandCaseStatement:
+            return true;
+        default:
+            return false;
+    }
+}
+
 }

--- a/tests/unit_tests/ExpressionBindingTests.cpp
+++ b/tests/unit_tests/ExpressionBindingTests.cpp
@@ -39,7 +39,7 @@ TEST_CASE("Evaluate assignment expression", "[binding:expressions") {
 
     // Fabricate a symbol for the `i` variable
     auto varToken = syntax.root()->getFirstToken();
-    LocalVariableSymbol local {
+    VariableSymbol local {
         varToken.valueText(), varToken.location(),
         sem.getKnownType(SyntaxKind::LogicType)
     };
@@ -72,7 +72,7 @@ TEST_CASE("Check type propagation", "[binding:expressions]") {
 
     // Fabricate a symbol for the `i` variable
     auto varToken = syntax.root()->getFirstToken();
-    LocalVariableSymbol local {
+    VariableSymbol local {
         varToken.valueText(), varToken.location(),
         sem.getIntegralType(20, false)
     };
@@ -100,7 +100,7 @@ TEST_CASE("Check type propagation 2", "[binding:expressions]") {
 
     // Fabricate a symbol for the `i` variable
     auto varToken = syntax.root()->getFirstToken();
-    LocalVariableSymbol local {
+    VariableSymbol local {
         varToken.valueText(), varToken.location(),
         sem.getIntegralType(20, false)
     };

--- a/tests/unit_tests/ModuleBindingTests.cpp
+++ b/tests/unit_tests/ModuleBindingTests.cpp
@@ -235,7 +235,7 @@ endmodule
     CHECK(alwaysComb.kind == ProceduralBlock::AlwaysComb);
 
     const auto& variable = instance.getChild<VariableSymbol>(2);
-    CHECK(variable.typeSymbol.kind == SymbolKind::IntegralType);
+    CHECK(variable.type->kind == SymbolKind::IntegralType);
     CHECK(variable.name == "arr1");
 }
 
@@ -243,6 +243,7 @@ TEST_CASE("Function declaration", "[binding:modules]") {
     auto tree = SyntaxTree::fromText(R"(
 module Top;
     function static logic [15:0] foo(a, int b, output logic [15:0] u, v, inout w);
+        return a + b;
     endfunction
 endmodule
 )");
@@ -264,6 +265,11 @@ endmodule
     CHECK(foo.arguments[3]->direction == FormalArgumentDirection::Out);
     CHECK(foo.arguments[4]->type->as<IntegralTypeSymbol>().width == 1);
     CHECK(foo.arguments[4]->direction == FormalArgumentDirection::InOut);
+
+    const auto& returnStmt = *(const BoundReturnStatement*)foo.body->list[0];
+    REQUIRE(returnStmt.kind == BoundNodeKind::ReturnStatement);
+    CHECK(!returnStmt.expr->bad());
+    CHECK(returnStmt.expr->type->as<IntegralTypeSymbol>().width == 32);
 }
 
 }


### PR DESCRIPTION
Currently only supports return statements. I should probably rename ExpressionBinder now, since it also binds statements.

This also merges the LocalVariable and Variable symbols, since they're basically the same thing, and adds an error when symbol lookup fails to find them.