### PR TITLE
Parse assignment patterns that are lists of expressions

### DIFF
--- a/source/Parser_expressions.cpp
+++ b/source/Parser_expressions.cpp
@@ -466,6 +466,22 @@ AssignmentPatternExpressionSyntax* Parser::parseAssignmentPatternExpression(Data
                 );
             break;
         }
+        case TokenKind::Comma:
+            buffer.append(firstExpr);
+            buffer.append(consume());
+            parseSeparatedList<isPossibleExpressionOrComma, isEndOfBracedList>(
+                buffer,
+                TokenKind::CloseBrace,
+                TokenKind::Comma,
+                closeBrace,
+                DiagCode::ExpectedExpression,
+                [this](bool) { return parseExpression(); }
+            );
+            pattern = alloc.emplace<SimpleAssignmentPatternSyntax>(
+                openBrace,
+                buffer.copy(alloc),
+                closeBrace);
+            break;
         default:
             buffer.append(firstExpr);
             parseSeparatedList<isPossibleExpressionOrComma, isEndOfBracedList>(


### PR DESCRIPTION
parseSeparatedList assumes we start with an item and not a separator, so we should append the first comma manually