### PR TITLE
FindPython requires CMake 3.12

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 # slang - cmake entry point
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.12)
 project(slang VERSION 0.1.0 LANGUAGES CXX)
 
 option(SLANG_MSVC_W4 "Enable /W4 for MSVC builds" ON)


### PR DESCRIPTION
FindPython appears to have been added in CMake 3.12:
https://cmake.org/cmake/help/v3.12/release/3.12.html?highlight=findpython#modules