### PR TITLE
error out on unpacked array assignments with unequal fixed sizes

### DIFF
--- a/source/symbols/Type.cpp
+++ b/source/symbols/Type.cpp
@@ -401,6 +401,8 @@ bool Type::isAssignmentCompatible(const Type& rhs) const {
         // need to check the fixed size condition here, since the only way it would
         // matter is if the source (rhs) is dynamically sized, which can't be checked
         // until runtime.
+        if (l->kind == r->kind && l->kind == SymbolKind::FixedSizeUnpackedArrayType)
+            return false; // !isEquivalent implies unequal widths or non-eqivalent elements
         return l->getArrayElementType()->isEquivalent(*r->getArrayElementType());
     }
 

--- a/tests/unittests/TypeTests.cpp
+++ b/tests/unittests/TypeTests.cpp
@@ -961,3 +961,23 @@ endmodule
     CHECK(diags[0].code == diag::PackedArrayTooLarge);
     CHECK(diags[1].code == diag::ArrayDimTooLarge);
 }
+
+TEST_CASE("Unpacked array assignment") {
+    auto tree = SyntaxTree::fromText(R"(
+ module test;
+     localparam int a [1:0] = {1, 2};
+     localparam int b [0:2] = a;
+     int A[10:1];
+     int C[24:1];
+     assign A = C;
+ endmodule
+ )");
+
+    Compilation compilation;
+    compilation.addSyntaxTree(tree);
+
+    auto& diags = compilation.getAllDiagnostics();
+    REQUIRE(diags.size() == 2);
+    CHECK(diags[0].code == diag::BadAssignment);
+    CHECK(diags[1].code == diag::BadAssignment);
+}


### PR DESCRIPTION
SV-2007 standard §7.6 (Array Assignments) page 152 says the following SystemVerilog code should have type check error
```sv
  int A[10:1];
  int C[24:1];
  assign A = C;
```
but slang currently does not report any error. For a similar illegal parameter assignment
```sv
  localparam int a [1:0] = {1, 2};
  localparam int b [0:2] = a;
```
slang gives a good error in release build, but has an assertion failure in debug build at AssignmentExpressions.cpp:582
```c++
  ASSERT(!to.hasFixedRange() || !from.hasFixedRange());
```
A fix is included to report proper errors without any assertion failure. A unit test case is added to ensure proper error checking.
