### PR TITLE
Fix incorrect constant evaluation for mixed unknowns or mixed signedness

### DIFF
--- a/include/slang/numeric/SVInt.h
+++ b/include/slang/numeric/SVInt.h
@@ -434,7 +434,7 @@ public:
 
     SVInt operator-() const;
     SVInt operator~() const;
-    logic_t operator!() const { return *this == 0; }
+    logic_t operator!() const { return !reductionOr(); }
 
     SVInt operator+(const SVInt& rhs) const;
     SVInt operator-(const SVInt& rhs) const;
@@ -459,13 +459,13 @@ public:
     logic_t operator<=(const SVInt& rhs) const { return (*this < rhs) || (*this == rhs); }
     logic_t operator>(const SVInt& rhs) const { return !(*this <= rhs); }
     logic_t operator>=(const SVInt& rhs) const { return !(*this < rhs); }
-    logic_t operator&&(const SVInt& rhs) const { return *this != 0 && rhs != 0; }
-    logic_t operator||(const SVInt& rhs) const { return *this != 0 || rhs != 0; }
+    logic_t operator&&(const SVInt& rhs) const { return reductionOr() && rhs.reductionOr(); }
+    logic_t operator||(const SVInt& rhs) const { return reductionOr() || rhs.reductionOr(); }
 
     logic_t operator[](const SVInt& index) const;
     logic_t operator[](int32_t index) const;
 
-    explicit operator logic_t() const { return *this != 0; }
+    explicit operator logic_t() const { return reductionOr(); }
 
     /// Constructs from a string (in SystemVerilog syntax). This is mostly for convenience;
     /// any errors will assert instead of being handled gracefully.
@@ -554,6 +554,7 @@ private:
     // Check if we still need to have the unknownFlag set after doing an
     // operation that might have removed the unknown bits in the number.
     void checkUnknown();
+    void makeUnknown();
 
     static constexpr uint32_t whichWord(bitwidth_t bitIndex) { return bitIndex / BITS_PER_WORD; }
     static constexpr uint32_t whichBit(bitwidth_t bitIndex) { return bitIndex % BITS_PER_WORD; }

--- a/source/binding/AssignmentExpressions.cpp
+++ b/source/binding/AssignmentExpressions.cpp
@@ -579,6 +579,9 @@ ConstantValue ConversionExpression::convert(EvalContext& context, const Type& fr
         return cv;
     }
 
+    if (castKind == ConversionKind::Propagated && value.isInteger() && to.isIntegral())
+        value.integer().setSigned(to.isSigned());
+
     if (to.isIntegral())
         return value.convertToInt(to.getBitWidth(), to.isSigned(), to.isFourState());
 

--- a/source/binding/AssignmentExpressions.cpp
+++ b/source/binding/AssignmentExpressions.cpp
@@ -579,6 +579,9 @@ ConstantValue ConversionExpression::convert(EvalContext& context, const Type& fr
         return cv;
     }
 
+    // [11.8.2] last bullet says: the operand shall be sign-extended only if the propagated type is
+    // signed. It is different from [11.8.3] ConstantValue::convertToInt uses.
+    // ConversionKind::Propagated marked in Expression::PropagationVisitor
     if (castKind == ConversionKind::Propagated && value.isInteger() && to.isIntegral())
         value.integer().setSigned(to.isSigned());
 

--- a/source/binding/Expression.cpp
+++ b/source/binding/Expression.cpp
@@ -120,8 +120,11 @@ struct Expression::PropagationVisitor {
         }
 
         Expression* result = &expr;
-        if (needConversion)
-            result = &Expression::implicitConversion(context, newType, expr);
+        if (needConversion) {
+            Expression::selfDetermined(context, result);
+            result = context.scope.getCompilation().emplace<ConversionExpression>(
+                newType, ConversionKind::Propagated, expr, expr.sourceRange);
+        }
 
         return *result;
     }

--- a/source/numeric/SVInt.cpp
+++ b/source/numeric/SVInt.cpp
@@ -1071,14 +1071,17 @@ SVInt& SVInt::operator&=(const SVInt& rhs) {
                 pVal[0] = ~pVal[1] & pVal[0] & rhs.val;
             }
             else {
-                if (rhs.hasUnknown())
-                    for (uint32_t i = 0; i < words; i++)
+                if (rhs.hasUnknown()) {
+                    for (uint32_t i = 0; i < words; i++) {
                         pVal[i + words] = (pVal[i + words] | rhs.pVal[i + words]) &
                                           (pVal[i + words] | pVal[i]) &
                                           (rhs.pVal[i + words] | rhs.pVal[i]);
-                else
+                    }
+                }
+                else {
                     for (uint32_t i = 0; i < words; i++)
                         pVal[i + words] &= rhs.pVal[i];
+                }
 
                 for (uint32_t i = 0; i < words; i++)
                     pVal[i] = ~pVal[i + words] & pVal[i] & rhs.pVal[i];
@@ -1115,13 +1118,16 @@ SVInt& SVInt::operator|=(const SVInt& rhs) {
                 pVal[0] = ~pVal[1] & (pVal[0] | rhs.val);
             }
             else {
-                if (rhs.hasUnknown())
-                    for (uint32_t i = 0; i < words; i++)
+                if (rhs.hasUnknown()) {
+                    for (uint32_t i = 0; i < words; i++) {
                         pVal[i + words] = (pVal[i + words] & (rhs.pVal[i + words] | ~rhs.pVal[i])) |
                                           (~pVal[i] & rhs.pVal[i + words]);
-                else
+                    }
+                }
+                else {
                     for (uint32_t i = 0; i < words; i++)
                         pVal[i + words] &= ~rhs.pVal[i];
+                }
 
                 for (uint32_t i = 0; i < words; i++)
                     pVal[i] = ~pVal[i + words] & (pVal[i] | rhs.pVal[i]);
@@ -1156,9 +1162,10 @@ SVInt& SVInt::operator^=(const SVInt& rhs) {
             if (rhs.isSingleWord())
                 pVal[0] = ~pVal[1] & (pVal[0] ^ rhs.val);
             else {
-                if (rhs.hasUnknown())
+                if (rhs.hasUnknown()) {
                     for (uint32_t i = 0; i < words; i++)
                         pVal[i + words] |= rhs.pVal[i + words];
+                }
 
                 for (uint32_t i = 0; i < words; i++)
                     pVal[i] = ~pVal[i + words] & (pVal[i] ^ rhs.pVal[i]);
@@ -1193,9 +1200,10 @@ SVInt SVInt::xnor(const SVInt& rhs) const {
             if (rhs.isSingleWord())
                 result.pVal[0] = ~result.pVal[1] & ~(result.pVal[0] ^ rhs.val);
             else {
-                if (rhs.hasUnknown())
+                if (rhs.hasUnknown()) {
                     for (uint32_t i = 0; i < words; i++)
                         result.pVal[i + words] |= rhs.pVal[i + words];
+                }
 
                 for (uint32_t i = 0; i < words; i++)
                     result.pVal[i] = ~result.pVal[i + words] & ~(result.pVal[i] ^ rhs.pVal[i]);
@@ -1725,8 +1733,12 @@ SVInt& SVInt::assignSlowCase(const SVInt& rhs) {
 }
 
 logic_t SVInt::equalsSlowCase(const SVInt& rhs) const {
-    if (unknownFlag || rhs.unknownFlag)
+    if (unknownFlag || rhs.unknownFlag) {
+        // We can't know whether the numbers are definitely equal, but if there is a 0/1 pair, it is
+        // definitely not equal. xor detects 0/1 pairs for each bit and !reductionOr collects all
+        // pairs.
         return !(*this ^ rhs).reductionOr();
+    }
 
     // handle unequal bit widths; spec says that if both values are signed, then do sign
     // extension

--- a/source/parsing/NumberParser.cpp
+++ b/source/parsing/NumberParser.cpp
@@ -261,13 +261,18 @@ Token NumberParser::finishValue(Token firstToken, bool singleToken) {
 void NumberParser::addDigit(logic_t digit, int maxValue) {
     // Leading zeros obviously don't count towards our bit limit, so
     // only count them if we've seen other non-zero digits
-    if (digit.value != 0 || digits.size() != 0) {
-        digits.append(digit);
-        if (digit.isUnknown())
-            hasUnknown = true;
-        else
-            ASSERT(digit.value < maxValue);
+    if (digit.isUnknown())
+        hasUnknown = true; // Keep one leading zero, if any, for msb extension
+    else {
+        ASSERT(digit.value < maxValue);
+        if (digits.size() == 1 && digits.front().value == 0) {
+            if (digit.value == 0)
+                return; // at most one leading zero
+            else
+                digits.pop(); // If first nonzero not unknown, no leading zeros
+        }
     }
+    digits.append(digit);
 }
 
 Diagnostic& NumberParser::addDiag(DiagCode code, SourceLocation location) {

--- a/tests/unittests/EvalTests.cpp
+++ b/tests/unittests/EvalTests.cpp
@@ -1697,6 +1697,7 @@ TEST_CASE("Mixed unknowns or signedness") {
     CHECK_THAT(session.eval("3'b0x1 & 3'b111").integer(), exactlyEquals("3'b0x1"_si));
     CHECK_THAT(session.eval("3'b000 ~^ 3'b0x1").integer(), exactlyEquals("3'b1x0"_si));
     CHECK_THAT(session.eval("3'b0x1 ^~ 3'b000").integer(), exactlyEquals("3'b1x0"_si));
+    CHECK_THAT(session.eval("599'b000 ^ 3'b0x1").integer(), exactlyEquals("599'b0x1"_si));
     CHECK_THAT(session.eval("3'b0x1 ^ 600'b0").integer(), exactlyEquals("600'b0x1"_si));
     CHECK_THAT(session.eval("3'b0x1 | 601'b0").integer(), exactlyEquals("601'b0x1"_si));
     CHECK_THAT(session.eval("3'b0x1 & {602{1'b1}}").integer(), exactlyEquals("602'b0x1"_si));
@@ -1711,7 +1712,7 @@ TEST_CASE("Mixed unknowns or signedness") {
     CHECK(session.eval("3'b0x1 || 1'b0").integer() == 1);
     CHECK(session.eval("3'b0x1 && 1'b1").integer() == 1);
 
-    // Equaulity operators with uknowns
+    // Equality operators with unknowns
     CHECK(session.eval("3'b0x1 == 0").integer() == 0);
     CHECK(session.eval("2'b1x ?16'h1234:16'h7890").integer() == 4660);
 

--- a/tests/unittests/EvalTests.cpp
+++ b/tests/unittests/EvalTests.cpp
@@ -1684,3 +1684,39 @@ typedef struct { logic[-2:5] a[][]; string b; bit c[$]; } f;
 
     NO_SESSION_ERRORS;
 }
+
+TEST_CASE("Mixed unknowns or signedness") {
+    ScriptSession session;
+
+    // Bitwise operator with exactly one operand unknown
+    CHECK_THAT(session.eval("3'b000 ^ 3'b0x1").integer(), exactlyEquals("3'b0x1"_si));
+    CHECK_THAT(session.eval("3'b0x1 ^ 3'b000").integer(), exactlyEquals("3'b0x1"_si));
+    CHECK_THAT(session.eval("3'b000 | 3'b0x1").integer(), exactlyEquals("3'b0x1"_si));
+    CHECK_THAT(session.eval("3'b0x1 | 3'b000").integer(), exactlyEquals("3'b0x1"_si));
+    CHECK_THAT(session.eval("3'b111 & 3'b0x1").integer(), exactlyEquals("3'b0x1"_si));
+    CHECK_THAT(session.eval("3'b0x1 & 3'b111").integer(), exactlyEquals("3'b0x1"_si));
+    CHECK_THAT(session.eval("3'b000 ~^ 3'b0x1").integer(), exactlyEquals("3'b1x0"_si));
+    CHECK_THAT(session.eval("3'b0x1 ^~ 3'b000").integer(), exactlyEquals("3'b1x0"_si));
+    CHECK_THAT(session.eval("3'b0x1 ^ 600'b0").integer(), exactlyEquals("600'b0x1"_si));
+    CHECK_THAT(session.eval("3'b0x1 | 601'b0").integer(), exactlyEquals("601'b0x1"_si));
+    CHECK_THAT(session.eval("3'b0x1 & {602{1'b1}}").integer(), exactlyEquals("602'b0x1"_si));
+    CHECK_THAT(session.eval("3'b0x1 ^~ {{600{1'b1}}, 3'b0}").integer(),
+               exactlyEquals("603'b1x0"_si));
+
+    // logical and reduction operators on mixed unknowns
+    CHECK(session.eval("! 3'b0x1").integer() == 0);
+    CHECK(session.eval("| 3'b0x1").integer() == 1);
+    CHECK(session.eval("& 3'b0x1").integer() == 0);
+    CHECK_THAT(session.eval("& 3'bx1").integer(), exactlyEquals(SVInt(logic_t::x)));
+    CHECK(session.eval("3'b0x1 || 1'b0").integer() == 1);
+    CHECK(session.eval("3'b0x1 && 1'b1").integer() == 1);
+
+    // Equaulity operators with uknowns
+    CHECK(session.eval("3'b0x1 == 0").integer() == 0);
+    CHECK(session.eval("2'b1x ?16'h1234:16'h7890").integer() == 4660);
+
+    // propagated signed extension
+    CHECK(session.eval("1'b0 ? 7'd100: 3'sb101").integer() == 5);
+
+    NO_SESSION_ERRORS;
+}


### PR DESCRIPTION
This is to fix some incorrect values of constant evaluation for some test cases with mixed unknowns or signedness. Unit tests showing the problems are included.
1. Reduction OR should be one as long as there is a one bit, regardless whether there are unknowns. An unknown value was incorrectly returned whenever there was an unknown bit.
```c++
    CHECK(session.eval("| 3'b0x1").integer() == 1);
```
A fix in SVInt::reductionOr() improves it.
```c++
    if (unknownFlag)
        return countOnes() > 0 ? logic_t(true) : logic_t::x;
```
2. The four bitwise operators crashed when the first operand had unknowns but the second operand didn't, and ignored the unknown in the second when the first did not have unknowns.
```c++
    CHECK_THAT(session.eval("3'b000 ^ 3'b0x1").integer(), exactlyEquals("3'b0x1"_si));
    CHECK_THAT(session.eval("3'b0x1 ^ 3'b000").integer(), exactlyEquals("3'b0x1"_si));
    CHECK_THAT(session.eval("3'b000 | 3'b0x1").integer(), exactlyEquals("3'b0x1"_si));
    CHECK_THAT(session.eval("3'b0x1 | 3'b000").integer(), exactlyEquals("3'b0x1"_si));
    CHECK_THAT(session.eval("3'b111 & 3'b0x1").integer(), exactlyEquals("3'b0x1"_si));
    CHECK_THAT(session.eval("3'b0x1 & 3'b111").integer(), exactlyEquals("3'b0x1"_si));
    CHECK_THAT(session.eval("3'b000 ~^ 3'b0x1").integer(), exactlyEquals("3'b1x0"_si));
    CHECK_THAT(session.eval("3'b0x1 ^~ 3'b000").integer(), exactlyEquals("3'b1x0"_si));
```
A new function SVInt::makeUnknown() is created to make the first operand unknown when the second has unknowns. Four functions are revised to handle unknowns better.
```c++
    SVInt operator&(const SVInt& rhs) const;
    SVInt operator|(const SVInt& rhs) const;
    SVInt operator^(const SVInt& rhs) const;
    SVInt xnor(const SVInt& rhs) const;
```
3. SVInt::reductionAnd() has a similar fix like SVInt::reductionOr(), but it is not sufficient to fix
```c++
    CHECK(session.eval("& 3'b0x1").integer() == 0);
```
The x/z extension in SVInt::fromPow2Digits
```c++
        // If the most significant bit is X or Z, we need to extend that out to the full range.
```
is not supposed to apply on 3'b0x1 whose msb is 0, but because NumberParser::addDigit removed all leading zeros, it incorrectly transformed 3'b0x1 into 3'bxx1. The fix in NumberParser::addDigit
```c++
    if (digit.isUnknown())
        hasUnknown = true; // Keep one leading zero, if any, for msb extension
    else {
        ASSERT(digit.value < maxValue);
        if (digits.size() == 1 && digits.front().value == 0) {
            if (digit.value == 0)
                return; // at most one leading zero
            else
                digits.pop(); // If first nonzero not unknown, no leading zeros
        }
    }
    digits.append(digit);
```
preserves one leading zero if the first nonzero bit is an unknown. If the first nonzero bit is not unknown, all leading zeros are still removed as before.

4. Context-determined sign extension should use propagated type, and 3'sb101 should have unsigned extension below:
```c++
    CHECK(session.eval("1'b0 ? 7'd100: 3'sb101").integer() == 5);
```
In ConstantValue::convertToInt:
```c++
    // [11.8.3] says that during an assignment we sign extend iff the rhs is signed.
    // That means we should resize first, and only then change the sign flag if desired.
```
is correct in its context but [11.8.2] has a different rule:

> When propagation reaches a simple operand as defined in 11.5, then that operand shall be converted to the propagated type and size. If the operand shall be extended, then it shall be sign-extended only if the propagated type is signed.

The solution is to mark in Expression::PropagationVisitor that the conversion is a propagated type
```c++
       if (needConversion) {
            Expression::selfDetermined(context, result);
            result = context.scope.getCompilation().emplace<ConversionExpression>(
                newType, ConversionKind::Propagated, expr, expr.sourceRange);
        }
```
and in ConversionExpression::convert, signedness is propagated for this kind of conversion
```c++
    if (castKind == ConversionKind::Propagated && value.isInteger() && to.isIntegral())
        value.integer().setSigned(to.isSigned());
```
5. == operator with unknowns should be fixed too.
```c++
   if (unknownFlag || rhs.unknownFlag)
        return !(*this ^ rhs).reductionOr();
```
6. The following 4 logic operators use reductionOr instead of == 0.
```c++
    logic_t operator!() const { return !reductionOr(); }
    logic_t operator&&(const SVInt& rhs) const { return reductionOr() && rhs.reductionOr(); }
    logic_t operator||(const SVInt& rhs) const { return reductionOr() || rhs.reductionOr(); }
    explicit operator logic_t() const { return reductionOr(); }
```
reductionOr delivers the same result as ==, but is more efficient than ==, which has overhead to create temporary second operand and check/adjust lengths/signedness of two operands. With the fix in reductionOr and == on unknowns, the following logic operators with unknowns work correctly now.
```c++
    CHECK(session.eval("3'b0x1 || 1'b0").integer() == 1);
    CHECK(session.eval("3'b0x1 && 1'b1").integer() == 1);
    CHECK(session.eval("3'b0x1 == 0").integer() == 0);
    CHECK(session.eval("2'b1x ?16'h1234:16'h7890").integer() == 4660);
```