### PR TITLE
macOS support for codegen, runtime and simtests.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -197,6 +197,12 @@ if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
         -Wzero-as-null-pointer-constant
         -Wno-missing-braces
     )
+    if (APPLE)
+        set(CMAKE_SHARED_LIBRARY_CREATE_CXX_FLAGS "${CMAKE_SHARED_LIBRARY_CREATE_CXX_FLAGS} -undefined dynamic_lookup -v")
+        if(STATIC_BUILD)
+          message(SEND_ERROR "STATIC_BUILD=ON not supported on macOS." )
+        endif()
+    endif()
 elseif (CMAKE_CXX_COMPILER_ID MATCHES "GNU")
     set(SLANG_WARN_FLAGS
         -Wall

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -198,7 +198,7 @@ if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
         -Wno-missing-braces
     )
     if (APPLE)
-        set(CMAKE_SHARED_LIBRARY_CREATE_CXX_FLAGS "${CMAKE_SHARED_LIBRARY_CREATE_CXX_FLAGS} -undefined dynamic_lookup -v")
+        set(CMAKE_SHARED_LIBRARY_CREATE_CXX_FLAGS "${CMAKE_SHARED_LIBRARY_CREATE_CXX_FLAGS} -undefined dynamic_lookup")
         if(STATIC_BUILD)
           message(SEND_ERROR "STATIC_BUILD=ON not supported on macOS." )
         endif()

--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -200,7 +200,5 @@ if(SLANG_INCLUDE_LLVM)
 
     llvm_map_components_to_libnames(llvm_libs support core orcjit native nativecodegen)
     target_link_libraries(slangcodegen PRIVATE ${llvm_libs})
-    if (APPLE)
-        target_compile_options(slangcodegen PRIVATE -Wno-unused-private-field)
-    endif()
+    target_compile_options(slangcodegen PRIVATE -Wno-unused-private-field)
 endif()

--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -200,4 +200,7 @@ if(SLANG_INCLUDE_LLVM)
 
     llvm_map_components_to_libnames(llvm_libs support core orcjit native nativecodegen)
     target_link_libraries(slangcodegen PRIVATE ${llvm_libs})
+    if (APPLE)
+        target_compile_options(slangcodegen PRIVATE -Wno-unused-private-field)
+    endif()
 endif()

--- a/source/codegen/CodeGenFunction.cpp
+++ b/source/codegen/CodeGenFunction.cpp
@@ -71,7 +71,7 @@ llvm::Value* CodeGenFunction::emit(const Instr& instr) {
             return emitStore(instr.getOperands()[0], instr.getOperands()[1]);
         case InstrKind::negate:
             return emitNegate(instr.type, instr.getOperands()[0]);
-        default: // Suppress clang -Wswitch
+        default:
             break;
     }
     THROW_UNREACHABLE;

--- a/source/codegen/CodeGenFunction.cpp
+++ b/source/codegen/CodeGenFunction.cpp
@@ -71,6 +71,8 @@ llvm::Value* CodeGenFunction::emit(const Instr& instr) {
             return emitStore(instr.getOperands()[0], instr.getOperands()[1]);
         case InstrKind::negate:
             return emitNegate(instr.type, instr.getOperands()[0]);
+        default: // Suppress clang -Wswitch
+            break;
     }
     THROW_UNREACHABLE;
 }

--- a/source/codegen/CodeGenerator.cpp
+++ b/source/codegen/CodeGenerator.cpp
@@ -86,8 +86,13 @@ GeneratedCode CodeGenerator::finish() {
 
     // Verify all generated code.
     bool bad = llvm::verifyModule(*module, &llvm::errs());
-    if (bad)
+    if (bad) {
+#ifdef __APPLE__
+        module->print(llvm::errs(), nullptr); // ld: undefined symbol llvm::Module::dump()
+#else
         module->dump();
+#endif
+    }
 
     return GeneratedCode(std::move(ctx), std::move(module));
 }

--- a/source/codegen/CodeGenerator.cpp
+++ b/source/codegen/CodeGenerator.cpp
@@ -86,13 +86,8 @@ GeneratedCode CodeGenerator::finish() {
 
     // Verify all generated code.
     bool bad = llvm::verifyModule(*module, &llvm::errs());
-    if (bad) {
-#ifdef __APPLE__
+    if (bad)
         module->print(llvm::errs(), nullptr); // ld: undefined symbol llvm::Module::dump()
-#else
-        module->dump();
-#endif
-    }
 
     return GeneratedCode(std::move(ctx), std::move(module));
 }

--- a/source/codegen/JIT.cpp
+++ b/source/codegen/JIT.cpp
@@ -37,18 +37,12 @@ JIT::JIT() {
 
     // Register all exported simrt functions with the JIT.
     auto exported = slang::runtime::getExportedFunctions();
-#ifdef __APPLE__
     // Mangle names according to https://llvm.org/docs/ORCv2.html
     auto& dl = jit->getDataLayout();
     MangleAndInterner Mangle(jit->getExecutionSession(), dl);
-#endif
     for (auto& [name, ptr] : exported) {
         llvm::JITEvaluatedSymbol sym(static_cast<llvm::JITTargetAddress>(ptr), {});
-#ifdef __APPLE__
         auto err = jit->defineAbsolute(*Mangle(llvm::StringRef(name.data(), name.length())), sym);
-#else
-        auto err = jit->defineAbsolute(llvm::StringRef(name.data(), name.length()), sym);
-#endif
         if (err)
             report(std::move(err));
     }

--- a/tests/simtests/CMakeLists.txt
+++ b/tests/simtests/CMakeLists.txt
@@ -7,3 +7,4 @@ add_executable(simtests
 target_link_libraries(simtests PRIVATE slangruntime slangcodegen)
 
 add_test(NAME simtests COMMAND simtests)
+set_tests_properties(simtests PROPERTIES TIMEOUT 10)

--- a/tests/simtests/CMakeLists.txt
+++ b/tests/simtests/CMakeLists.txt
@@ -7,4 +7,4 @@ add_executable(simtests
 target_link_libraries(simtests PRIVATE slangruntime slangcodegen)
 
 add_test(NAME simtests COMMAND simtests)
-set_tests_properties(simtests PROPERTIES TIMEOUT 10)
+set_tests_properties(simtests PROPERTIES TIMEOUT 60)

--- a/tests/simtests/JITTests.cpp
+++ b/tests/simtests/JITTests.cpp
@@ -4,6 +4,10 @@
 #include "slang/runtime/Runtime.h"
 #include "slang/symbols/BlockSymbols.h"
 
+#ifdef __APPLE__
+// Work around a clang optimization bug on deallocating "result" before lambda call
+[[clang::optnone]]
+#endif
 TEST_CASE("JIT test") {
     Compilation compilation = compile(R"(
 module m;

--- a/tests/unittests/CMakeLists.txt
+++ b/tests/unittests/CMakeLists.txt
@@ -36,3 +36,8 @@ add_custom_command(
 )
 
 add_test(NAME unittests COMMAND unittests)
+if(CI_BUILD)
+    set_tests_properties(unittests PROPERTIES TIMEOUT 10)
+else()
+    set_tests_properties(unittests PROPERTIES TIMEOUT 5)
+endif()

--- a/tests/unittests/CMakeLists.txt
+++ b/tests/unittests/CMakeLists.txt
@@ -37,7 +37,7 @@ add_custom_command(
 
 add_test(NAME unittests COMMAND unittests)
 if(CI_BUILD)
-    set_tests_properties(unittests PROPERTIES TIMEOUT 10)
+    set_tests_properties(unittests PROPERTIES TIMEOUT 60)
 else()
-    set_tests_properties(unittests PROPERTIES TIMEOUT 5)
+    set_tests_properties(unittests PROPERTIES TIMEOUT 30)
 endif()


### PR DESCRIPTION
This is to port slang to macOS when using "cmake -DSLANG_INCLUDE_LLVM=ON ...".
1. To suppress build error
> CodeGenerator.h:87:24: error: private field 'compilation' is not used [-Werror,-Wunused-private-field]
    const Compilation& compilation;

insert in source/CMakeLists.txt
```cmake
if (APPLE)
     target_compile_options(slangcodegen PRIVATE -Wno-unused-private-field)
endif()
```
2. To suppress build error
> CodeGenFunction.cpp:65:13: error: 4 enumeration values not handled in switch: 'bitnot', 'reducand', 'reducor'... [-Werror,-Wswitch]
    switch (instr.kind) {

insert in source/codegen/CodeGenFunction.cpp
```c++
default: // Suppress clang -Wswitch
    break;
```
3. To resolve build error ld: undefined symbol "llvm::Module::dump() const", follow [stackoverflow suggestion](https://stackoverflow.com/questions/46367910/llvm-5-0-linking-error-with-llvmmoduledump)
```c++
#ifdef __APPLE__
        module->print(llvm::errs(), nullptr); // ld: undefined symbol llvm::Module::dump()
#else
        module->dump();
#endif
```
4. With the above 3 changes, build is successful but simtests crashes. The first problem at the end of JIT::run
```c++
    auto fp = (int (*)())(intptr_t)sym->getAddress();
    return fp();
```
there are messages
> JIT session error: Symbols not found: [ _printInt, _flush, _printStr ]
JIT session error: Failed to materialize symbols: { (0x1037d1fa0, { ___orc_anon.0, _main }) }

Follow [llvm doc](https://llvm.org/docs/ORCv2.html)
> On Linux this mangling is a no-op, but on other platforms it usually involves adding a prefix to the string (e.g. ‘_’ on Darwin). 

to insert in JIT.cpp
```c++
#ifdef __APPLE__
    // Mangle names according to https://llvm.org/docs/ORCv2.html
    auto& dl = jit->getDataLayout();
    MangleAndInterner Mangle(jit->getExecutionSession(), dl);
#endif
#ifdef __APPLE__
        auto err = jit->defineAbsolute(*Mangle(llvm::StringRef(name.data(), name.length())), sym);
#else
```
5. With the above change, simtests passes on debug build (-DCMAKE_BUILD_TYPE=Debug) but with -O1 or above optimization still crash at JITTests.cpp for bad address of "result" inside lambda call
```c++
    slang::runtime::setOutputHandler([&](string_view text) { result += text; });
```
I suspect that it is a clang optimization bug and work around it by
```c++
#ifdef __APPLE__
// Work around a clang optimization bug on deallocating "result" before lambda call
[[clang::optnone]]
#endif
```

With the above 5 changes, -DSLANG_INCLUDE_LLVM=ON build is successful and simtests 100% passes on macOS.
In addition. TIMEOUT properties are appended for unittests and simtests.


