### PR TITLE
$itor not truncate argument at 32-bit width and a fix for arithmetic shift right const eval with msb=x/z

### DIFF
--- a/source/compilation/builtins/MathFuncs.cpp
+++ b/source/compilation/builtins/MathFuncs.cpp
@@ -33,7 +33,9 @@ public:
         if (!v)
             return nullptr;
 
-        return SVInt(32, clog2(v.integer()), true);
+        auto ci = v.integer();
+        ci.flattenUnknowns();
+        return SVInt(32, clog2(ci), true);
     }
 };
 

--- a/tests/unittests/EvalTests.cpp
+++ b/tests/unittests/EvalTests.cpp
@@ -1745,6 +1745,8 @@ TEST_CASE("Mixed unknowns or signedness") {
                exactlyEquals("30'b00000000000010xz01101110000000"_si));
     CHECK_THAT(session.eval("5'sbz001x>>>2").integer(), exactlyEquals("5'bzzz00"_si));
     CHECK_THAT(session.eval("129'sb0xzxz>>>1").integer(), exactlyEquals("129'sb0xzx"_si));
+    CHECK_THAT(session.eval("65'sbx >>> 66").integer(), exactlyEquals("65'sbx"_si));
+    CHECK_THAT(session.eval("35'sbz >>> 66").integer(), exactlyEquals("35'sbz"_si));
 
     NO_SESSION_ERRORS;
 }

--- a/tests/unittests/EvalTests.cpp
+++ b/tests/unittests/EvalTests.cpp
@@ -1748,5 +1748,12 @@ TEST_CASE("Mixed unknowns or signedness") {
     CHECK_THAT(session.eval("65'sbx >>> 66").integer(), exactlyEquals("65'sbx"_si));
     CHECK_THAT(session.eval("35'sbz >>> 66").integer(), exactlyEquals("35'sbz"_si));
 
+    // system functions with unknown arguments
+    CHECK(session.eval("$itor(3'bz1x)").real() == 2.0);
+    CHECK(session.eval("$clog2(3'bz1x)").integer() == 1);
+    CHECK(session.eval("$clog2(-3'sb1)").integer() == 3);
+    CHECK(session.eval("$itor(37'sh198765432d)").real() == -27793210579.0);
+    CHECK(session.eval("$itor(66'h1 << 65)").real() == std::pow(2, 65));
+
     NO_SESSION_ERRORS;
 }


### PR DESCRIPTION
1. Another problem for for arithmetic shift right is fixed. When shift amount >= bitWidth and msb is x or z, the signed result should be all x or all z.
```c++
    CHECK_THAT(session.eval("65'sbx >>> 66").integer(), exactlyEquals("65'sbx"_si));
    CHECK_THAT(session.eval("35'sbz >>> 66").integer(), exactlyEquals("35'sbz"_si));
```
Some redundant amount >= bitWidth checks are consolidated so the fix can be done in one place.

2. $itor system function silently truncated its argument at 32-bit width. I remember a commercial simulator did not, and [this link](https://verificationacademy.com/forums/systemverilog/itor-purpose-question) indicated another commercial simulator did not. SV-2017 standard is not precise about it. The [old SystemVerilog 3.1a standard](http://courses.eees.dei.unibo.it/LABMPHSENG/wp-content/uploads/2016/02/SystemVerilog_3.1a.pdf) mentioned $itor in casting chapter and implied that it was simply an old way of doing type casting `real(a).
```c++
    CHECK(session.eval("$itor(37'sh198765432d)").real() == -27793210579.0);
    CHECK(session.eval("$itor(66'h1 << 65)").real() == std::pow(2, 65));
```
I make $itor(a) to behave like real'(a). I am not sure all commercial simulators implement it in this way.

3. For $itor and $clog2, the argument should be 2-state type, and 4-state to 2-state type conversion is performed. In particular, 'z' is converted to '0' like 'x'.
```c++
    CHECK(session.eval("$itor(3'bz1x)").real() == 2.0);
    CHECK(session.eval("$clog2(3'bz1x)").integer() == 1);
```
This may be simulator implementation dependent and I am not sure all major simulators implement it in this way.