### PR TITLE
Get raw text properly for empty macro argument

### DIFF
--- a/source/Token.cpp
+++ b/source/Token.cpp
@@ -118,6 +118,7 @@ StringRef Token::rawText() const {
             case TokenKind::TimeLiteral:
             case TokenKind::Directive:
             case TokenKind::MacroUsage:
+            case TokenKind::EmptyMacroArgument:
                 return info->rawText;
             case TokenKind::EndOfDirective:
             case TokenKind::EndOfFile:


### PR DESCRIPTION
Special case to avoid hitting the assertion below since these tokens don't have associated text.