### PR TITLE
Fixed literal parsing corner cases

### DIFF
--- a/include/SVInt.h
+++ b/include/SVInt.h
@@ -24,6 +24,8 @@ enum class LiteralBase : uint8_t {
     Hex
 };
 
+bool literalBaseFromChar(char base, LiteralBase& result);
+
 /// Represents a single 4-state bit. The usual bit values of 0 and 1 are
 /// augmented with X (unknown) and Z (high impedance). Both X and Z are
 /// considered "unknown" for most computation purposes.

--- a/include/Token.h
+++ b/include/Token.h
@@ -53,7 +53,7 @@ enum class TimeUnit : uint8_t {
     Femtoseconds
 };
 
-TimeUnit suffixToTimeUnit(StringRef timeSuffix, bool &success);
+bool suffixToTimeUnit(StringRef timeSuffix, TimeUnit& unit);
 
 StringRef timeUnitToSuffix(TimeUnit unit);
 

--- a/source/ConstantEvaluator.cpp
+++ b/source/ConstantEvaluator.cpp
@@ -203,9 +203,7 @@ ConstantValue ConstantEvaluator::evaluateSelect(const BoundSelectExpression* exp
         // If any part of an address is unknown, then the whole thing returns
         // 'x; let's handle this here so everywhere else we can assume the inputs
         // are normal numbers
-        auto foo = SVInt::createFillX(expr->type->width(), false);
-        ASSERT(foo.hasUnknown());
-        return foo;
+        return SVInt::createFillX(expr->type->width(), false);
     }
     int16_t actualMsb = (lb < 0 ? -1 : 1) * msb.getAssertInt64() - lb;
     // here "actual" bit refers to bits numbered from

--- a/source/Diagnostics.cpp
+++ b/source/Diagnostics.cpp
@@ -87,7 +87,7 @@ DiagnosticWriter::DiagnosticWriter(SourceManager& sourceManager) :
     descriptors[DiagCode::RealExponentOverflow] = { "real literal overflows 64 bits", DiagnosticSeverity::Error };
     descriptors[DiagCode::SignedIntegerOverflow] = { "signed integer overflows 32 bits", DiagnosticSeverity::Error };
     descriptors[DiagCode::DecimalLiteralOverflow] = { "decimal literal overflows 32 bits", DiagnosticSeverity::Error };
-    descriptors[DiagCode::VectorLiteralOverflow] = { "vector literal too large for the given number of bits", DiagnosticSeverity::Error };
+    descriptors[DiagCode::VectorLiteralOverflow] = { "vector literal too large for the given number of bits", DiagnosticSeverity::Warning };
 
     // preprocessor
     descriptors[DiagCode::CouldNotOpenIncludeFile] = { "could not find or open include file", DiagnosticSeverity::Error };

--- a/source/Lexer.cpp
+++ b/source/Lexer.cpp
@@ -858,32 +858,17 @@ TokenKind Lexer::lexApostrophe(Token::Info* info) {
 }
 
 bool Lexer::lexIntegerBase(Token::Info* info, bool isSigned) {
-    switch (peek()) {
-        case 'd':
-        case 'D':
-            advance();
-            info->setNumFlags(LiteralBase::Decimal, isSigned);
-            return true;
-        case 'b':
-        case 'B':
-            advance();
-            info->setNumFlags(LiteralBase::Binary, isSigned);
-            return true;
-        case 'o':
-        case 'O':
-            advance();
-            info->setNumFlags(LiteralBase::Octal, isSigned);
-            return true;
-        case 'h':
-        case 'H':
-            advance();
-            info->setNumFlags(LiteralBase::Hex, isSigned);
-            return true;
+    LiteralBase base;
+    if (literalBaseFromChar(peek(), base)) {
+        advance();
+        info->setNumFlags(base, isSigned);
+        return true;
     }
     return false;
 }
 
 bool Lexer::lexTimeLiteral(Token::Info* info) {
+    // XXX: see if this can be cheated on with like, mX
 #define CASE(c, flag) \
     case c: if (peek(1) == 's') { \
         advance(2); \

--- a/source/Lexer.cpp
+++ b/source/Lexer.cpp
@@ -868,7 +868,6 @@ bool Lexer::lexIntegerBase(Token::Info* info, bool isSigned) {
 }
 
 bool Lexer::lexTimeLiteral(Token::Info* info) {
-    // XXX: see if this can be cheated on with like, mX
 #define CASE(c, flag) \
     case c: if (peek(1) == 's') { \
         advance(2); \

--- a/source/Preprocessor.cpp
+++ b/source/Preprocessor.cpp
@@ -517,9 +517,9 @@ Trivia Preprocessor::handleTimescaleDirective(Token directive) {
     auto eod = parseEndOfDirective();
 
     if (foundSpecifiers) {
-        bool success1, success2;
-        TimeUnit unitValue = suffixToTimeUnit(valueUnit.valueText(), success1);
-        TimeUnit unitPrecision = suffixToTimeUnit(precisionUnit.valueText(), success2);
+        TimeUnit unitValue, unitPrecision;
+        bool success1 = suffixToTimeUnit(valueUnit.valueText(), unitValue);
+        bool success2 = suffixToTimeUnit(precisionUnit.valueText(), unitPrecision);
         // both unit and precision must have valid units, and
         // the precision must be at least as precise as the value.
         // larger values of TimeUnit are more precise than smaller values

--- a/source/SVInt.cpp
+++ b/source/SVInt.cpp
@@ -200,6 +200,7 @@ SVInt::SVInt(uint16_t bits, LiteralBase base, bool isSigned, bool anyUnknown, Ar
             val += d.value;
             ASSERT(d.value < radix, "Digit %d too large for radix %d", d.value, radix);
         }
+        // handles overflow
         clearUnusedBits();
         return;
     }
@@ -213,9 +214,6 @@ SVInt::SVInt(uint16_t bits, LiteralBase base, bool isSigned, bool anyUnknown, Ar
 
     // If the user specified a number too large to fit in the number of bits specified,
     // the spec says to truncate from the left, which this method will successfully do.
-    // TODO: we should almost certainly also issue a warning, people shouldn't do this
-    // TODO: have a reasonable way of having warnings / diagnostics triggered from SVInt,
-    // basically all assertions in this file should actually be diagnostic messages
     for (const logic_t& d : digits) {
         int unknown = 0;
         int value = d.value;

--- a/source/Token.cpp
+++ b/source/Token.cpp
@@ -243,24 +243,23 @@ Token Token::createExpected(BumpAllocator& alloc, Diagnostics& diagnostics, Toke
     return Token::createMissing(alloc, expected, location);
 }
 
-TimeUnit suffixToTimeUnit(StringRef timeSuffix, bool &success) {
-    success = true;
+bool suffixToTimeUnit(StringRef timeSuffix, TimeUnit& unit) {
     if (timeSuffix == "s") {
-        return TimeUnit::Seconds;
+        unit = TimeUnit::Seconds;
     } else if (timeSuffix == "ms") {
-        return TimeUnit::Milliseconds;
+        unit = TimeUnit::Milliseconds;
     } else if (timeSuffix == "us") {
-        return TimeUnit::Microseconds;
+        unit = TimeUnit::Microseconds;
     } else if (timeSuffix == "ns") {
-        return TimeUnit::Nanoseconds;
+        unit = TimeUnit::Nanoseconds;
     } else if (timeSuffix == "ps") {
-        return TimeUnit::Picoseconds;
+        unit = TimeUnit::Picoseconds;
     } else if (timeSuffix == "fs") {
-        return TimeUnit::Femtoseconds;
+        unit = TimeUnit::Femtoseconds;
     } else {
-        success = false;
-        return TimeUnit::Seconds;
+        return false;
     }
+    return true;
 }
 
 StringRef timeUnitToSuffix(TimeUnit unit) {

--- a/source/VectorBuilder.cpp
+++ b/source/VectorBuilder.cpp
@@ -166,11 +166,17 @@ SVInt VectorBuilder::finish() {
             bits += clog2(digits[0].value + 1);
 
         if (bits > sizeBits) {
-            if (sizeBits || bits > SVInt::MAX_BITS) {
+            if (bits > SVInt::MAX_BITS) {
                 diagnostics.add(DiagCode::VectorLiteralOverflow, firstLocation);
-                return SVInt(0);
+                bits = SVInt::MAX_BITS;
             }
-            return SVInt(std::max(32, bits), literalBase, signFlag, hasUnknown, ArrayRef<logic_t>(digits.begin(), digits.count()));
+            if (sizeBits == 0) {
+                return SVInt(std::max(32, bits), literalBase, signFlag, hasUnknown, ArrayRef<logic_t>(digits.begin(), digits.count()));
+            } else {
+                // we should warn about overflow here, but the spec says it is valid and
+                // the literal gets truncated. Definitely a warning though.
+                diagnostics.add(DiagCode::VectorLiteralOverflow, firstLocation);
+            }
         }
     }
 

--- a/tests/unit_tests/EvalTests.cpp
+++ b/tests/unit_tests/EvalTests.cpp
@@ -157,7 +157,8 @@ TEST_CASE(descr, "[eval]") { \
     ScriptSession session; \
     auto value = session.eval(expr).integer(); \
     auto res = SVInt(StringRef(result)); \
-    /* uncomment for diagonstics: printf("%s = %s\n", value.toString(LiteralBase::Binary).c_str(), res.toString(LiteralBase::Binary).c_str());*/ \
+    /* uncomment for diagonstics: */ \
+    /* printf("%s = %s\n", value.toString(LiteralBase::Binary).c_str(), res.toString(LiteralBase::Binary).c_str()); */ \
     CHECK(exactlyEqual(value, res)); \
 }
 
@@ -193,10 +194,18 @@ EVAL_TEST_EX("partially oob rangeselect (right)", "4'b1001[3 : -1]", "5'b1001x")
 EVAL_TEST_EX("partially oob rangeselect (left)", "4'b1001[4 : 1]", "4'bx100");
 EVAL_TEST_EX("partially oob rangeselect (both)", "4'b1001[4 : -1]", "6'bx1001x");
 EVAL_TEST_EX("totally oob rangeselect", "4'b1001[105 : 101]", "5'bxxxxx");
-//TODO: Figure out why a test like this fails, seems like something wrong with literals with x's?
-//EVAL_TEST_EX("lit", "43'b10x", "43'b10x");
 EVAL_TEST("bits system call", "$bits(3'b101)", 3);
 EVAL_TEST("bits system call 2", "$bits(23)", 32);
+// Some basic tests that literals evaluate to the right values
+EVAL_TEST_EX("lit", "43'b10x", "43'b10x");
+EVAL_TEST_EX("lit2", "22'b101x", "22'b101x");
+EVAL_TEST_EX("bigliteral with a high x", "72'hxxffffffffffffffff",
+                                         "72'hxxffffffffffffffff");
+EVAL_TEST_EX("literal truncation", "2'b101", "2'b01");
+// If the highest bit is a z or x, that is extended to the full size
+EVAL_TEST_EX("xpadding", "5'bx01", "5'bxxx01");
+EVAL_TEST_EX("zpadding", "5'bz01", "5'bzzz01");
+EVAL_TEST_EX("really long zpadding", "68'bz0000", "68'hzzzzzzzzzzzzzzzzz0");
 
 TEST_CASE("bit select weird indexes", "[eval]") {
     // The above bit select cases test the "normal" case where vectors are specified

--- a/tests/unit_tests/LexerTests.cpp
+++ b/tests/unit_tests/LexerTests.cpp
@@ -529,6 +529,11 @@ TEST_CASE("Time literals", "[lexer]") {
     checkTimeLiteral("42fs", TimeUnit::Femtoseconds, 42);
 }
 
+TEST_CASE("Bad time literal", "[lexer]") {
+    Token token = lexToken("10mX");
+    CHECK(token.kind != TokenKind::TimeLiteral);
+}
+
 TEST_CASE("Misplaced directive char", "[lexer]") {
     auto& text = "`";
     Token token = lexToken(text);


### PR DESCRIPTION
In particular this change:

- Combines a lot of the SVInt(StringRef) and SVInt(...., ArrayRef<logic_t>) code for simplicity/ code reuse
- Due to ^, propagates my previous fix for literals with unknown bits to the other constructor
- Adds a fast path for constructing SVInts from vectors that fit in one word
- Adds support for "unknown padding" of literals as described in the spec, i.e `3'bx1 == 3'bxx1`
- Adds support for literal truncation, and downgrades overflow from an error to a warning
- Cleans up some related code