### PR TITLE
Fix case statement serialization

### DIFF
--- a/source/binding/Statements.cpp
+++ b/source/binding/Statements.cpp
@@ -1049,10 +1049,11 @@ void CaseStatement::serializeTo(ASTSerializer& serializer) const {
 
         serializer.endObject();
     }
+    serializer.endArray();
+
     if (defaultCase) {
         serializer.write("defaultCase", *defaultCase);
     }
-    serializer.endArray();
 }
 
 Statement& ForLoopStatement::fromSyntax(Compilation& compilation,


### PR DESCRIPTION
I'm sorry that I forgot to check the case statement with default case. The ordering of ending array is wrong. This should fix it.