### PR TITLE
make macro stringification more robust

### DIFF
--- a/include/Token.h
+++ b/include/Token.h
@@ -571,6 +571,7 @@ enum class TokenKind : uint16_t {
     MacroQuote,
     MacroEscapedQuote,
     MacroPaste,
+    EmptyMacroArgument,
 
     // special placeholders for intrinsic macros
     IntrinsicFileMacro,

--- a/include/Trivia.h
+++ b/include/Trivia.h
@@ -49,7 +49,9 @@ public:
     /// If this trivia is tracking a skipped syntax node, return that now.
     SyntaxNode* syntax() const;
 
-    StringRef getRawText() const {
+    /// Get the raw whitespace of some trivia
+    StringRef getRawWhitespace() const {
+        ASSERT(kind == TriviaKind::Whitespace);
         return rawText;
     }
 private:

--- a/include/Trivia.h
+++ b/include/Trivia.h
@@ -49,6 +49,9 @@ public:
     /// If this trivia is tracking a skipped syntax node, return that now.
     SyntaxNode* syntax() const;
 
+    StringRef getRawText() const {
+        return rawText;
+    }
 private:
     union {
         StringRef rawText;

--- a/source/Lexer.cpp
+++ b/source/Lexer.cpp
@@ -166,7 +166,7 @@ Token Lexer::stringify(BumpAllocator& alloc, SourceLocation location, ArrayRef<T
         if (!noWhitespace && cur.hasTrivia(TriviaKind::Whitespace)) {
             for (const Trivia& trivia : cur.trivia()) {
                 if (trivia.kind == TriviaKind::Whitespace) {
-                    text.appendRange(trivia.getRawText());
+                    text.appendRange(trivia.getRawWhitespace());
                 }
             }
         }

--- a/source/Preprocessor.cpp
+++ b/source/Preprocessor.cpp
@@ -927,7 +927,7 @@ bool Preprocessor::expandMacro(DefineDirectiveSyntax* macro, Token usageSite, Ma
                     // the macro argument contained no tokens.
                     // we still need to supply an empty token here to ensure
                     // that the trivia of the formal paremter is passed on
-                    dest.append(*alloc.emplace<Token>(TokenKind::EmptyMacroArgument, token.getInfo()));
+                    dest.append(Token(TokenKind::EmptyMacroArgument, token.getInfo()));
                 }
             }
         }

--- a/tests/unit_tests/PreprocessorTests.cpp
+++ b/tests/unit_tests/PreprocessorTests.cpp
@@ -255,6 +255,15 @@ TEST_CASE("Macro stringify", "[preprocessor]") {
     CHECK(diagnostics.empty());
 }
 
+TEST_CASE("Macro stringify whitespace", "[preprocessor]") {
+    auto& text = "`define FOO(x,y) `\" x ( y)\t  x   x`\"\n`FOO(bar,)";
+    Token token = lexToken(text);
+
+    REQUIRE(token.kind == TokenKind::StringLiteral);
+    CHECK(token.valueText() == " bar ( )\t  bar   bar");
+    CHECK(diagnostics.empty());
+}
+
 TEST_CASE("IfDef branch (taken)", "[preprocessor]") {
     auto& text = "`define FOO\n`ifdef FOO\n42\n`endif";
     Token token = lexToken(text);


### PR DESCRIPTION
This change makes us take all whitespace in a macro definition that we are stringifying literally, which is what all other preprocessors I have tested do. This includes having to include any whitespace before an actual argument of no tokens.

This addresses Issue #3 