### PR TITLE
Add option to enable static linking

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,6 +10,7 @@ option(FUZZ_TARGET "Enables changes to make binaries easier to fuzz test" OFF)
 option(SLANG_INCLUDE_TESTS "Include test targets in the build" ON)
 option(SLANG_INCLUDE_DOCS "Include documentation targets in the build" OFF)
 option(SLANG_INCLUDE_LLVM "Include LLVM in the build for code generation" OFF)
+option(STATIC_BUILD "Make the linked binaries static" OFF)
 option(BUILD_SHARED_LIBS "Generate a shared library instead of static" OFF)
 set(DOXYGENPY_PATH "" CACHE STRING "When building docs, the path to doxygen.py tool")
 

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -1,11 +1,17 @@
 add_executable(driver driver/driver.cpp)
 target_link_libraries(driver PRIVATE slangcompiler)
+if(STATIC_BUILD)
+    target_link_libraries(driver PRIVATE -static -Wl,--whole-archive -lpthread -Wl,--no-whole-archive)
+endif()
 set_target_properties(driver PROPERTIES OUTPUT_NAME "slang")
 
 install(TARGETS driver RUNTIME DESTINATION bin)
 
 add_executable(rewriter rewriter/rewriter.cpp)
 target_link_libraries(rewriter PRIVATE slangcompiler)
+if(STATIC_BUILD)
+    target_link_libraries(rewriter PRIVATE -static -Wl,--whole-archive -lpthread -Wl,--no-whole-archive)
+endif()
 
 if(FUZZ_TARGET)
     message("Tweaking driver for fuzz testing")


### PR DESCRIPTION
This is what could be used to avoid issues with the slang conda-packages (and sv-tests).

This would help us avoid maintaining the patch mentioned in https://github.com/SymbiFlow/sv-tests/issues/955

Please let me know if this is acceptable or if you want this renamed or moved.