### PR TITLE
add proper dependencies

### DIFF
--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -81,6 +81,8 @@ add_library(slang STATIC
 	util/Util.cpp
 )
 
+add_dependencies(slang gen_version)
+
 if(CMAKE_CXX_COMPILER_ID MATCHES "MSVC")
 	# Warnings as errors
 	target_compile_options(slang PRIVATE /WX)


### PR DESCRIPTION
When using debug/dev mode in cmake, `Version.cpp` somehow won't get generated. This patch fixes the dependency.