### PR TITLE
Built and run on macOS successfully

### DIFF
--- a/include/slang/text/SourceManager.h
+++ b/include/slang/text/SourceManager.h
@@ -15,6 +15,8 @@
 #include <set>
 #include <shared_mutex>
 #include <variant>
+#include <unordered_map>
+#include <vector>
 
 #include "slang/text/SourceLocation.h"
 #include "slang/util/Util.h"

--- a/include/slang/util/CommandLine.h
+++ b/include/slang/util/CommandLine.h
@@ -9,6 +9,7 @@
 #include <map>
 #include <variant>
 #include <vector>
+#include <string>
 
 #include "slang/util/Util.h"
 

--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -69,7 +69,7 @@ add_library(slangcore
 slang_define_lib(slangcore)
 add_dependencies(slangcore gen_version)
 
-if(NOT CMAKE_CXX_COMPILER_ID MATCHES "MSVC")
+if(NOT CMAKE_CXX_COMPILER_ID MATCHES "MSVC" AND NOT APPLE)
     # Link against C++17 filesystem
     target_link_libraries(slangcore PUBLIC stdc++fs)
 endif()

--- a/source/parsing/Preprocessor_macros.cpp
+++ b/source/parsing/Preprocessor_macros.cpp
@@ -500,7 +500,7 @@ bool Preprocessor::expandIntrinsic(MacroIntrinsic intrinsic, MacroExpansion& exp
         }
         case MacroIntrinsic::Line: {
             size_t lineNum = sourceManager.getLineNumber(loc);
-            uintToStr(text, lineNum);
+            uintToStr(text, static_cast<uint64_t>(lineNum));
 
             string_view rawText = toStringView(text.copy(alloc));
             Token token(alloc, TokenKind::IntegerLiteral, {}, rawText, loc, lineNum);


### PR DESCRIPTION
I changed 4 files (totally 5 lines) to make slang source code built and run on macOS with clang.

1. Makes 2 headers file self-contained to have
 ```cpp
 #include <unordered_map>
 #include <vector>
 #include <string>
```
    for STL containers they use.

2. In source/CMakeLists.txt do not link stdc++fs like MSVC
```cmake
if(NOT CMAKE_CXX_COMPILER_ID MATCHES "MSVC" AND NOT APPLE)
```
3. Resolves ambiguity of size_t between uint64_t and uint32_t by adding static_cast
 ```cpp
uintToStr(text, static_cast<uint64_t>(lineNum));
```

