### PR TITLE
Parse coverpoints of the form bins id[]...

### DIFF
--- a/source/Parser_expressions.cpp
+++ b/source/Parser_expressions.cpp
@@ -501,6 +501,9 @@ ElementSelectSyntax* Parser::parseElementSelect() {
 }
 
 SelectorSyntax* Parser::parseElementSelector() {
+    if (peek().kind == TokenKind::CloseBracket) {
+        return nullptr;
+    }
     auto expr = parseExpression();
     switch (peek().kind) {
         case TokenKind::Colon: {


### PR DESCRIPTION
We use parseElementSlelect when parsing coverpoints, so let's allow an empty SelectorSytnax.