### PR TITLE
added test/workaround hack for type parameter matching error

### DIFF
--- a/source/types/Type.cpp
+++ b/source/types/Type.cpp
@@ -540,6 +540,8 @@ bool Type::isAssignmentCompatible(const Type& rhs) const {
 
         auto& lv = l->as<VirtualInterfaceType>();
         auto& rv = r->as<VirtualInterfaceType>();
+        // the following check fails when disableInstanceCaching set from tools/driver astJsonFile flag
+        // (even though the getDefinition() values and parameters match)
         if (&lv.iface != &rv.iface)
             return false;
 

--- a/tests/regression/CMakeLists.txt
+++ b/tests/regression/CMakeLists.txt
@@ -1,2 +1,3 @@
 add_test(NAME regression_delayed_reg COMMAND driver "${CMAKE_CURRENT_LIST_DIR}/delayed_reg.v")
 add_test(NAME regression_wire_module COMMAND driver "${CMAKE_CURRENT_LIST_DIR}/wire_module.v")
+add_test(NAME regression_type_parameter COMMAND driver "${CMAKE_CURRENT_LIST_DIR}/type_parameter.v")

--- a/tests/regression/type_parameter.v
+++ b/tests/regression/type_parameter.v
@@ -1,0 +1,21 @@
+
+class uvm_resource_db #(type T);
+  static function bit read_by_name(inout T val);
+    return 1;
+  endfunction
+endclass
+
+interface clk_gen_if(
+    output bit       valid,
+    output bit       clk,
+    input      [7:0] out,
+    output bit [7:0] in
+);
+endinterface: clk_gen_if
+
+module env;
+    virtual clk_gen_if m_if;
+    function void connect_phase();
+        assert(uvm_resource_db#(virtual clk_gen_if)::read_by_name(m_if));
+    endfunction: connect_phase
+endmodule

--- a/tools/driver/driver.cpp
+++ b/tools/driver/driver.cpp
@@ -571,8 +571,10 @@ int driverMain(int argc, TArgs argv, bool suppressColorsStdout, bool suppressCol
         coptions.maxConstexprBacktrace = *maxConstexprBacktrace;
     if (errorLimit.has_value())
         coptions.errorLimit = *errorLimit * 2;
+#if 1
     if (astJsonFile)
         coptions.disableInstanceCaching = true;
+#endif
     if (onlyLint == true) {
         coptions.suppressUnused = true;
         coptions.lintMode = true;


### PR DESCRIPTION
I added a  file 'tests/regression/type_parameter.v' to demonstrate a compilation error
when using type parameters and generating JSON output. (this arises when
compiling uvm code in sv-tests, using the '--ast-json' flag)

When compiling the test by:
    ./bin/slang --ast-json xx.json ../tests/regression/type_parameter.v
it gets the error:
     error: value of type 'T' cannot be assigned to type 'clk_gen_if'
When compiling the unit test by running 'make test' in the regression build
directory, it compiles without error.

The error appears to be triggered by setting 'disableInstanceCaching' in tools/driver/driver.cpp,
which causes the 2 instantiations of T (one passed into the constructor and the other
in the function parameter type after specialization) to get differing types generated in the parser.

I expect the actual error is in ' Type::isAssignmentCompatible', but
am unsure what is the best fix.  Should this equality check be changed?
Alternatively, should the 'disableInstanceCaching' check be overridden
when instantiating type parameters?

Ideas?
Thanks!