### PR TITLE
$bits constant evaluation on unpacked types. Bit-stream types include…

### DIFF
--- a/include/slang/numeric/ConstantValue.h
+++ b/include/slang/numeric/ConstantValue.h
@@ -146,6 +146,8 @@ public:
     ConstantValue convertToStr() const;
     ConstantValue convertToByteArray(bitwidth_t size, bool isSigned) const;
     ConstantValue convertToByteQueue(bool isSigned) const;
+    /// Gets $bits of the constant expression.
+    bitwidth_t dollarBits() const;
 
     static const ConstantValue Invalid;
 

--- a/include/slang/symbols/Type.h
+++ b/include/slang/symbols/Type.h
@@ -54,6 +54,9 @@ public:
     /// Gets the total width of the type in bits. Returns zero if the type does not have a
     /// statically known size.
     bitwidth_t getBitWidth() const;
+    /// Gets $bits of the type.
+    /// Returns zero if the type does not have a statically known size.
+    bitwidth_t dollarBits() const;
 
     /// Indicates whether the type can represent negative numeric values. For non-numeric types,
     /// this always returns false.

--- a/scripts/diagnostics.txt
+++ b/scripts/diagnostics.txt
@@ -381,6 +381,7 @@ subsystem ConstEval
 note NoteInCallTo "in call to '{}'"
 note NoteSkippingFrames "(skipping {} calls in backtrace; use --constexpr-backtrace-limit=0 to see all)"
 error ConstEvalNonConstVariable "reference to non-constant variable '{}' is not allowed in a constant expression"
+error ConstEvalBitsNotFixedSize "$bits argument type is not fixed-size in a constant expression"
 error ConstEvalArrayIndexInvalid "cannot refer to element {} of {} in a constant expression"
 error ConstEvalPartSelectInvalid "cannot select range of [{}:{}] from {} in a constant expression"
 error ConstEvalStringIndexInvalid "cannot select index {} from string of length {} in a constant expression"

--- a/source/numeric/ConstantValue.cpp
+++ b/source/numeric/ConstantValue.cpp
@@ -401,6 +401,34 @@ ConstantValue ConstantValue::convertToByteQueue(bool isSigned) const {
     return queue;
 }
 
+bitwidth_t ConstantValue::dollarBits() const {
+    if (isInteger())
+        return integer().getBitWidth();
+    if (isReal())
+        return 64;
+    if (isShortReal())
+        return 32;
+    if (isNullHandle())
+        return 0;
+    if (isString())
+        return static_cast<bitwidth_t>(str().length() * CHAR_BIT);
+    bitwidth_t width = 0;
+    if (isUnpacked()) {
+        for (const auto& cv : elements())
+            width += cv.dollarBits();
+    }
+    else if (isMap()) {
+        for (const auto& kv : *map()) {
+            width += kv.second.dollarBits();
+        }
+    }
+    else if (isQueue()) {
+        for (const auto& cv : *queue())
+            width += cv.dollarBits();
+    }
+    return width;
+}
+
 std::ostream& operator<<(std::ostream& os, const ConstantValue& cv) {
     return os << cv.toString();
 }

--- a/tests/unittests/EvalTests.cpp
+++ b/tests/unittests/EvalTests.cpp
@@ -1610,3 +1610,23 @@ TEST_CASE("Unpacked array concat") {
     REQUIRE(diags.size() == 1);
     CHECK(diags[0].code == diag::UnpackedConcatSize);
 }
+
+TEST_CASE("$bits unpacked types") {
+    ScriptSession session;
+    session.eval(R"(
+localparam string str = "hello";
+logic [0:2] fixed [17:13];
+struct { time a; enum bit [0:1] {red, yellow, blue} b; } record;
+localparam bit dynamic[] = '{1, 0};
+localparam shortint queue[$] = '{8, 1, 3};
+localparam byte asso[string] = '{ "Jon": 20, "Paul":22, "Al":23, default:-1 };
+)");
+    CHECK(session.eval("$bits(str)").integer() == 40);
+    CHECK(session.eval("$bits(fixed)").integer() == 15);
+    CHECK(session.eval("$bits(record)").integer() == 66);
+    CHECK(session.eval("$bits(dynamic)").integer() == 2);
+    CHECK(session.eval("$bits(queue)").integer() == 48);
+    CHECK(session.eval("$bits(asso)").integer() == 24);
+
+    NO_SESSION_ERRORS;
+}

--- a/tests/unittests/ExpressionTests.cpp
+++ b/tests/unittests/ExpressionTests.cpp
@@ -1300,3 +1300,28 @@ endmodule
     REQUIRE(diags.size() == 1);
     CHECK(diags[0].code == diag::BadAssignment);
 }
+
+bool testBitsNonFixedSizeArray(const std::string& text) {
+    const auto& fullText = "module Top; " + text + " endmodule";
+    auto tree = SyntaxTree::fromText(string_view(fullText));
+    Compilation compilation;
+    compilation.addSyntaxTree(tree);
+    auto& diags = compilation.getAllDiagnostics();
+    return diags.size() == 0;
+}
+
+TEST_CASE("$bits on non-fixed-size array") {
+    std::string intBits = "int b = $bits(a);";
+    std::string paramBits = "localparam b = $bits(a);";
+    const char* types[] = {
+        "string a;",
+        "logic[1:0] a[];",
+        "bit a[$];",
+        "byte a[int];",
+    };
+    int num = sizeof(types) / sizeof(const char*);
+    for (int i = 0; i < num; ++i) {
+        CHECK(testBitsNonFixedSizeArray(types[i] + intBits));
+        CHECK(!testBitsNonFixedSizeArray(types[i] + paramBits));
+    }
+}


### PR DESCRIPTION
1. Enhance Type::isBitstreamType() to include string, according to standard §6.24.3. The previous rejected SystemVerilog code below is now accepted.
```sv
string a;
int b = $bits(a);
```
2. Add function Type::dollarBits() to calculate $bits value handling unpacked structs and fixed-size unpacked arrays. Returns 0 if strings, dynamic arrays, associative arrays, or queues are encountered. In BitsFunction::eval, if Type::dollarBits() returns a positive value, it means the type has static size and the value is returned.

3. If $bits argument type is not fixed-size, attempt to evaluate its argument as a constant. If it is a constant, new function ConstantValue::dollarBits() will calculate $bits value on the constant.

4. If neither type is fixed-size nor value is constant, an additional error is shown.
```txt
$bits argument type is not fixed-size in a constant expression
```
5. Two unit test cases are added.

