### PR TITLE
$11.4.14.4 Stream expression "with" range expression support

### DIFF
--- a/include/slang/binding/Bitstream.h
+++ b/include/slang/binding/Bitstream.h
@@ -48,12 +48,17 @@ public:
     /// Validates stream expression "with" expression range
     static bool validStreamWithRange(const Type& arrayType, WithRangeKind kind,
                                      optional<int32_t> left, optional<int32_t> right,
-                                     const BindContext& context, SourceRange leftRange,
-                                     SourceRange rightRange, bool isTarget = false);
+                                     std::variant<const BindContext*, EvalContext*> context,
+                                     SourceRange leftRange, SourceRange rightRange);
 
     /// Derives constant width from "with" expression range
     static optional<int32_t> withRangeWidth(WithRangeKind kind, optional<int32_t> left,
                                             optional<int32_t> right);
+
+    /// Evaluates stream with expression to a constant range
+    static optional<ConstantRange> evaluateWith(
+        const Type& arrayType, const StreamingConcatenationExpression::WithExpression& with,
+        EvalContext& context);
 
 private:
     Bitstream() = default;

--- a/include/slang/binding/Bitstream.h
+++ b/include/slang/binding/Bitstream.h
@@ -60,6 +60,10 @@ public:
         const Type& arrayType, const StreamingConcatenationExpression::WithExpression& with,
         EvalContext& context);
 
+    /// Resize a constant array value from [0:size-1] to [lower:upper]
+    static ConstantValue resizeToRange(ConstantValue&& value, ConstantRange range,
+                                       ConstantValue defaultValue, bool keepArray = false);
+
 private:
     Bitstream() = default;
 };

--- a/include/slang/binding/Bitstream.h
+++ b/include/slang/binding/Bitstream.h
@@ -6,18 +6,9 @@
 //------------------------------------------------------------------------------
 #pragma once
 
-#include <cstddef>
+#include "slang/binding/OperatorExpressions.h"
 
 namespace slang {
-
-class BindContext;
-class ConstantValue;
-class EvalContext;
-class Expression;
-class SourceLocation;
-class SourceRange;
-class StreamingConcatenationExpression;
-class Type;
 
 class Bitstream {
 public:
@@ -53,6 +44,16 @@ public:
     /// Performs constant evaluation of an assignment with a streaming concatenation as the target
     static ConstantValue evaluateTarget(const StreamingConcatenationExpression& lhs,
                                         const Expression& rhs, EvalContext& context);
+
+    /// Validates stream expression "with" expression range
+    static bool validStreamWithRange(const Type& arrayType, WithRangeKind kind,
+                                     optional<int32_t> left, optional<int32_t> right,
+                                     const BindContext& context, SourceRange leftRange,
+                                     SourceRange rightRange, bool isTarget = false);
+
+    /// Derives constant width from "with" expression range
+    static optional<int32_t> withRangeWidth(WithRangeKind kind, optional<int32_t> left,
+                                            optional<int32_t> right);
 
 private:
     Bitstream() = default;

--- a/include/slang/binding/OperatorExpressions.h
+++ b/include/slang/binding/OperatorExpressions.h
@@ -261,13 +261,13 @@ public:
 
     struct WithExpression {
         WithRangeKind kind;
-        Expression* left;
-        Expression* right;
-        optional<int32_t> width; // constant width
+        not_null<const Expression*> left;
+        const Expression* right;
+        optional<int32_t> width; // elaboration-time constant width
     };
     struct StreamExpression {
-        Expression* operand;
-        WithExpression* with;
+        not_null<const Expression*> operand;
+        const WithExpression* with;
     };
 
     StreamingConcatenationExpression(const Type& type, size_t sliceSize,

--- a/include/slang/binding/OperatorExpressions.h
+++ b/include/slang/binding/OperatorExpressions.h
@@ -248,6 +248,10 @@ private:
 
 struct StreamingConcatenationExpressionSyntax;
 
+#define RANGE(x) x(Simple) x(IndexedUp) x(IndexedDown) x(Bit)
+ENUM(WithRangeKind, RANGE); // RangeSelectionKind + Bit
+#undef RANGE
+
 /// Represents a streaming concatenation
 class StreamingConcatenationExpression : public Expression {
 public:
@@ -255,13 +259,24 @@ public:
     /// concatenation. Otherwise, it's a right-to-left concatenation.
     const size_t sliceSize;
 
+    struct WithExpression {
+        WithRangeKind kind;
+        Expression* left;
+        Expression* right;
+        optional<int32_t> width; // constant width
+    };
+    struct StreamExpression {
+        Expression* operand;
+        WithExpression* with;
+    };
+
     StreamingConcatenationExpression(const Type& type, size_t sliceSize,
-                                     span<const Expression* const> streams,
+                                     span<const StreamExpression* const> streams,
                                      SourceRange sourceRange) :
         Expression(ExpressionKind::Streaming, type, sourceRange),
         sliceSize(sliceSize), streams_(streams) {}
 
-    span<const Expression* const> streams() const { return streams_; }
+    span<const StreamExpression* const> streams() const { return streams_; }
 
     ConstantValue evalImpl(EvalContext& context) const;
     bool verifyConstantImpl(EvalContext& context) const;
@@ -276,15 +291,21 @@ public:
 
     template<typename TVisitor>
     void visitExprs(TVisitor&& visitor) const {
-        for (auto op : streams())
-            op->visit(visitor);
+        for (auto stream : streams()) {
+            stream->operand->visit(visitor);
+            if (stream->with) {
+                stream->with->left->visit(visitor);
+                if (stream->with->right)
+                    stream->with->right->visit(visitor);
+            }
+        }
     }
 
     bool isFixedSize() const;
     size_t bitstreamWidth() const;
 
 private:
-    span<const Expression* const> streams_;
+    span<const StreamExpression* const> streams_;
 };
 
 struct OpenRangeExpressionSyntax;

--- a/include/slang/binding/SelectExpressions.h
+++ b/include/slang/binding/SelectExpressions.h
@@ -90,9 +90,9 @@ public:
         right().visit(visitor);
     }
 
+    static ConstantRange getIndexedRange(bool up, int32_t l, int32_t r, bool littleEndian);
+
 private:
-    static ConstantRange getIndexedRange(RangeSelectionKind kind, int32_t l, int32_t r,
-                                         bool littleEndian);
     optional<ConstantRange> getFixedRange(EvalContext& context, const ConstantValue& cl,
                                           const ConstantValue& cr) const;
     optional<ConstantRange> getDynamicRange(EvalContext& context, const ConstantValue& cl,

--- a/include/slang/binding/SelectExpressions.h
+++ b/include/slang/binding/SelectExpressions.h
@@ -90,7 +90,8 @@ public:
         right().visit(visitor);
     }
 
-    static ConstantRange getIndexedRange(bool up, int32_t l, int32_t r, bool littleEndian);
+    static ConstantRange getIndexedRange(RangeSelectionKind kind, int32_t l, int32_t r,
+                                         bool littleEndian);
 
 private:
     optional<ConstantRange> getFixedRange(EvalContext& context, const ConstantValue& cl,

--- a/scripts/diagnostics.txt
+++ b/scripts/diagnostics.txt
@@ -325,6 +325,7 @@ error BadStreamSourceType "source type {} of streaming concatenation is not a bi
 error BadStreamContext "streaming operator can only be used in an assignment or bit-stream cast argument"
 error BadStreamSize "streaming operator target size {} does not fit source size {}"
 error BadStreamCast "streaming concatenation cannot be converted to type {}"
+error BadStreamWithType "stream expression type before 'with' must be a one-dimensional unpacked array"
 warning ignored-slice IgnoredSlice "slice size ignored for left-to-right streaming operator"
 
 subsystem Statements

--- a/scripts/diagnostics.txt
+++ b/scripts/diagnostics.txt
@@ -326,6 +326,7 @@ error BadStreamContext "streaming operator can only be used in an assignment or 
 error BadStreamSize "streaming operator target size {} does not fit source size {}"
 error BadStreamCast "streaming concatenation cannot be converted to type {}"
 error BadStreamWithType "stream expression type before 'with' must be a one-dimensional unpacked array"
+error BadStreamWithOrder "stream expression with 'with' cannot appear after unconstrained dynamically sized stream expression"
 warning ignored-slice IgnoredSlice "slice size ignored for left-to-right streaming operator"
 
 subsystem Statements

--- a/source/binding/Bitstream.cpp
+++ b/source/binding/Bitstream.cpp
@@ -359,7 +359,7 @@ static ConstantValue unpackBitstream(const Type& type, PackIterator& iter,
     if (type.isIntegral()) {
         auto cc = concatPacked(type.getBitWidth(), type.isFourState());
         cc.setSigned(type.isSigned());
-        return std::move(cc);
+        return cc;
     }
 
     if (type.isString()) {
@@ -654,7 +654,7 @@ ConstantValue Bitstream::reOrder(ConstantValue&& value, size_t sliceSize, size_t
         result.emplace_back(std::move(**iter++));
     sliceOrAppend(iter);
 
-    return std::move(result);
+    return result;
 }
 
 /// Performs unpack operation of streaming concatenation target on a bit-stream.
@@ -1009,7 +1009,7 @@ ConstantValue Bitstream::resizeToRange(ConstantValue&& value, ConstantRange rang
             sliceValue.insert(sliceValue.end(), old.cbegin() + lower, old.cbegin() + upper);
             sliceValue.insert(sliceValue.end(), more, defaultValue);
             ASSERT(sliceValue.size() == range.width());
-            return std::move(sliceValue);
+            return sliceValue;
         }
         else {
             ASSERT(value.isQueue());
@@ -1017,7 +1017,7 @@ ConstantValue Bitstream::resizeToRange(ConstantValue&& value, ConstantRange rang
             SVQueue sliceValue(old->cbegin() + lower, old->cbegin() + upper);
             sliceValue.insert(sliceValue.end(), more, defaultValue);
             ASSERT(sliceValue.size() == range.width());
-            return std::move(sliceValue);
+            return sliceValue;
         }
     }
     return std::move(value);

--- a/source/binding/Expression.cpp
+++ b/source/binding/Expression.cpp
@@ -304,7 +304,7 @@ bool Expression::verifyAssignable(const BindContext& context, bool isNonBlocking
         case ExpressionKind::Streaming: {
             auto& stream = as<StreamingConcatenationExpression>();
             for (auto op : stream.streams()) {
-                if (!op->verifyAssignable(context, isNonBlocking, location))
+                if (!op->operand->verifyAssignable(context, isNonBlocking, location))
                     return false;
             }
             return true;

--- a/source/binding/OperatorExpressions.cpp
+++ b/source/binding/OperatorExpressions.cpp
@@ -1696,7 +1696,7 @@ ConstantValue StreamingConcatenationExpression::evalImpl(EvalContext& context) c
                 else
                     cv = std::move(cv).at(size_t(range->left));
             }
-            else if (range->lower() > 0 || range->width() > cv.size()) {
+            else if (range->lower() > 0 || range->width() != cv.size()) {
                 auto upper = static_cast<uint32_t>(range->upper());
                 auto lower = static_cast<uint32_t>(range->lower());
                 auto size = static_cast<uint32_t>(cv.size());

--- a/source/binding/SelectExpressions.cpp
+++ b/source/binding/SelectExpressions.cpp
@@ -414,8 +414,8 @@ Expression& RangeSelectExpression::fromSyntax(Compilation& compilation, Expressi
                     return badExpr(compilation, result);
                 }
 
-                selectionRange =
-                    getIndexedRange(selectionKind, *index, *rv, valueRange.isLittleEndian());
+                selectionRange = getIndexedRange(selectionKind == RangeSelectionKind::IndexedUp,
+                                                 *index, *rv, valueRange.isLittleEndian());
 
                 if (!validateRange(selectionRange))
                     return badExpr(compilation, result);
@@ -424,8 +424,8 @@ Expression& RangeSelectExpression::fromSyntax(Compilation& compilation, Expressi
                 // Otherwise, the resulting range will start with the fixed lower bound of the type.
                 int32_t l = selectionKind == RangeSelectionKind::IndexedUp ? valueRange.lower()
                                                                            : valueRange.upper();
-                selectionRange =
-                    getIndexedRange(selectionKind, l, *rv, valueRange.isLittleEndian());
+                selectionRange = getIndexedRange(selectionKind == RangeSelectionKind::IndexedUp, l,
+                                                 *rv, valueRange.isLittleEndian());
             }
         }
 
@@ -587,7 +587,8 @@ optional<ConstantRange> RangeSelectExpression::getFixedRange(EvalContext& contex
 
         optional<int32_t> r = cr.integer().as<int32_t>();
         ASSERT(r);
-        result = getIndexedRange(selectionKind, *l, *r, valueRange.isLittleEndian());
+        result = getIndexedRange(selectionKind == RangeSelectionKind::IndexedUp, *l, *r,
+                                 valueRange.isLittleEndian());
     }
 
     if (!valueRange.containsPoint(result.left) || !valueRange.containsPoint(result.right)) {
@@ -639,15 +640,7 @@ optional<ConstantRange> RangeSelectExpression::getDynamicRange(EvalContext& cont
         result = { l, r };
     }
     else {
-        int32_t count = r - 1;
-        if (selectionKind == RangeSelectionKind::IndexedUp) {
-            result.left = l;
-            result.right = l + count;
-        }
-        else {
-            result.left = l - count;
-            result.right = l;
-        }
+        result = getIndexedRange(selectionKind == RangeSelectionKind::IndexedUp, l, r, false);
     }
 
     // Out of bounds ranges are allowed, we just issue a warning.
@@ -662,11 +655,11 @@ optional<ConstantRange> RangeSelectExpression::getDynamicRange(EvalContext& cont
     return result;
 }
 
-ConstantRange RangeSelectExpression::getIndexedRange(RangeSelectionKind kind, int32_t l, int32_t r,
+ConstantRange RangeSelectExpression::getIndexedRange(bool up, int32_t l, int32_t r,
                                                      bool littleEndian) {
     ConstantRange result;
     int32_t count = r - 1;
-    if (kind == RangeSelectionKind::IndexedUp) {
+    if (up) {
         auto upper = checkedAddS32(l, count);
         if (!upper)
             upper = INT32_MAX;

--- a/tests/unittests/ExpressionTests.cpp
+++ b/tests/unittests/ExpressionTests.cpp
@@ -1547,6 +1547,7 @@ TEST_CASE("Stream expression with") {
         { "byte b[]; int a = {<<3{b with[3:2]}};", diag::SelectEndianMismatch },
         { "byte b[], c[4]; assign {>>{b, {<<3{c with[b[0]:b[1]]}}}} = 9;",
           diag::BadStreamWithOrder },
+        { "int a[],b[],c[];bit d;assign {>>{b}}={<<{a with [2+:3],c,d}};", diag::BadStreamSize },
     };
 
     for (const auto& test : illegal)


### PR DESCRIPTION
This is to to complete a TODO item for stream operator support about "with" range expressions, whose details is described in [11.4.14.4]. The rules look similar to some other sections, but are not identical. For example, "[expression+:expression]" looks like indexed part-select, but the right operand of indexed part-select must be an elaboration-time constant, while "with" expressions do not require it. As a result, functions in RangeSelectExpression and  ElementSelectExpression cannot be directly called, but some of their code is either copy-pasted or referenced.
1. Inside class StreamingConcatenationExpression, struct StreamExpression and struct WithExpression are created to represent "with" expressions.
2. Bitstream.h adds 3 new helper functions:
```c++
    /// Validates stream expression "with" expression range
    static bool validStreamWithRange(const Type& arrayType, WithRangeKind kind,
                                     optional<int32_t> left, optional<int32_t> right,
                                     std::variant<const BindContext*, EvalContext*> context,
                                     SourceRange leftRange, SourceRange rightRange);

    /// Derives constant width from "with" expression range
    static optional<int32_t> withRangeWidth(WithRangeKind kind, optional<int32_t> left,
                                            optional<int32_t> right);

    /// Evaluates stream with expression to a constant range
    static optional<ConstantRange> evaluateWith(
        const Type& arrayType, const StreamingConcatenationExpression::WithExpression& with,
        EvalContext& context);
```
3. Size checks and constant evaluation of streaming concatenation are enhanced to take "with" into consideration. Unit tests are expanded for "with".