### PR TITLE
Fix compilation with threads

### DIFF
--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -170,6 +170,9 @@ endif()
 target_link_libraries(slang PUBLIC CONAN_PKG::jsonformoderncpp)
 target_link_libraries(slang PUBLIC CONAN_PKG::fmt)
 
+find_package(Threads)
+target_link_libraries(slang PUBLIC ${CMAKE_THREAD_LIBS_INIT})
+
 target_include_directories(slang PUBLIC ../include/)
 target_include_directories(slang PUBLIC ${CMAKE_CURRENT_BINARY_DIR})
 target_include_directories(slang SYSTEM PUBLIC ../external/)


### PR DESCRIPTION
This fix is needed for the code to compile in Travis which uses an old Ubuntu version (16.04).

Refer to https://github.com/SymbiFlow/conda-packages/pull/52 for more information about the issue.

This does not seem affect the compilation on a modern OS.

Please let me know if you think this should be put in a different place or if it should be solved differently.