### PR TITLE
A string literal can be assigned to an unpacked array of bytes.

### DIFF
--- a/include/slang/numeric/ConstantValue.h
+++ b/include/slang/numeric/ConstantValue.h
@@ -144,7 +144,8 @@ public:
     ConstantValue convertToReal() const;
     ConstantValue convertToShortReal() const;
     ConstantValue convertToStr() const;
-    ConstantValue convertToByteArray(bitwidth_t size, bool isSigned = false) const;
+    ConstantValue convertToByteArray(bitwidth_t size, bool isSigned) const;
+    ConstantValue convertToByteQueue(bool isSigned) const;
 
     static const ConstantValue Invalid;
 

--- a/include/slang/symbols/Type.h
+++ b/include/slang/symbols/Type.h
@@ -165,9 +165,6 @@ public:
     /// Indicates whether this is a string type.
     bool isString() const { return getCanonicalType().kind == SymbolKind::StringType; }
 
-    /// Indicates unpacked array of bytes to accept string literals conversion
-    bool isUnpackedArrayOfByte() const;
-
     /// Indicates whether this is an event type.
     bool isEvent() const { return getCanonicalType().kind == SymbolKind::EventType; }
 

--- a/source/binding/AssignmentExpressions.cpp
+++ b/source/binding/AssignmentExpressions.cpp
@@ -105,7 +105,7 @@ namespace slang {
 Expression& Expression::implicitConversion(const BindContext& context, const Type& targetType,
                                            Expression& expr) {
     ASSERT(targetType.isAssignmentCompatible(*expr.type) ||
-           (targetType.canBeStringLike() && expr.isImplicitString()) ||
+           ((targetType.isString() || targetType.isByteArray()) && expr.isImplicitString()) ||
            (targetType.isEnum() && isSameEnum(expr, targetType)));
 
     Expression* result = &expr;
@@ -292,7 +292,7 @@ Expression& Expression::convertAssignment(const BindContext& context, const Type
     if (!type.isAssignmentCompatible(*rt)) {
         // String literals have a type of integer, but are allowed to implicitly convert to the
         // string type. See comments on isSameEnum for why that's here as well.
-        if ((type.canBeStringLike() && expr.isImplicitString()) ||
+        if (((type.isString() || type.isByteArray()) && expr.isImplicitString()) ||
             (type.isEnum() && isSameEnum(expr, type))) {
 
             result = &implicitConversion(context, type, *result);

--- a/source/numeric/ConstantValue.cpp
+++ b/source/numeric/ConstantValue.cpp
@@ -343,7 +343,7 @@ ConstantValue ConstantValue::convertToStr() const {
     int32_t extraBits = int32_t(val.getBitWidth() % 8);
 
     std::string result;
-    result.reserve(msb / 8 + 1);
+    result.reserve((val.getBitWidth() + 7) / 8);
     if (extraBits) {
         auto c = val.slice(msb, msb - extraBits + 1).as<uint8_t>();
         if (c && *c)
@@ -369,7 +369,7 @@ ConstantValue ConstantValue::convertToByteArray(bitwidth_t size, bool isSigned) 
         const SVInt& val = integer();
         int32_t msb = int32_t(val.getBitWidth() - 1);
         int32_t extraBits = int32_t(val.getBitWidth() % 8);
-        result.reserve(msb / 8 + 1);
+        result.reserve((val.getBitWidth() + 7) / 8);
         if (extraBits) {
             auto c = val.slice(msb, msb - extraBits + 1).as<uint8_t>();
             if (c && *c)
@@ -392,7 +392,7 @@ ConstantValue ConstantValue::convertToByteArray(bitwidth_t size, bool isSigned) 
     for (auto ch: result) {
         if (array.size() >= size)
             break;
-        array.emplace_back(SVInt(8, ch, isSigned));
+        array.emplace_back(SVInt(8, static_cast<uint64_t>(ch), isSigned));
     }
     while (array.size() < size) {
         array.emplace_back(SVInt(8, 0, isSigned));

--- a/source/symbols/Type.cpp
+++ b/source/symbols/Type.cpp
@@ -221,7 +221,8 @@ bool Type::isByteArray() const {
     const Type& ct = getCanonicalType();
     if (!ct.isUnpackedArray())
         return false;
-
+    if (ct.kind == SymbolKind::AssociativeArrayType)
+        return false;
     auto& elem = ct.getArrayElementType()->getCanonicalType();
     return elem.isPredefinedInteger() &&
            elem.as<PredefinedIntegerType>().integerKind == PredefinedIntegerType::Byte;
@@ -237,13 +238,6 @@ bool Type::isUnpackedArray() const {
         default:
             return false;
     }
-}
-
-bool Type::isUnpackedArrayOfByte() const {
-    if (getCanonicalType().kind != SymbolKind::FixedSizeUnpackedArrayType)
-        return false;
-    auto elemType = &getArrayElementType()->getCanonicalType();
-    return elemType->isIntegral() && !elemType->isEnum() && elemType->getBitWidth() == 8;
 }
 
 bool Type::isMatching(const Type& rhs) const {

--- a/tests/unittests/ExpressionTests.cpp
+++ b/tests/unittests/ExpressionTests.cpp
@@ -1250,17 +1250,13 @@ std::string testStringLiteralsToByteArray(const std::string& text) {
     NO_COMPILATION_ERRORS;
 
     const auto& module = *compilation.getRoot().topInstances[0];
-    if (!tree->diagnostics().empty())
-        WARN(report(tree->diagnostics()));
-
     const ParameterSymbol& param = module.body.memberAt<ParameterSymbol>(0);
     const auto& value = param.getValue();
     std::string result;
     if (value.isUnpacked()) {
         for (const auto& svInt : value.elements()) {
-            REQUIRE(svInt.isInteger());
             REQUIRE(svInt.integer().getBitWidth() == 8);
-            auto ch = static_cast<char>(*svInt.integer().getRawPtr());
+            auto ch = *svInt.integer().as<char>();
             if (!ch)
                 break;
             result.push_back(ch);
@@ -1269,9 +1265,8 @@ std::string testStringLiteralsToByteArray(const std::string& text) {
     else {
         REQUIRE(value.isQueue());
         for (const auto& svInt : *value.queue().get()) {
-            REQUIRE(svInt.isInteger());
             REQUIRE(svInt.integer().getBitWidth() == 8);
-            auto ch = static_cast<char>(*svInt.integer().getRawPtr());
+            auto ch = *svInt.integer().as<char>();
             if (!ch)
                 break;
             result.push_back(ch);


### PR DESCRIPTION
I am investigating slang failures on [SystemVerilog Tester](https://symbiflow.github.io/sv-tests/). This is an attempt to support test case [5.9-string-word-assignment.sv](https://github.com/SymbiFlow/sv-tests/blob/master/tests/chapter-5/5.9-string-word-assignment.sv). SV-2017 standard §5.9 on page 77 says:

> A string literal can be assigned to an unpacked array of bytes. If the size differs, it is left justified.
byte c3 [0:12] = "hello world\n" ;

Major C++ code changes include

1. bool Type::isUnpackedArrayOfByte() detects if a type is unpacked arrays of bytes.
2. ConstantValue ConstantValue::convertToByteArray(bitwidth_t size, bool isSigned) converts constant string literals to byte arrays.
3. Utilizes above two functions in Expression::convertAssignment and ConversionExpression::convert.

A sample SystemVerilog test case:
```sv
module top;
  byte b[3 : 0] = "hello world\n";
  logic [7:0]  c[3 : 0] = "hi2";
  // test ConversionExpression::convert
  localparam byte d[3 : 0] = "hi2";
  parameter bit [7:0]  e[3 : 0] = "hello world\n";
endmodule
```
