### PR TITLE
Fix invalid json due to double value in parameter

### DIFF
--- a/source/symbols/ASTSerializer.cpp
+++ b/source/symbols/ASTSerializer.cpp
@@ -147,9 +147,11 @@ void ASTSerializer::visit(const T& elem) {
         if constexpr (std::is_base_of_v<ValueSymbol, T>) {
             write("type", elem.getType());
 
-            auto& value = elem.getConstantValue();
-            if (value)
-                write("value", value);
+            if constexpr (!std::is_base_of_v<ParameterSymbol, T>) {
+                auto& value = elem.getConstantValue();
+                if (value)
+                    write("value", value);
+            }
 
             if (auto init = elem.getInitializer())
                 write("initializer", *init);

--- a/source/symbols/ParameterSymbols.cpp
+++ b/source/symbols/ParameterSymbols.cpp
@@ -79,6 +79,7 @@ void ParameterSymbol::setValue(ConstantValue value) {
 }
 
 void ParameterSymbol::serializeTo(ASTSerializer& serializer) const {
+    serializer.write("value", getValue());
     serializer.write("isLocal", isLocalParam());
     serializer.write("isPort", isPortParam());
     serializer.write("isBody", isBodyParam());

--- a/source/symbols/ParameterSymbols.cpp
+++ b/source/symbols/ParameterSymbols.cpp
@@ -79,7 +79,6 @@ void ParameterSymbol::setValue(ConstantValue value) {
 }
 
 void ParameterSymbol::serializeTo(ASTSerializer& serializer) const {
-    serializer.write("value", getValue());
     serializer.write("isLocal", isLocalParam());
     serializer.write("isPort", isPortParam());
     serializer.write("isBody", isBodyParam());


### PR DESCRIPTION
Here is the serialization result with parameter:
```JSON
             {
              "name": "P",
              "kind": "Parameter",
              "addr": 94025333194336,
              "type": "bit[3:0]",
              "value": "4'b100",
              "initializer": {
                "kind": "IntegerLiteral",
                "type": "bit[3:0]",
                "constant": "4'b100"
              },
              "value": "4'b100",
              "isLocal": false,
              "isPort": true,
              "isBody": false
            },
```

To reproduce, you can run the driver with this simple input file
```SystemVerilog
module mod #(parameter P = 4'h4)

logic [P-1:0] v;
endmodule   // mod
```

It turns out that in the generic symbol serialization, it already takes care of the `value` part:
https://github.com/MikePopoloski/slang/blob/ee4f970e3a9af0f692187569e52fbdbab58e4651/source/symbols/ASTSerializer.cpp#L147-L152

I haven't notice any other double `value` bug in serialization due to this line, but I could be wrong.