### PR TITLE
Fix path to unittest binary

### DIFF
--- a/scripts/build_clang.sh
+++ b/scripts/build_clang.sh
@@ -3,7 +3,7 @@ set -ev
 export ASAN_SYMBOLIZER_PATH=/usr/lib/llvm-6.0/bin/llvm-symbolizer
 cd /slang
 make -C build -j 8
-build/tests/unittests/unittests
+build/bin/unittests
 bash <(curl -s https://codecov.io/bash) -x 'llvm-cov-6.0 gcov' -X gcovout || echo 'Codecov failed to upload'
 FILES=$(find source -type f -name '*.cpp')
 for f in $FILES; do

--- a/scripts/build_gcc.sh
+++ b/scripts/build_gcc.sh
@@ -2,5 +2,5 @@
 set -ev
 cd /slang
 make -C build -j 8
-build/tests/unittests/unittests
+build/bin/unittests
 /tmp/cppcheck/cppcheck source -I. -Iexternal -Isource -q --enable=warning,performance,portability --inconclusive --suppressions-list=scripts/cppcheck_suppressions.txt


### PR DESCRIPTION
After the switch to a new build system the path to unittest binary was changed. Currently, Travis builds are failed.

A possible solution of the issue is change of paths in build scripts