### PR TITLE
Source manager memory allocation fix

### DIFF
--- a/source/text/SourceManager.cpp
+++ b/source/text/SourceManager.cpp
@@ -432,7 +432,7 @@ bool SourceManager::readFile(const fs::path& path, std::vector<char>& buffer) {
         return false;
 
     // + 1 for null terminator
-    buffer.resize((uint32_t)size + 1);
+    buffer.resize((size_t)size + 1);
     std::ifstream stream(path, std::ios::binary);
     if (!stream.read(buffer.data(), (std::streamsize)size))
         return false;

--- a/tools/rewriter/rewriter.cpp
+++ b/tools/rewriter/rewriter.cpp
@@ -21,7 +21,7 @@ using namespace slang;
 
 int main(int argc, char** argv) try {
     if (argc != 2) {
-        fprintf(stderr, "usage: rewriter file");
+        fprintf(stderr, "usage: rewriter file\n");
         return 1;
     }
 

--- a/tools/rewriter/rewriter.cpp
+++ b/tools/rewriter/rewriter.cpp
@@ -12,6 +12,8 @@
 #    include <io.h>
 #endif
 
+#include <filesystem>
+
 #include "slang/syntax/SyntaxPrinter.h"
 #include "slang/syntax/SyntaxTree.h"
 
@@ -27,6 +29,16 @@ int main(int argc, char** argv) try {
 #if defined(_WIN32)
     _setmode(_fileno(stdout), _O_BINARY);
 #endif
+
+    if (!std::filesystem::exists(argv[1])) {
+        fprintf(stderr, "File does not exist: %s\n", argv[1]);
+        return 1;
+    }
+
+    if (!std::filesystem::is_regular_file(argv[1])) {
+        fprintf(stderr, "%s is not a file\n", argv[1]);
+        return 1;
+    }
 
     auto tree = SyntaxTree::fromFile(argv[1]);
     printf("%s", SyntaxPrinter::printFile(*tree).c_str());


### PR DESCRIPTION
Casting the total size to u32_t effectively limits the max files size. This can cause a SEGFAULT if the input file is larger than 2**32 B.
    
Fixes #261

Additionally this PR adds some sanity checks to the rewriter tool.