### PR TITLE
Do not match type logic/reg to signed logic/reg

### DIFF
--- a/source/symbols/Type.cpp
+++ b/source/symbols/Type.cpp
@@ -336,7 +336,7 @@ bool Type::isMatching(const Type& rhs) const {
         auto ls = l->as<ScalarType>().scalarKind;
         auto rs = r->as<ScalarType>().scalarKind;
         return (ls == ScalarType::Logic || ls == ScalarType::Reg) &&
-               (rs == ScalarType::Logic || rs == ScalarType::Reg);
+               (rs == ScalarType::Logic || rs == ScalarType::Reg) && l->isSigned() == r->isSigned();
     }
 
     // Special casing for type synonyms: real/realtime

--- a/tests/unittests/EvalTests.cpp
+++ b/tests/unittests/EvalTests.cpp
@@ -1717,6 +1717,8 @@ TEST_CASE("Mixed unknowns or signedness") {
     CHECK_THAT(session.eval("& 3'bx1").integer(), exactlyEquals(SVInt(logic_t::x)));
     CHECK(session.eval("3'b0x1 || 1'b0").integer() == 1);
     CHECK(session.eval("3'b0x1 && 1'b1").integer() == 1);
+    CHECK(session.eval("&65'bx10").integer() == 0);
+    CHECK_THAT(session.eval("&65'bx1").integer(), exactlyEquals(SVInt(logic_t::x)));
 
     // equality operators with unknowns
     CHECK(session.eval("3'b0x1 == 0").integer() == 0);
@@ -1734,6 +1736,9 @@ TEST_CASE("Mixed unknowns or signedness") {
     CHECK(session.eval("4'd3**500'sd3").integer() == 11);
     CHECK(session.eval("10**3'b100").integer() == 10000);
     CHECK(session.eval("3'b111**2'sb10").integer() == 0);
+    CHECK(session.eval("3'b111**2'sb10").integer() == 0);
+    CHECK(session.eval("(-5'sd10 / 5'sd3) + 2'b01").integer() == 8);
+    CHECK(session.eval("(5'sd3 - 5'sd10) + 2'b01").integer() == 26);
 
     NO_SESSION_ERRORS;
 }


### PR DESCRIPTION
The following code inside Type::isMatching() correctly returned 2-state type "bit" not matching "bit signed", but incorrectly returned 4-state type "logic/reg" matching "logic/reg signed":
```c++
        return (ls == ScalarType::Logic || ls == ScalarType::Reg) &&
               (rs == ScalarType::Logic || rs == ScalarType::Reg);
```
This led to mistakenly make the following unsigned expression (because of an unsigned operand 2'b01 [11.8.1]) signed.
```c++
    CHECK(session.eval("(-5'sd10 / 5'sd3) + 2'b01").integer() == 8);
```
This was because division created 4-state type
```c++
        case SyntaxKind::DivideExpression:
            // Result is forced to 4-state because result can be X.
```
and in Expression::binaryOperatorType for operator "+"
```c++
    // Attempt to preserve any type aliases passed in when selecting the result.
    if (lt->isMatching(*result))
        return lt;
```
"lt" was "logic signed[4:0]" and "result" was "logic[4:0]", because "isMatching" returned true, it chose wrong signed "lt" instead of correct unsigned "result". On the other hand,
```c++
    CHECK(session.eval("(5'sd3 - 5'sd10) + 2'b01").integer() == 26);
```
was correct because of 2-state types. When "lt" was "bit signed[4:0]" and "result" was "bit[4:0]", "isMatching" returned false, and correct unsigned "result" was chosen.

The fix is to add "&& l->isSigned() == r->isSigned()" to the problematic code.
