### PR TITLE
Add missing serializations

### DIFF
--- a/source/binding/MiscExpressions.cpp
+++ b/source/binding/MiscExpressions.cpp
@@ -1079,13 +1079,13 @@ void CallExpression::serializeTo(ASTSerializer& serializer) const {
     else {
         const SubroutineSymbol& symbol = *std::get<0>(subroutine);
         serializer.writeLink("subroutine", symbol);
+    }
 
-        if (!arguments().empty()) {
-            serializer.startArray("arguments");
-            for (auto arg : arguments())
-                serializer.serialize(*arg);
-            serializer.endArray();
-        }
+    if (!arguments().empty()) {
+        serializer.startArray("arguments");
+        for (auto arg : arguments())
+            serializer.serialize(*arg);
+        serializer.endArray();
     }
 }
 

--- a/source/binding/Statements.cpp
+++ b/source/binding/Statements.cpp
@@ -1048,6 +1048,7 @@ bool CaseStatement::verifyConstantImpl(EvalContext& context) const {
 void CaseStatement::serializeTo(ASTSerializer& serializer) const {
     serializer.write("condition", toString(condition));
     serializer.write("check", toString(check));
+    serializer.write("expr", expr);
     serializer.startArray("items");
     for (auto const& item : items) {
         serializer.startObject();

--- a/source/symbols/MemberSymbols.cpp
+++ b/source/symbols/MemberSymbols.cpp
@@ -269,6 +269,13 @@ void SubroutineSymbol::serializeTo(ASTSerializer& serializer) const {
     serializer.write("returnType", getReturnType());
     serializer.write("defaultLifetime", toString(defaultLifetime));
     serializer.write("subroutineKind", toString(subroutineKind));
+    serializer.write("body", getBody());
+
+    serializer.startArray("arguments");
+    for (auto const arg: arguments) {
+        arg->serializeTo(serializer);
+    }
+    serializer.endArray();
 }
 
 ModportSymbol::ModportSymbol(Compilation& compilation, string_view name, SourceLocation loc) :

--- a/source/symbols/MemberSymbols.cpp
+++ b/source/symbols/MemberSymbols.cpp
@@ -272,7 +272,7 @@ void SubroutineSymbol::serializeTo(ASTSerializer& serializer) const {
     serializer.write("body", getBody());
 
     serializer.startArray("arguments");
-    for (auto const arg: arguments) {
+    for (auto const arg : arguments) {
         arg->serializeTo(serializer);
     }
     serializer.endArray();


### PR DESCRIPTION
- Add `expr` to `CaseStatement`
- Add `body` and `arguments` to `SubroutineSymbol`
- Adjust `arguments` to `CallExpression` so that arguments will get properly serialized in both cases.

Once thing I'm not sure is whether to check if the `arguments` in `SubroutineSymbol` are empty and serialize accordingly.