### PR TITLE
Recursive function calls parsing and evaluation

### DIFF
--- a/include/slang/binding/MiscExpressions.h
+++ b/include/slang/binding/MiscExpressions.h
@@ -113,6 +113,8 @@ private:
     const Expression* thisClass_;
     span<const Expression*> arguments_;
     LookupLocation lookupLocation;
+
+    mutable bool inRecursion = false;
 };
 
 /// Adapts a data type for use in an expression tree. This is for cases where both an expression

--- a/include/slang/numeric/ConstantValue.h
+++ b/include/slang/numeric/ConstantValue.h
@@ -99,6 +99,7 @@ public:
     SVInt& integer() & { return std::get<SVInt>(value); }
     const SVInt& integer() const& { return std::get<SVInt>(value); }
     SVInt integer() && { return std::get<SVInt>(std::move(value)); }
+    SVInt integer() const&& { return std::get<SVInt>(std::move(value)); }
 
     real_t real() const { return std::get<real_t>(value); }
     shortreal_t shortReal() const { return std::get<shortreal_t>(value); }
@@ -109,14 +110,17 @@ public:
     std::string& str() & { return std::get<std::string>(value); }
     const std::string& str() const& { return std::get<std::string>(value); }
     std::string str() && { return std::get<std::string>(std::move(value)); }
+    std::string str() const&& { return std::get<std::string>(std::move(value)); }
 
     Map& map() & { return std::get<Map>(value); }
     const Map& map() const& { return std::get<Map>(value); }
     Map map() && { return std::get<Map>(std::move(value)); }
+    Map map() const&& { return std::get<Map>(std::move(value)); }
 
     Queue& queue() & { return std::get<Queue>(value); }
     const Queue& queue() const& { return std::get<Queue>(value); }
     Queue queue() && { return std::get<Queue>(std::move(value)); }
+    Queue queue() const&& { return std::get<Queue>(std::move(value)); }
 
     ConstantValue getSlice(int32_t upper, int32_t lower, const ConstantValue& defaultValue) const;
 

--- a/include/slang/numeric/ConstantValue.h
+++ b/include/slang/numeric/ConstantValue.h
@@ -99,7 +99,6 @@ public:
     SVInt& integer() & { return std::get<SVInt>(value); }
     const SVInt& integer() const& { return std::get<SVInt>(value); }
     SVInt integer() && { return std::get<SVInt>(std::move(value)); }
-    SVInt integer() const&& { return std::get<SVInt>(std::move(value)); }
 
     real_t real() const { return std::get<real_t>(value); }
     shortreal_t shortReal() const { return std::get<shortreal_t>(value); }
@@ -110,17 +109,14 @@ public:
     std::string& str() & { return std::get<std::string>(value); }
     const std::string& str() const& { return std::get<std::string>(value); }
     std::string str() && { return std::get<std::string>(std::move(value)); }
-    std::string str() const&& { return std::get<std::string>(std::move(value)); }
 
     Map& map() & { return std::get<Map>(value); }
     const Map& map() const& { return std::get<Map>(value); }
     Map map() && { return std::get<Map>(std::move(value)); }
-    Map map() const&& { return std::get<Map>(std::move(value)); }
 
     Queue& queue() & { return std::get<Queue>(value); }
     const Queue& queue() const& { return std::get<Queue>(value); }
     Queue queue() && { return std::get<Queue>(std::move(value)); }
-    Queue queue() const&& { return std::get<Queue>(std::move(value)); }
 
     ConstantValue getSlice(int32_t upper, int32_t lower, const ConstantValue& defaultValue) const;
 

--- a/include/slang/util/Bag.h
+++ b/include/slang/util/Bag.h
@@ -32,7 +32,7 @@ public:
     /// (moving in the new item in the process).
     template<typename T>
     void set(T&& item) {
-        items[std::type_index(typeid(T))] = std::move(item);
+        items[std::type_index(typeid(T))] = std::forward<T>(item);
     }
 
     /// Gets an element of type T from the bag, if it exists.

--- a/include/slang/util/CopyPtr.h
+++ b/include/slang/util/CopyPtr.h
@@ -66,7 +66,7 @@ public:
         return *this;
     }
 
-    CopyPtr& operator=(CopyPtr&& other) {
+    CopyPtr& operator=(CopyPtr&& other) noexcept {
         if (this != &other) {
             delete ptr;
             ptr = std::exchange(other.ptr, nullptr);

--- a/include/slang/util/NotNull.h
+++ b/include/slang/util/NotNull.h
@@ -29,7 +29,7 @@ public:
     template<typename U, typename = std::enable_if_t<std::is_convertible<U, T>::value>>
     constexpr not_null(const not_null<U>& other) : not_null(other.get()) {}
 
-    not_null(not_null&& other) = default;
+    not_null(not_null&& other) noexcept = default;
     not_null(const not_null& other) = default;
     not_null& operator=(const not_null& other) = default;
 

--- a/source/binding/Expression.cpp
+++ b/source/binding/Expression.cpp
@@ -656,6 +656,17 @@ Expression& Expression::bindName(Compilation& compilation, const NameSyntax& syn
         return *compilation.emplace<DataTypeExpression>(resultType, syntax.sourceRange());
     }
 
+    // Recursive function call
+    if (invocation && symbol->kind == SymbolKind::Variable && result.selectors.empty()) {
+        auto scope = symbol->getParentScope();
+        if (scope && scope->asSymbol().kind == SymbolKind::Subroutine &&
+            scope->asSymbol().as<SubroutineSymbol>().returnValVar == symbol) {
+            ASSERT(scope->asSymbol().as<SubroutineSymbol>().subroutineKind ==
+                   SubroutineKind::Function);
+            symbol = &scope->asSymbol();
+        }
+    }
+
     Expression* expr;
     if (symbol->kind == SymbolKind::Subroutine) {
         expr = &CallExpression::fromLookup(compilation, &symbol->as<SubroutineSymbol>(), nullptr,

--- a/source/binding/MiscExpressions.cpp
+++ b/source/binding/MiscExpressions.cpp
@@ -561,6 +561,13 @@ bool CallExpression::verifyConstantImpl(EvalContext& context) const {
     if (!checkConstant(context, symbol, sourceRange))
         return false;
 
+    // Recursive function calls check body only once
+    // otherwise never finish until exceeding depth limit
+    if (inRecursion)
+        return true;
+    inRecursion = true;
+    auto guard = ScopeGuard([this] { inRecursion = false; });
+
     if (!context.pushFrame(symbol, sourceRange.start(), lookupLocation))
         return false;
 

--- a/tests/unittests/EvalTests.cpp
+++ b/tests/unittests/EvalTests.cpp
@@ -1877,3 +1877,19 @@ endfunction
 
     NO_SESSION_ERRORS;
 }
+
+TEST_CASE("Recursive function call") {
+    ScriptSession session;
+    session.eval(R"(
+function automatic integer factorial (input [31:0] operand);
+    if (operand >= 2)
+        factorial = factorial (operand - 1) * operand;
+    else
+        factorial = 1;
+endfunction: factorial
+)");
+
+    CHECK(session.eval("factorial(6)").integer() == 720);
+
+    NO_SESSION_ERRORS;
+}


### PR DESCRIPTION
1. Using the exact example on IEEE standard [13.4.2] page 327
```sv
  function automatic integer factorial (input [31:0] operand);
      if (operand >= 2)
          factorial = factorial (operand - 1) * operand;
      else
          factorial = 1;
  endfunction: factorial
```
slang failed to parse with
```sv
test.v:4:33: error: expression is not callable
          factorial = factorial (operand - 1) * operand;
                      ~~~~~~~~~ ^
```
The reason was that the symbol lookup found the implicit return variable "returnValVar" which is not a function. A solution is to replace the "returnValVar" with its parent function scope when a function call is expected and no selector exists.
```c++
    // Recursive function call
    if (invocation && symbol->kind == SymbolKind::Variable && result.selectors.empty()) {
        auto scope = symbol->getParentScope();
        if (scope && scope->asSymbol().kind == SymbolKind::Subroutine &&
            scope->asSymbol().as<SubroutineSymbol>().returnValVar == symbol) {
            ASSERT(scope->asSymbol().as<SubroutineSymbol>().subroutineKind ==
                   SubroutineKind::Function);
            symbol = &scope->asSymbol();
        }
    }
```
2. Then when a constant evaluation occurred on this function, slang failed with
```sv
test.v:2:30: error: constant evaluation exceeded maximum depth of 256 calls
  function automatic integer factorial (input [31:0] operand);
```
The problem was CallExpression::verifyConstantImpl never finished recursion until depth limit was reached. Adding a bool variable in CallExpression, and inside CallExpression::verifyConstantImpl
```c++
    // Recursive function calls check body only once
    // otherwise never finish until exceeding depth limit
    if (inRecursion)
        return true;
    inRecursion = true;
    auto guard = ScopeGuard([this] { inRecursion = false; });
```
fixes the problem. With the above two changes, evalImpl works well and evaluates a correct value.

3. When I use clang-tidy to check std::move problems on Bitstream.cpp
```sh
clang-tidy -p build -header-filter=.* -checks=*-move* source/binding/Bitstream.cpp
```
after I fixed problem in Bitstream.cpp, the header file option reports warnings like
```c++
include/slang/numeric/ConstantValue.h:102:54: warning: std::move of the const expression has no effect; remove std::move() [hicpp-move-const-arg]
    SVInt integer() const&& { return std::get<SVInt>(std::move(value)); }


include/slang/util/CopyPtr.h:69:14: warning: move assignment operators should be marked noexcept [hicpp-noexcept-move]
    CopyPtr& operator=(CopyPtr&& other) {
             ^
                                         noexcept 
```
The warnings make sense to me so I remove redundant const&& move constructors in ConstantValue.h, and add noexcept in   move constructors of CopyPtr.h and NotNull.h. If there is any concern, I will reverse these changes.

4. When I ran clang-tidy on Type.cpp, I got warnings like
```c++
include/slang/compilation/Compilation.h:106:5: warning: move constructors should be marked noexcept [hicpp-noexcept-move]
    Compilation(Compilation&& other);
    ^
                                     noexcept 

include/slang/util/Bag.h:35:45: warning: forwarding reference passed to std::move(), which may unexpectedly cause lvalues to be moved; use std::forward() instead [bugprone-move-forwarding-reference]
        items[std::type_index(typeid(T))] = std::move(item);
                                            ^~~~~~~~~
                                            std::forward<T>
```
I have not looked into them or made any changes. Please let me know if there is any value paying attention to these.