### PR TITLE
Make syntax.txt match AllSyntax.h

### DIFF
--- a/tools/syntax.txt
+++ b/tools/syntax.txt
@@ -686,7 +686,9 @@ StatementSyntax statement
 ForeachLoopListSyntax kind=ForeachLoopList
 token openParen
 NameSyntax arrayName
+token openBracket
 separated_list<NameSyntax> loopVariables
+token closeBracket
 token closeParen
 
 ForeachLoopStatementSyntax base=StatementSyntax kind=ForeachLoopStatement


### PR DESCRIPTION
I changed the ForEachLoopListSyntax in AllSyntax.h before I had realized I needed to update syntax.txt.  This change edits syntax.txt so it actually generates the code in AllSyntax.h.