### PR TITLE
downgraded UnknownModule from error to warning, added ability to print to stderr

### DIFF
--- a/include/slang/util/OS.h
+++ b/include/slang/util/OS.h
@@ -62,6 +62,23 @@ public:
             fmt::vprint(format, fmt::make_format_args(args...));
         }
     }
+
+    /// Prints formatted text to stderr, handling Unicode conversions where necessary.
+    template<typename... Args>
+    static void error_print(string_view format, const Args&... args) {
+        fmt::vprint(stderr, format, fmt::make_format_args(args...));
+    }
+
+    /// Prints colored formatted text to stdout, handling Unicode conversions where necessary.
+    template<typename... Args>
+    static void error_print(const fmt::text_style& style, string_view format, const Args&... args) {
+        if (showColors) {
+            fmt::vprint(stderr, style, format, fmt::make_format_args(args...));
+        }
+        else {
+            fmt::vprint(stderr, format, fmt::make_format_args(args...));
+        }
+    }
 #endif
 
 private:

--- a/scripts/diagnostics.txt
+++ b/scripts/diagnostics.txt
@@ -209,7 +209,7 @@ error PortDeclDimensionsMismatch "dimensions of port '{}' do not match its decla
 error PortDeclInANSIModule "can't use port declaration in module with ANSI style port list"
 error UnusedPortDecl "port declaration '{}' does not match any port in the module's port list"
 error UnknownPackage "unknown package '{}'"
-error UnknownModule "unknown module '{}'"
+warning unknown-module UnknownModule "unknown module '{}'"
 error UnknownInterface "unknown interface '{}'"
 error MixingOrderedAndNamedPorts "mixing ordered and named port connections is not allowed"
 error DuplicateWildcardPortConnection "duplicate wildcard port connection"

--- a/tools/driver/driver.cpp
+++ b/tools/driver/driver.cpp
@@ -162,7 +162,7 @@ bool runCompiler(Compilation& compilation, const std::vector<std::string>& warni
 
 #ifndef FUZZ_TARGET
     std::string diagStr = client->getString();
-    OS::print("{}", diagStr);
+    OS::error_print("{}", diagStr);
 
     if (!quiet && !onlyParse) {
         if (diagStr.size() > 1)


### PR DESCRIPTION
The first commit is RE issue #332 (UnknownModule) (thank you - including the ports was a nice touch) & a piece of cake to decide yes/no. I'm hoping for yes (clearly), as unknown modules are common enough that it seems like a more appropriate default to have as a warning that can be upgraded (-Werror=unknown-module) to an error if needed.

To call the second commit half-baked is generous but I'm submitting it regardless as a working proof of concept in an attempt to encourage you to mull over possible divisions of output streams as opposed to everything going to stdout. As coded in the 2nd commit, it enables one to separate the --ast-json output written to stdout from other outputs such as diagStr (which, when written to stderr, allows one to pipe the --ast-json output (stdout) to a file, preserving the parseability of the json while seeing errors (when present) in the stderr stream)