### PR TITLE
Fix power operator const eval with mixed-signed operands

### DIFF
--- a/source/binding/AssignmentExpressions.cpp
+++ b/source/binding/AssignmentExpressions.cpp
@@ -579,14 +579,14 @@ ConstantValue ConversionExpression::convert(EvalContext& context, const Type& fr
         return cv;
     }
 
-    // [11.8.2] last bullet says: the operand shall be sign-extended only if the propagated type is
-    // signed. It is different from [11.8.3] ConstantValue::convertToInt uses.
-    // ConversionKind::Propagated marked in Expression::PropagationVisitor
-    if (castKind == ConversionKind::Propagated && value.isInteger() && to.isIntegral())
-        value.integer().setSigned(to.isSigned());
-
-    if (to.isIntegral())
+    if (to.isIntegral()) {
+        // [11.8.2] last bullet says: the operand shall be sign-extended only if the propagated type
+        // is signed. It is different from [11.8.3] ConstantValue::convertToInt uses.
+        // ConversionKind::Propagated marked in Expression::PropagationVisitor
+        if (castKind == ConversionKind::Propagated && value.isInteger())
+            value.integer().setSigned(to.isSigned());
         return value.convertToInt(to.getBitWidth(), to.isSigned(), to.isFourState());
+    }
 
     if (to.isFloating()) {
         switch (to.getBitWidth()) {

--- a/source/numeric/SVInt.cpp
+++ b/source/numeric/SVInt.cpp
@@ -833,7 +833,7 @@ SVInt SVInt::pow(const SVInt& rhs) const {
         return SVInt(bitWidth, 1, signFlag);
 
     if (signFlag && isNegative()) {
-        if (reductionAnd()) {
+        if (reductionAnd()) { // x == -1
             // if rhs is odd, result is -1
             // otherwise, result is 1
             if (rhs.isOdd())

--- a/tests/unittests/EvalTests.cpp
+++ b/tests/unittests/EvalTests.cpp
@@ -1718,8 +1718,16 @@ TEST_CASE("Mixed unknowns or signedness") {
     CHECK_THAT(session.eval("3'sb1x0 == 4'sb11x0").integer(), exactlyEquals(SVInt(logic_t::x)));
     CHECK(session.eval("{1'b1, 99'b0x0} == 0").integer() == 0);
 
-    // propagated signed extension
+    // mixed signed
     CHECK(session.eval("1'b0 ? 7'd100: 3'sb101").integer() == 5);
+    CHECK(session.eval("3'sd2**2'b10 > -2").integer() == 1);
+    CHECK(session.eval("-1**2'b11").integer() == -1);
+    CHECK(session.eval("500'habcdef**-2").integer() == 0);
+    CHECK(session.eval("-500'sd1**7'd37").integer() == -1);
+    CHECK(session.eval("-500'sd1**-3").integer() == -1);
+    CHECK(session.eval("4'd3**500'sd3").integer() == 11);
+    CHECK(session.eval("10**3'b100").integer() == 10000);
+    CHECK(session.eval("3'b111**2'sb10").integer() == 0);
 
     NO_SESSION_ERRORS;
 }

--- a/tests/unittests/EvalTests.cpp
+++ b/tests/unittests/EvalTests.cpp
@@ -1688,7 +1688,7 @@ typedef struct { logic[-2:5] a[][]; string b; bit c[$]; } f;
 TEST_CASE("Mixed unknowns or signedness") {
     ScriptSession session;
 
-    // Bitwise operator with exactly one operand unknown
+    // bitwise operator with exactly one operand unknown
     CHECK_THAT(session.eval("3'b000 ^ 3'b0x1").integer(), exactlyEquals("3'b0x1"_si));
     CHECK_THAT(session.eval("3'b0x1 ^ 3'b000").integer(), exactlyEquals("3'b0x1"_si));
     CHECK_THAT(session.eval("3'b000 | 3'b0x1").integer(), exactlyEquals("3'b0x1"_si));
@@ -1712,9 +1712,11 @@ TEST_CASE("Mixed unknowns or signedness") {
     CHECK(session.eval("3'b0x1 || 1'b0").integer() == 1);
     CHECK(session.eval("3'b0x1 && 1'b1").integer() == 1);
 
-    // Equality operators with unknowns
+    // equality operators with unknowns
     CHECK(session.eval("3'b0x1 == 0").integer() == 0);
     CHECK(session.eval("2'b1x ?16'h1234:16'h7890").integer() == 4660);
+    CHECK_THAT(session.eval("3'sb1x0 == 4'sb11x0").integer(), exactlyEquals(SVInt(logic_t::x)));
+    CHECK(session.eval("{1'b1, 99'b0x0} == 0").integer() == 0);
 
     // propagated signed extension
     CHECK(session.eval("1'b0 ? 7'd100: 3'sb101").integer() == 5);


### PR DESCRIPTION
1. SV-2017 standard [11.4.3]  says

> In all cases, the second operand of the power operator shall be treated as self-determined.

Table 11-4 and Table 11-21 also indicate two operands of a power operator can have different signs. SVInt::pow incorrectly used "bothSigned" to determine operand signedness. "bothSigned" is replaced with signeFlag of each operand. Additional unit tests show the problems.
```c++
    CHECK(session.eval("3'sd2**2'b10 > -2").integer() == 1);
    CHECK(session.eval("-1**2'b11").integer() == -1);
    CHECK(session.eval("500'habcdef**-2").integer() == 0);
    CHECK(session.eval("-500'sd1**7'd37").integer() == -1);
    CHECK(session.eval("-500'sd1**-3").integer() == -1);
    CHECK(session.eval("4'd3**500'sd3").integer() == 11);
    CHECK(session.eval("10**3'b100").integer() == 10000);
    CHECK(session.eval("3'b111**2'sb10").integer() == 0);
```
2. A little polish on the code of the previous pull request. There should be no functionality change. The revision on reductionOr/reductionAnd hasUnknown() improves a little efficiency on very long vectors. countOnes and countZeros traverse an entire long vector, while the revision stops whenever a one or zero is found.
