### PR TITLE
Enabled parsing of timing control in subexpressions

### DIFF
--- a/source/Parser_expressions.cpp
+++ b/source/Parser_expressions.cpp
@@ -35,11 +35,10 @@ ExpressionSyntax* Parser::parseSubExpression(ExpressionOptions::Enum options, in
     auto current = peek();
     if (current.kind == TokenKind::NewKeyword)
         return parseNewExpression(nullptr);
-    // TODO:
-    /*else if (isPossibleDelayOrEventControl(current.kind)) {
+    else if (isPossibleDelayOrEventControl(current.kind)) {
         auto timingControl = parseTimingControl();
         return alloc.emplace<TimingControlExpressionSyntax>(timingControl, parseExpression());
-    }*/
+    }
     else if (current.kind == TokenKind::TaggedKeyword) {
         // TODO: check for trailing expression
         auto tagged = consume();


### PR DESCRIPTION
This code seems to work fine to me.  It fixes parsing errors in several of our files.  Any reason why it should remain commented out?