### PR TITLE
Fix shift operator constant evaluation with negative right operand or unknowns

### DIFF
--- a/include/slang/numeric/SVInt.h
+++ b/include/slang/numeric/SVInt.h
@@ -556,7 +556,7 @@ private:
     void checkUnknown();
     void makeUnknown();
 
-    // $unsigned(*this) value truncated at bitwidth_t::max()
+    // $unsigned(*this) value saturated at bitwidth_t::max()
     bitwidth_t unsignedAmount() const;
 
     static constexpr uint32_t whichWord(bitwidth_t bitIndex) { return bitIndex / BITS_PER_WORD; }

--- a/include/slang/numeric/SVInt.h
+++ b/include/slang/numeric/SVInt.h
@@ -556,6 +556,9 @@ private:
     void checkUnknown();
     void makeUnknown();
 
+    // $unsigned(*this) value truncated at bitwidth_t::max()
+    bitwidth_t unsignedAmount() const;
+
     static constexpr uint32_t whichWord(bitwidth_t bitIndex) { return bitIndex / BITS_PER_WORD; }
     static constexpr uint32_t whichBit(bitwidth_t bitIndex) { return bitIndex % BITS_PER_WORD; }
     static constexpr uint64_t maskBit(bitwidth_t bitIndex) { return 1ULL << whichBit(bitIndex); }

--- a/source/numeric/SVInt.cpp
+++ b/source/numeric/SVInt.cpp
@@ -490,7 +490,7 @@ bitwidth_t SVInt::unsignedAmount() const {
     bitwidth_t bits = getActiveBits();
     if (bits > sizeof(bitwidth_t) * CHAR_BIT)
         return std::numeric_limits<bitwidth_t>::max();
-    return static_cast<bitwidth_t>(isSingleWord() ? val : pVal[0]);
+    return static_cast<bitwidth_t>(*getRawPtr());
 }
 
 SVInt SVInt::shl(const SVInt& rhs) const {
@@ -599,7 +599,10 @@ SVInt SVInt::ashr(bitwidth_t amount) const {
         return *this;
     if (amount >= bitWidth)
         return SVInt(bitWidth, *this >= 0 ? 0 : UINT64_MAX, signFlag);
-    if (!signFlag || !(*this)[int32_t(bitWidth) - 1]) // unsigned or positive
+
+    // !(*this)[int32_t(bitWidth) - 1]) checks msb==0
+    // Not precisely !isNegative() which is msb!=1 or msb==[0xz]
+    if (!signFlag || !(*this)[int32_t(bitWidth) - 1]) // unsigned or nonnegative
         return lshr(amount);
 
     bitwidth_t contractedWidth = bitWidth - amount;

--- a/source/numeric/SVInt.cpp
+++ b/source/numeric/SVInt.cpp
@@ -485,15 +485,24 @@ void SVInt::shrinkToFit() {
         *this = resize(minBits);
 }
 
+bitwidth_t SVInt::unsignedAmount() const {
+    // [11.4.10] The right operand of shift operators is always treated as an unsigned number
+    bitwidth_t bits = getActiveBits();
+    if (bits > sizeof(bitwidth_t) * CHAR_BIT)
+        return std::numeric_limits<bitwidth_t>::max();
+    return static_cast<bitwidth_t>(isSingleWord() ? val : pVal[0]);
+}
+
 SVInt SVInt::shl(const SVInt& rhs) const {
     // if the shift amount is unknown, result is all X's
     if (rhs.hasUnknown())
         return createFillX(bitWidth, signFlag);
 
+    auto amount = rhs.unsignedAmount();
     // if the shift amount is too large, we end up with zero anyway
-    if (rhs >= bitWidth)
+    if (amount >= bitWidth)
         return SVInt(bitWidth, 0, signFlag);
-    return shl(rhs.as<bitwidth_t>().value());
+    return shl(amount);
 }
 
 SVInt SVInt::shl(bitwidth_t amount) const {
@@ -536,10 +545,11 @@ SVInt SVInt::lshr(const SVInt& rhs) const {
     if (rhs.hasUnknown())
         return createFillX(bitWidth, signFlag);
 
+    auto amount = rhs.unsignedAmount();
     // if the shift amount is too large, we end up with zero anyway
-    if (rhs >= bitWidth)
+    if (amount >= bitWidth)
         return SVInt(bitWidth, 0, signFlag);
-    return lshr(rhs.as<bitwidth_t>().value());
+    return lshr(amount);
 }
 
 SVInt SVInt::lshr(bitwidth_t amount) const {
@@ -576,39 +586,26 @@ SVInt SVInt::ashr(const SVInt& rhs) const {
         return lshr(rhs);
     if (rhs.hasUnknown())
         return createFillX(bitWidth, signFlag);
-    if (rhs >= bitWidth)
+
+    auto amount = rhs.unsignedAmount();
+    if (amount >= bitWidth)
         return SVInt(bitWidth, *this >= 0 ? 0 : UINT64_MAX, signFlag);
 
-    return ashr(rhs.as<bitwidth_t>().value());
+    return ashr(amount);
 }
 
 SVInt SVInt::ashr(bitwidth_t amount) const {
-    if (!signFlag)
-        return lshr(amount);
     if (amount == 0)
         return *this;
     if (amount >= bitWidth)
         return SVInt(bitWidth, *this >= 0 ? 0 : UINT64_MAX, signFlag);
+    if (!signFlag || !(*this)[int32_t(bitWidth) - 1]) // unsigned or positive
+        return lshr(amount);
 
     bitwidth_t contractedWidth = bitWidth - amount;
-    SVInt tmp = lshr(amount);
 
-    if (contractedWidth <= 64 && getNumWords() > 1) {
-        // signExtend won't be safe as it will assume it is operating on a single-word
-        // input when it isn't, so let's manually take care of that case here.
-        SVInt result = SVInt::allocUninitialized(bitWidth, signFlag, unknownFlag);
-        uint64_t newVal = tmp.pVal[0] << (SVInt::BITS_PER_WORD - contractedWidth);
-        result.pVal[0] = uint64_t((int64_t)newVal >> (SVInt::BITS_PER_WORD - contractedWidth));
-        for (size_t i = 1; i < getNumWords(); ++i) {
-            // sign extend the rest based on original sign
-            result.pVal[i] = (val & (1ULL << 63)) ? 0 : ~0ULL;
-        }
-        result.clearUnusedBits();
-        return result;
-    }
     // Pretend our width is just the width we shifted to, then signExtend
-    tmp.bitWidth = contractedWidth;
-    return tmp.sext(bitWidth);
+    return lshr(amount).trunc(contractedWidth).sext(bitWidth);
 }
 
 SVInt SVInt::replicate(const SVInt& times) const {
@@ -1540,7 +1537,7 @@ SVInt SVInt::trunc(bitwidth_t bits) const {
 
     if (isSingleWord()) {
         uint64_t mask = bits == 64 ? UINT64_MAX : (1ull << bits) - 1;
-        return SVInt(bits, val & mask, false);
+        return SVInt(bits, val & mask, signFlag);
     }
 
     SVInt result;

--- a/tests/unittests/EvalTests.cpp
+++ b/tests/unittests/EvalTests.cpp
@@ -1740,5 +1740,11 @@ TEST_CASE("Mixed unknowns or signedness") {
     CHECK(session.eval("(-5'sd10 / 5'sd3) + 2'b01").integer() == 8);
     CHECK(session.eval("(5'sd3 - 5'sd10) + 2'b01").integer() == 26);
 
+    // shift operators negative right operand or with unknonws
+    CHECK_THAT(session.eval("30'b10xz0110111<<-3'sb1").integer(),
+               exactlyEquals("30'b00000000000010xz01101110000000"_si));
+    CHECK_THAT(session.eval("5'sbz001x>>>2").integer(), exactlyEquals("5'bzzz00"_si));
+    CHECK_THAT(session.eval("129'sb0xzxz>>>1").integer(), exactlyEquals("129'sb0xzx"_si));
+
     NO_SESSION_ERRORS;
 }


### PR DESCRIPTION
This is to fix problems for shift operator constant evaluation.
1. SV-2017 standard [11.4.10] says the right operand of shift operators is always treated as an unsigned number.
```c++
    CHECK_THAT(session.eval("30'b10xz0110111<<-3'sb1").integer(),
               exactlyEquals("30'b00000000000010xz01101110000000"_si));
```
The shift amount should be $unsigned(-3'sb1) = 7, but was incorrectly calculated to UINT_MAX. The fix creates a new private SVInt function
```c++
    // $unsigned(*this) value truncated at bitwidth_t::max()
    bitwidth_t unsignedAmount() const;
```
to calculate the correct shift amount.

2. For arithmetic right shift, when the left operand has unknowns and the right doesn't, the result is not reliable.
```c++
    CHECK_THAT(session.eval("5'sbz001x>>>2").integer(), exactlyEquals("5'bzzz00"_si));
    CHECK_THAT(session.eval("129'sb0xzxz>>>1").integer(), exactlyEquals("129'sb0xzx"_si));
```
The code in SVInt::ashr
```c++
    if (contractedWidth <= 64 && getNumWords() > 1) {
        // signExtend won't be safe as it will assume it is operating on a single-word
        // input when it isn't, so let's manually take care of that case here.
        SVInt result = SVInt::allocUninitialized(bitWidth, signFlag, unknownFlag);
        uint64_t newVal = tmp.pVal[0] << (SVInt::BITS_PER_WORD - contractedWidth);
        result.pVal[0] = uint64_t((int64_t)newVal >> (SVInt::BITS_PER_WORD - contractedWidth));
        for (size_t i = 1; i < getNumWords(); ++i) {
            // sign extend the rest based on original sign
            result.pVal[i] = (val & (1ULL << 63)) ? 0 : ~0ULL;
        }
        result.clearUnusedBits();
        return result;
    }
    // Pretend our width is just the width we shifted to, then signExtend
    tmp.bitWidth = contractedWidth;
```
did not handle unknowns. When contractedWidth > 64, unknowns might be incorrect in sext. The comments said "signExtend won't be safe", but the real problem was "tmp.bitWidth = contractedWidth;" corrupted pVal/val memory when the number of words changes because of reducing bitWidth. A solution is to replace the above problematic code with
```c++
   tmp = tmp.trunc(contractedWidth);
```
When SVInt::trunc sets bitWidth to a new value, it updates pVal/val accordingly.

3. This led to another bug in SVInt::trunc that cleared signFlag for isSingleWord().
```c++
    if (isSingleWord()) {
        uint64_t mask = bits == 64 ? UINT64_MAX : (1ull << bits) - 1;
        return SVInt(bits, val & mask, false);
    }
```
This did not look intentional, because if not  isSingleWord(), SVInt::trunc preserves signFlag. The fix preserves signFlag for isSingleWord().

