### PR TITLE
GCC Compile fix, Regressions tests and gitignore update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .vs/
 build/
+compile_commands.json

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -126,4 +126,8 @@ conan_cmake_run(CONANFILE conanfile.txt BASIC_SETUP CMAKE_TARGETS)
 
 add_subdirectory(source)
 add_subdirectory(tools)
+
+include(CTest)
+
 add_subdirectory(tests/unittests)
+add_subdirectory(tests/regression)

--- a/include/slang/symbols/DeclaredType.h
+++ b/include/slang/symbols/DeclaredType.h
@@ -15,6 +15,7 @@ class Expression;
 class Scope;
 class Symbol;
 class Type;
+struct BindContext;
 struct DataTypeSyntax;
 struct ExpressionSyntax;
 struct VariableDeclaratorSyntax;

--- a/tests/regression/CMakeLists.txt
+++ b/tests/regression/CMakeLists.txt
@@ -1,0 +1,2 @@
+add_test(NAME regression_delayed_reg COMMAND driver "${CMAKE_CURRENT_LIST_DIR}/delayed_reg.v")
+add_test(NAME regression_wire_module COMMAND driver "${CMAKE_CURRENT_LIST_DIR}/wire_module.v")

--- a/tests/regression/delayed_reg.v
+++ b/tests/regression/delayed_reg.v
@@ -1,0 +1,9 @@
+module delayed_reg (input in, output out);
+
+    reg out;
+
+    always @(posedge in) begin
+        #10 out = !out;
+    end
+
+endmodule

--- a/tests/regression/wire_module.v
+++ b/tests/regression/wire_module.v
@@ -1,0 +1,5 @@
+module wire_module (input in, output out);
+
+  assign out = in;
+
+endmodule


### PR DESCRIPTION
I didn't see a contributor.txt or something similar so I will state here:

All my contributions under the slang project are also under the MIT license.

I found this project an hour ago. It looks very promising.

There was no regression test system in place so I just made a folder with a CMakeLists.txt

I tried a few module descriptions, but it seems to run into a few internal errors. I've simplified it as much as possible and put the two failing cases in regression tests.