### PR TITLE
Add serialization for statements

### DIFF
--- a/include/slang/binding/Statements.h
+++ b/include/slang/binding/Statements.h
@@ -43,6 +43,21 @@ struct StatementSyntax;
     x(Assertion)
 ENUM(StatementKind, STATEMENT);
 #undef STATEMENT
+
+#define CONDITION(x) \
+ x(Normal) \
+ x(WildcardXOrZ) \
+ x(WildcardJustZ) \
+ x(Inside)
+ENUM(CaseStatementCondition, CONDITION)
+#undef CONDITION
+#define CHECK(x) \
+ x(None) \
+ x(Unique) \
+ x(Unique0) \
+ x(Priority)
+ENUM(CaseStatementCheck, CHECK)
+#undef CHECK
 // clang-format on
 
 /// The base class for all statements in SystemVerilog.
@@ -176,6 +191,8 @@ public:
 
     static bool isKind(StatementKind kind) { return kind == StatementKind::Invalid; }
 
+    void serializeTo(ASTSerializer& serializer) const;
+
     static const InvalidStatement Instance;
 };
 
@@ -187,6 +204,8 @@ public:
 
     EvalResult evalImpl(EvalContext&) const { return EvalResult::Success; }
     bool verifyConstantImpl(EvalContext&) const { return true; }
+
+    void serializeTo(ASTSerializer&) const {}
 
     static bool isKind(StatementKind kind) { return kind == StatementKind::Empty; }
 };
@@ -201,6 +220,8 @@ public:
 
     EvalResult evalImpl(EvalContext& context) const;
     bool verifyConstantImpl(EvalContext& context) const;
+
+    void serializeTo(ASTSerializer& serializer) const;
 
     static bool isKind(StatementKind kind) { return kind == StatementKind::List; }
 };
@@ -221,6 +242,8 @@ public:
     const Statement& getStatements() const;
     EvalResult evalImpl(EvalContext& context) const;
     bool verifyConstantImpl(EvalContext& context) const;
+
+    void serializeTo(ASTSerializer& serializer) const;
 
     static Statement& fromSyntax(Compilation& compilation, const BlockStatementSyntax& syntax,
                                  const BindContext& context, StatementContext& stmtCtx);
@@ -247,6 +270,8 @@ public:
     static Statement& fromSyntax(Compilation& compilation, const ReturnStatementSyntax& syntax,
                                  const BindContext& context);
 
+    void serializeTo(ASTSerializer& serializer) const;
+
     static bool isKind(StatementKind kind) { return kind == StatementKind::Return; }
 };
 
@@ -263,6 +288,8 @@ public:
     static Statement& fromSyntax(Compilation& compilation, const JumpStatementSyntax& syntax,
                                  const BindContext& context, StatementContext& stmtCtx);
 
+    void serializeTo(const ASTSerializer&) const {}
+
     static bool isKind(StatementKind kind) { return kind == StatementKind::Break; }
 };
 
@@ -277,6 +304,8 @@ public:
     static Statement& fromSyntax(Compilation& compilation, const JumpStatementSyntax& syntax,
                                  const BindContext& context, StatementContext& stmtCtx);
 
+    void serializeTo(const ASTSerializer&) const {}
+
     static bool isKind(StatementKind kind) { return kind == StatementKind::Continue; }
 };
 
@@ -289,6 +318,8 @@ public:
 
     EvalResult evalImpl(EvalContext& context) const;
     bool verifyConstantImpl(EvalContext& context) const;
+
+    void serializeTo(ASTSerializer& serializer) const;
 
     static bool isKind(StatementKind kind) { return kind == StatementKind::VariableDeclaration; }
 };
@@ -312,6 +343,8 @@ public:
     static Statement& fromSyntax(Compilation& compilation, const ConditionalStatementSyntax& syntax,
                                  const BindContext& context, StatementContext& stmtCtx);
 
+    void serializeTo(ASTSerializer& serializer) const;
+
     static bool isKind(StatementKind kind) { return kind == StatementKind::Conditional; }
 };
 
@@ -324,17 +357,14 @@ public:
         not_null<const Statement*> stmt;
     };
 
-    enum class Condition { Normal, WildcardXOrZ, WildcardJustZ, Inside };
-    enum class Check { None, Unique, Unique0, Priority };
-
     const Expression& expr;
     span<ItemGroup const> items;
     const Statement* defaultCase = nullptr;
-    Condition condition;
-    Check check;
+    CaseStatementCondition condition;
+    CaseStatementCheck check;
 
-    CaseStatement(Condition condition, Check check, const Expression& expr,
-                  span<ItemGroup const> items, const Statement* defaultCase,
+    CaseStatement(CaseStatementCondition condition, CaseStatementCheck check,
+                  const Expression& expr, span<ItemGroup const> items, const Statement* defaultCase,
                   SourceRange sourceRange) :
         Statement(StatementKind::Case, sourceRange),
         expr(expr), items(items), defaultCase(defaultCase), condition(condition), check(check) {}
@@ -344,6 +374,8 @@ public:
 
     static Statement& fromSyntax(Compilation& compilation, const CaseStatementSyntax& syntax,
                                  const BindContext& context, StatementContext& stmtCtx);
+
+    void serializeTo(ASTSerializer& serializer) const;
 
     static bool isKind(StatementKind kind) { return kind == StatementKind::Case; }
 };
@@ -367,6 +399,8 @@ public:
     static Statement& fromSyntax(Compilation& compilation, const ForLoopStatementSyntax& syntax,
                                  const BindContext& context, StatementContext& stmtCtx);
 
+    void serializeTo(ASTSerializer& serializer) const;
+
     static bool isKind(StatementKind kind) { return kind == StatementKind::ForLoop; }
 };
 
@@ -385,6 +419,8 @@ public:
 
     static Statement& fromSyntax(Compilation& compilation, const LoopStatementSyntax& syntax,
                                  const BindContext& context, StatementContext& stmtCtx);
+
+    void serializeTo(ASTSerializer& serializer) const;
 
     static bool isKind(StatementKind kind) { return kind == StatementKind::RepeatLoop; }
 };
@@ -410,6 +446,8 @@ public:
     static Statement& fromSyntax(Compilation& compilation, const ForeachLoopStatementSyntax& syntax,
                                  const BindContext& context, StatementContext& stmtCtx);
 
+    void serializeTo(ASTSerializer& serializer) const;
+
     static bool isKind(StatementKind kind) { return kind == StatementKind::ForeachLoop; }
 
 private:
@@ -431,6 +469,8 @@ public:
     static Statement& fromSyntax(Compilation& compilation, const LoopStatementSyntax& syntax,
                                  const BindContext& context, StatementContext& stmtCtx);
 
+    void serializeTo(ASTSerializer& serializer) const;
+
     static bool isKind(StatementKind kind) { return kind == StatementKind::WhileLoop; }
 };
 
@@ -450,6 +490,8 @@ public:
     static Statement& fromSyntax(Compilation& compilation, const DoWhileStatementSyntax& syntax,
                                  const BindContext& context, StatementContext& stmtCtx);
 
+    void serializeTo(ASTSerializer& serializer) const;
+
     static bool isKind(StatementKind kind) { return kind == StatementKind::DoWhileLoop; }
 };
 
@@ -467,6 +509,8 @@ public:
 
     static Statement& fromSyntax(Compilation& compilation, const ForeverStatementSyntax& syntax,
                                  const BindContext& context, StatementContext& stmtCtx);
+
+    void serializeTo(ASTSerializer& serializer) const;
 
     static bool isKind(StatementKind kind) { return kind == StatementKind::ForeverLoop; }
 };
@@ -491,6 +535,8 @@ public:
                                  const VoidCastedCallStatementSyntax& syntax,
                                  const BindContext& context);
 
+    void serializeTo(ASTSerializer& serializer) const;
+
     static bool isKind(StatementKind kind) { return kind == StatementKind::ExpressionStatement; }
 };
 
@@ -510,6 +556,8 @@ public:
     static Statement& fromSyntax(Compilation& compilation,
                                  const TimingControlStatementSyntax& syntax,
                                  const BindContext& context, StatementContext& stmtCtx);
+
+    void serializeTo(ASTSerializer& serializer) const;
 
     static bool isKind(StatementKind kind) { return kind == StatementKind::Timed; }
 };
@@ -538,6 +586,8 @@ public:
     static Statement& fromSyntax(Compilation& compilation,
                                  const ImmediateAssertionStatementSyntax& syntax,
                                  const BindContext& context, StatementContext& stmtCtx);
+
+    void serializeTo(ASTSerializer& serializer) const;
 
     static bool isKind(StatementKind kind) { return kind == StatementKind::Assertion; }
 };

--- a/include/slang/binding/Statements.h
+++ b/include/slang/binding/Statements.h
@@ -44,20 +44,20 @@ struct StatementSyntax;
 ENUM(StatementKind, STATEMENT);
 #undef STATEMENT
 
-#define CONDITION(x) \
+#define CASE_CONDITION(x) \
  x(Normal) \
  x(WildcardXOrZ) \
  x(WildcardJustZ) \
  x(Inside)
-ENUM(CaseStatementCondition, CONDITION)
-#undef CONDITION
-#define CHECK(x) \
+ENUM(CaseStatementCondition, CASE_CONDITION)
+#undef CASE_CONDITION
+#define CASE_CHECK(x) \
  x(None) \
  x(Unique) \
  x(Unique0) \
  x(Priority)
-ENUM(CaseStatementCheck, CHECK)
-#undef CHECK
+ENUM(CaseStatementCheck, CASE_CHECK)
+#undef CASE_CHECK
 // clang-format on
 
 /// The base class for all statements in SystemVerilog.

--- a/include/slang/symbols/ASTSerializer.h
+++ b/include/slang/symbols/ASTSerializer.h
@@ -14,6 +14,7 @@ namespace slang {
 class AttributeSymbol;
 class ConstantValue;
 class Expression;
+class Statement;
 class Symbol;
 class Type;
 
@@ -23,9 +24,12 @@ public:
 
     void serialize(const Symbol& symbol);
     void serialize(const Expression& expr);
+    void serialize(const Statement& statement);
 
     void startArray(string_view name);
     void endArray();
+    void startObject(string_view name);
+    void endObject();
 
     void write(string_view name, string_view value);
     void write(string_view name, int64_t value);
@@ -35,6 +39,7 @@ public:
     void write(string_view name, const Symbol& value);
     void write(string_view name, const ConstantValue& value);
     void write(string_view name, const Expression& value);
+    void write(string_view name, const Statement& value);
 
     void writeLink(string_view name, const Symbol& value);
 
@@ -52,11 +57,13 @@ public:
 private:
     friend Symbol;
     friend Expression;
+    friend Statement;
 
     template<typename T>
     void visit(const T& symbol);
 
     void visitInvalid(const Expression& expr);
+    void visitInvalid(const Statement &statement);
 
     JsonWriter& writer;
 };

--- a/include/slang/symbols/ASTSerializer.h
+++ b/include/slang/symbols/ASTSerializer.h
@@ -63,7 +63,7 @@ private:
     void visit(const T& symbol);
 
     void visitInvalid(const Expression& expr);
-    void visitInvalid(const Statement &statement);
+    void visitInvalid(const Statement& statement);
 
     JsonWriter& writer;
 };

--- a/include/slang/symbols/ASTSerializer.h
+++ b/include/slang/symbols/ASTSerializer.h
@@ -25,10 +25,11 @@ public:
     void serialize(const Symbol& symbol);
     void serialize(const Expression& expr);
     void serialize(const Statement& statement);
+    void serialize(std::string_view value);
 
     void startArray(string_view name);
     void endArray();
-    void startObject(string_view name);
+    void startObject();
     void endObject();
 
     void write(string_view name, string_view value);

--- a/source/binding/Statements.cpp
+++ b/source/binding/Statements.cpp
@@ -536,9 +536,8 @@ bool StatementList::verifyConstantImpl(EvalContext& context) const {
 
 void StatementList::serializeTo(ASTSerializer& serializer) const {
     serializer.startArray("list");
-    for (auto const& stmt : list) {
-        if (stmt)
-            serializer.serialize(*stmt);
+    for (auto stmt : list) {
+        serializer.serialize(*stmt);
     }
     serializer.endArray();
 }
@@ -1041,15 +1040,12 @@ void CaseStatement::serializeTo(ASTSerializer& serializer) const {
         serializer.startObject("item");
 
         serializer.startArray("expressions");
-        for (auto const& ex : item.expressions) {
-            if (ex)
-                serializer.serialize(*ex);
+        for (auto ex : item.expressions) {
+            serializer.serialize(*ex);
         }
         serializer.endArray();
 
-        serializer.startObject("stmt");
-        serializer.serialize(*item.stmt);
-        serializer.endObject();
+        serializer.write("stmt", *item.stmt);
 
         serializer.endObject();
     }
@@ -1149,9 +1145,8 @@ bool ForLoopStatement::verifyConstantImpl(EvalContext& context) const {
 
 void ForLoopStatement::serializeTo(ASTSerializer& serializer) const {
     serializer.startArray("initializers");
-    for (auto const& ini : initializers) {
-        if (ini)
-            serializer.serialize(*ini);
+    for (auto ini : initializers) {
+        serializer.serialize(*ini);
     }
     serializer.endArray();
 
@@ -1159,9 +1154,8 @@ void ForLoopStatement::serializeTo(ASTSerializer& serializer) const {
         serializer.write("stopExpr", *stopExpr);
 
     serializer.startArray("steps");
-    for (auto const& step : steps) {
-        if (step)
-            serializer.serialize(*step);
+    for (auto step : steps) {
+        serializer.serialize(*step);
     }
     serializer.endArray();
 
@@ -1339,7 +1333,7 @@ void ForeachLoopStatement::serializeTo(ASTSerializer& serializer) const {
     serializer.endArray();
 
     serializer.startArray("loopVariables");
-    for (auto const& v : loopVariables) {
+    for (auto v : loopVariables) {
         if (v)
             serializer.serialize(*v);
     }

--- a/source/binding/Statements.cpp
+++ b/source/binding/Statements.cpp
@@ -1037,7 +1037,7 @@ void CaseStatement::serializeTo(ASTSerializer& serializer) const {
     serializer.write("check", toString(check));
     serializer.startArray("items");
     for (auto const& item : items) {
-        serializer.startObject("item");
+        serializer.startObject();
 
         serializer.startArray("expressions");
         for (auto ex : item.expressions) {
@@ -1328,7 +1328,7 @@ void ForeachLoopStatement::serializeTo(ASTSerializer& serializer) const {
 
     serializer.startArray("loopRanges");
     for (auto const& r : loopRanges) {
-        serializer.write("range", r.toString());
+        serializer.serialize(r.toString());
     }
     serializer.endArray();
 

--- a/source/symbols/ASTSerializer.cpp
+++ b/source/symbols/ASTSerializer.cpp
@@ -26,6 +26,10 @@ void ASTSerializer::serialize(const Statement& statement) {
     statement.visit(*this);
 }
 
+void ASTSerializer::serialize(string_view value) {
+    writer.writeValue(value);
+}
+
 void ASTSerializer::write(string_view name, string_view value) {
     writer.writeProperty(name);
     writer.writeValue(value);
@@ -86,8 +90,7 @@ void ASTSerializer::endArray() {
     writer.endArray();
 }
 
-void ASTSerializer::startObject(string_view name) {
-    writer.writeProperty(name);
+void ASTSerializer::startObject() {
     writer.startObject();
 }
 

--- a/source/symbols/ASTSerializer.cpp
+++ b/source/symbols/ASTSerializer.cpp
@@ -22,7 +22,7 @@ void ASTSerializer::serialize(const Expression& expr) {
     expr.visit(*this);
 }
 
-void ASTSerializer::serialize(const Statement &statement) {
+void ASTSerializer::serialize(const Statement& statement) {
     statement.visit(*this);
 }
 
@@ -66,7 +66,7 @@ void ASTSerializer::write(string_view name, const Expression& value) {
     serialize(value);
 }
 
-void ASTSerializer::write(string_view name, const Statement &value) {
+void ASTSerializer::write(string_view name, const Statement& value) {
     writer.writeProperty(name);
     serialize(value);
 }
@@ -110,8 +110,8 @@ void ASTSerializer::visit(const T& elem) {
         }
 
         writer.endObject();
-    } else if constexpr(std::is_base_of_v<Statement, T>) {
-        (void)(elem);
+    }
+    else if constexpr (std::is_base_of_v<Statement, T>) {
         writer.startObject();
         write("kind", toString(elem.kind));
 

--- a/source/symbols/BlockSymbols.cpp
+++ b/source/symbols/BlockSymbols.cpp
@@ -186,6 +186,7 @@ ProceduralBlockSymbol& ProceduralBlockSymbol::fromSyntax(
 
 void ProceduralBlockSymbol::serializeTo(ASTSerializer& serializer) const {
     serializer.write("procedureKind", toString(procedureKind));
+    serializer.write("body", getBody());
 }
 
 static string_view getGenerateBlockName(const SyntaxNode& node) {


### PR DESCRIPTION
This PR adds serialization (JSON) to statements. The `name` for each `ASTSerializer.write()` call is consistent with the class field name. 

Minor API changes:
- I added `startObject` and `endObject` to `ASTSerializer` since in the case statement, each item is a key-value pair.
- I refactored the enums in the case statement to the top level so that they can have `toString` generated automatically.

Please let me know if you have any code-review related questions.