### PR TITLE
Bit-stream type check on unpacked array/struct

### DIFF
--- a/source/symbols/Type.cpp
+++ b/source/symbols/Type.cpp
@@ -201,19 +201,19 @@ bool Type::isStruct() const {
 }
 
 bool Type::isBitstreamType() const {
-    // TODO: classes
     if (isIntegral())
         return true;
     if (isUnpackedArray())
         return getArrayElementType()->isBitstreamType();
     if (isUnpackedStruct()) {
-        auto& us = as<UnpackedStructType>();
+        auto& us = getCanonicalType().as<UnpackedStructType>();
         for (auto& field : us.membersOfType<FieldSymbol>()) {
             if (!field.getType().isBitstreamType())
                 return false;
         }
         return true;
     }
+    // TODO: classes
     return false;
 }
 

--- a/source/symbols/Type.cpp
+++ b/source/symbols/Type.cpp
@@ -202,7 +202,19 @@ bool Type::isStruct() const {
 
 bool Type::isBitstreamType() const {
     // TODO: classes
-    return isIntegral() || isUnpackedArray() || isUnpackedStruct();
+    if (isIntegral())
+        return true;
+    if (isUnpackedArray())
+        return getArrayElementType()->isBitstreamType();
+    if (isUnpackedStruct()) {
+        auto& us = as<UnpackedStructType>();
+        for (auto& field : us.membersOfType<FieldSymbol>()) {
+            if (!field.getType().isBitstreamType())
+                return false;
+        }
+        return true;
+    }
+    return false;
 }
 
 bool Type::isSimpleType() const {

--- a/tests/unittests/TypeTests.cpp
+++ b/tests/unittests/TypeTests.cpp
@@ -981,3 +981,25 @@ TEST_CASE("Unpacked array assignment") {
     CHECK(diags[0].code == diag::BadAssignment);
     CHECK(diags[1].code == diag::BadAssignment);
 }
+
+TEST_CASE("Unpacked array/struct bit-streaming types") {
+    auto tree = SyntaxTree::fromText(R"(
+ module test;
+     event a;
+     localparam bits_a = $bits(a);
+     event b [3:0];
+     localparam bits_b = $bits(b);
+     struct { event a; } c;
+     localparam bits_c = $bits(c);
+ endmodule
+ )");
+
+    Compilation compilation;
+    compilation.addSyntaxTree(tree);
+
+    auto& diags = compilation.getAllDiagnostics();
+    REQUIRE(diags.size() == 3);
+    CHECK(diags[0].code == diag::BadSystemSubroutineArg);
+    CHECK(diags[1].code == diag::BadSystemSubroutineArg);
+    CHECK(diags[2].code == diag::BadSystemSubroutineArg);
+}


### PR DESCRIPTION
Now slang correctly detect an error where"event" is not a bit-stream type
```sv
  event a;
  localparam bits_a = $bits(a);
```
but not on unpacked array of event or unpacked struct of event
```sv
  event b [3:0];
  localparam bits_b = $bits(b);
  struct { event a; } c;
  localparam bits_c = $bits(c);
```
SV-2017 standard §6.24.3 on page 135 says for a bit-stream type "This definition is recursive".
This code enhances "Type::isBitstreamType" to recursively check elements of unpacked arrays and fields of unpacked struct. A unit test case is added to ensure proper error checking.