### PR TITLE
Implement coverage control functions and predefined macros

### DIFF
--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -133,6 +133,7 @@ add_library(slangcompiler
 
     compilation/builtins/ArrayMethods.cpp
     compilation/builtins/ConversionFuncs.cpp
+    compilation/builtins/CoverageFuncs.cpp
     compilation/builtins/EnumMethods.cpp
     compilation/builtins/GateTypes.cpp
     compilation/builtins/MathFuncs.cpp

--- a/source/compilation/Compilation.cpp
+++ b/source/compilation/Compilation.cpp
@@ -25,6 +25,7 @@ namespace slang::Builtins {
 
 void registerArrayMethods(Compilation&);
 void registerConversionFuncs(Compilation&);
+void registerCoverageFuncs(Compilation&);
 void registerEnumMethods(Compilation&);
 void registerMathFuncs(Compilation&);
 void registerMiscSystemFuncs(Compilation&);
@@ -141,6 +142,7 @@ Compilation::Compilation(const Bag& options) :
     // Register all system tasks, functions, and methods.
     Builtins::registerArrayMethods(*this);
     Builtins::registerConversionFuncs(*this);
+    Builtins::registerCoverageFuncs(*this);
     Builtins::registerEnumMethods(*this);
     Builtins::registerMathFuncs(*this);
     Builtins::registerMiscSystemFuncs(*this);

--- a/source/compilation/builtins/CoverageFuncs.cpp
+++ b/source/compilation/builtins/CoverageFuncs.cpp
@@ -1,0 +1,116 @@
+//------------------------------------------------------------------------------
+// CoverageFuncs.cpp
+// Coverage control functions
+//
+// File is under the MIT license; see LICENSE for details
+//------------------------------------------------------------------------------
+#include "slang/binding/SystemSubroutine.h"
+#include "slang/compilation/Compilation.h"
+#include "slang/diagnostics/DeclarationsDiags.h"
+#include "slang/diagnostics/SysFuncsDiags.h"
+
+namespace slang::Builtins {
+
+class CoverageControlFunc : public SimpleSystemSubroutine {
+public:
+    CoverageControlFunc(Compilation& comp) : SimpleSystemSubroutine("$coverage_control", SubroutineKind::Function, 4,
+       { &comp.getIntType(), &comp.getIntType(), &comp.getIntType(), &comp.getStringType() }, comp.getIntType(), false) {};
+
+    ConstantValue eval(EvalContext&, const Args&,
+                       const CallExpression::SystemCallInfo&) const final {
+        return nullptr;
+    }
+};
+
+class CoverageGetMaxFunc : public SimpleSystemSubroutine {
+public:
+    CoverageGetMaxFunc(Compilation& comp) : SimpleSystemSubroutine("$coverage_get_max", SubroutineKind::Function, 3,
+       { &comp.getIntType(), &comp.getIntType(), &comp.getStringType() }, comp.getIntType(), false) {};
+
+    ConstantValue eval(EvalContext&, const Args&,
+                       const CallExpression::SystemCallInfo&) const final {
+        return nullptr;
+    }
+};
+
+class CoverageGet : public SimpleSystemSubroutine {
+public:
+    CoverageGet(Compilation& comp) : SimpleSystemSubroutine("$coverage_get", SubroutineKind::Function, 3,
+       { &comp.getIntType(), &comp.getIntType(), &comp.getStringType() }, comp.getIntType(), false) {};
+
+    ConstantValue eval(EvalContext&, const Args&,
+                       const CallExpression::SystemCallInfo&) const final {
+        return nullptr;
+    }
+};
+
+class CoverageMerge : public SimpleSystemSubroutine {
+public:
+    CoverageMerge(Compilation& comp) : SimpleSystemSubroutine("$coverage_merge", SubroutineKind::Function, 2,
+       { &comp.getIntType(), &comp.getStringType() }, comp.getIntType(), false) {};
+
+    ConstantValue eval(EvalContext&, const Args&,
+                       const CallExpression::SystemCallInfo&) const final {
+        return nullptr;
+    }
+};
+
+class CoverageSave : public SimpleSystemSubroutine {
+public:
+    CoverageSave(Compilation& comp) : SimpleSystemSubroutine("$coverage_save", SubroutineKind::Function, 2,
+       { &comp.getIntType(), &comp.getStringType() }, comp.getIntType(), false) {};
+
+    ConstantValue eval(EvalContext&, const Args&,
+                       const CallExpression::SystemCallInfo&) const final {
+        return nullptr;
+    }
+};
+
+class GetCoverage : public SimpleSystemSubroutine {
+public:
+    GetCoverage(Compilation& comp) : SimpleSystemSubroutine("$get_coverage", SubroutineKind::Function, 0,
+        {}, comp.getRealType(), false) {};
+
+    ConstantValue eval(EvalContext&, const Args&,
+                       const CallExpression::SystemCallInfo&) const final {
+        return nullptr;
+    }
+};
+
+class SetCoverageDbName : public SimpleSystemSubroutine {
+public:
+    SetCoverageDbName(Compilation& comp) : SimpleSystemSubroutine("$set_coverage_db_name", SubroutineKind::Function, 1,
+        { &comp.getStringType() }, comp.getVoidType(), false) {};
+
+    ConstantValue eval(EvalContext&, const Args&,
+                       const CallExpression::SystemCallInfo&) const final {
+        return nullptr;
+    }
+};
+
+class LoadCoverageDb : public SimpleSystemSubroutine {
+public:
+    LoadCoverageDb(Compilation& comp) : SimpleSystemSubroutine("$load_coverage_db", SubroutineKind::Function, 1,
+        { &comp.getStringType() }, comp.getVoidType(), false) {};
+
+    ConstantValue eval(EvalContext&, const Args&,
+                       const CallExpression::SystemCallInfo&) const final {
+        return nullptr;
+    }
+};
+
+void registerCoverageFuncs(Compilation& c) {
+#define REGISTER(name, ...) \
+    c.addSystemSubroutine(std::make_unique<name>(__VA_ARGS__))
+    REGISTER(CoverageControlFunc, c);
+    REGISTER(CoverageGetMaxFunc, c);
+    REGISTER(CoverageGet, c);
+    REGISTER(CoverageMerge, c);
+    REGISTER(CoverageSave, c);
+    REGISTER(GetCoverage, c);
+    REGISTER(SetCoverageDbName, c);
+    REGISTER(LoadCoverageDb, c);
+#undef REGISTER
+}
+
+} // namespace slang::Builtins

--- a/source/compilation/builtins/CoverageFuncs.cpp
+++ b/source/compilation/builtins/CoverageFuncs.cpp
@@ -31,11 +31,9 @@ public:
         if (argIndex >= argTypes.size())
             return SystemSubroutine::bindArgument(argIndex, *ctx, syntax, args);
 
-        if (argIndex == nameOrHierIndex) {
-            if (NameSyntax::isKind(syntax.kind)) {
-                return HierarchicalReferenceExpression::fromSyntax(context.getCompilation(),
-                    syntax.as<NameSyntax>(), context);
-            }
+        if (argIndex == nameOrHierIndex && NameSyntax::isKind(syntax.kind)) {
+            return HierarchicalReferenceExpression::fromSyntax(context.getCompilation(),
+               syntax.as<NameSyntax>(), context);
         }
 
         return Expression::bindArgument(*argTypes[argIndex], ArgumentDirection::In, syntax, *ctx);

--- a/source/compilation/builtins/CoverageFuncs.cpp
+++ b/source/compilation/builtins/CoverageFuncs.cpp
@@ -27,17 +27,15 @@ public:
 
     virtual const Expression& bindArgument(size_t argIndex, const BindContext& context,
                                            const ExpressionSyntax& syntax, const Args& args) const final {
-        const BindContext* ctx = &context;
-
         if (argIndex >= argTypes.size())
-            return SystemSubroutine::bindArgument(argIndex, *ctx, syntax, args);
+            return SystemSubroutine::bindArgument(argIndex, context, syntax, args);
 
         if (argIndex == nameOrHierIndex && NameSyntax::isKind(syntax.kind)) {
             return HierarchicalReferenceExpression::fromSyntax(context.getCompilation(),
                syntax.as<NameSyntax>(), context);
         }
 
-        return Expression::bindArgument(*argTypes[argIndex], ArgumentDirection::In, syntax, *ctx);
+        return Expression::bindArgument(*argTypes[argIndex], ArgumentDirection::In, syntax, context);
     }
 
     const Type& checkArguments(const BindContext& context, const Args& args,
@@ -46,7 +44,7 @@ public:
         if (!checkArgCount(context, false, args, range, requiredArgs, argTypes.size()))
             return comp.getErrorType();
 
-        auto& arg = args[nameOrHierIndex];
+        auto arg = args[nameOrHierIndex];
         if (arg->kind == ExpressionKind::HierarchicalReference) {
             auto& sym = *arg->as<HierarchicalReferenceExpression>().symbol;
             if (sym.isValue()) {
@@ -58,7 +56,7 @@ public:
                 }
             } else if (sym.kind != SymbolKind::Instance || !sym.as<InstanceSymbol>().isModule()) {
                 if (!context.scope->isUninstantiated())
-                    context.addDiag(diag::ExpectedModuleName, arg->sourceRange);
+                    context.addDiag(diag::ExpectedModuleInstance, arg->sourceRange);
                 return comp.getErrorType();
             }
         }

--- a/source/compilation/builtins/CoverageFuncs.cpp
+++ b/source/compilation/builtins/CoverageFuncs.cpp
@@ -51,7 +51,7 @@ public:
             auto& sym = *arg->as<HierarchicalReferenceExpression>().symbol;
             if (sym.isValue()) {
                 auto& type = sym.as<ValueSymbol>().getType();
-                if (!type.canBeStringLike()) {
+                if (!type.isString()) {
                     context.addDiag(diag::BadSystemSubroutineArg, arg->sourceRange)
                         << type << kindStr();
                     return comp.getErrorType();

--- a/source/compilation/builtins/CoverageFuncs.cpp
+++ b/source/compilation/builtins/CoverageFuncs.cpp
@@ -4,112 +4,87 @@
 //
 // File is under the MIT license; see LICENSE for details
 //------------------------------------------------------------------------------
+#include "slang/binding/MiscExpressions.h"
 #include "slang/binding/SystemSubroutine.h"
 #include "slang/compilation/Compilation.h"
-#include "slang/diagnostics/DeclarationsDiags.h"
 #include "slang/diagnostics/SysFuncsDiags.h"
+#include "slang/syntax/AllSyntax.h"
 
 namespace slang::Builtins {
 
-class CoverageControlFunc : public SimpleSystemSubroutine {
+class CoverageNameOrHierFunc : public SystemSubroutine {
 public:
-    CoverageControlFunc(Compilation& comp) : SimpleSystemSubroutine("$coverage_control", SubroutineKind::Function, 4,
-       { &comp.getIntType(), &comp.getIntType(), &comp.getIntType(), &comp.getStringType() }, comp.getIntType(), false) {};
+
+    CoverageNameOrHierFunc(const std::string& name, const Type& returnType, unsigned int nameOrHierIndex,
+                           size_t requiredArgs = 0, const std::vector<const Type*>& argTypes = {}) :
+        SystemSubroutine(name, SubroutineKind::Function),
+        argTypes(argTypes), returnType(&returnType),
+        nameOrHierIndex(nameOrHierIndex), requiredArgs(requiredArgs) {
+        ASSERT(requiredArgs <= argTypes.size());
+        ASSERT(nameOrHierIndex <= argTypes.size());
+    };
+
+    virtual const Expression& bindArgument(size_t argIndex, const BindContext& context,
+                                           const ExpressionSyntax& syntax, const Args& args) const final {
+        const BindContext* ctx = &context;
+
+        if (argIndex >= argTypes.size())
+            return SystemSubroutine::bindArgument(argIndex, *ctx, syntax, args);
+
+        if (argIndex == nameOrHierIndex) {
+            if (NameSyntax::isKind(syntax.kind)) {
+                return HierarchicalReferenceExpression::fromSyntax(context.getCompilation(),
+                    syntax.as<NameSyntax>(), context);
+            }
+        }
+
+        return Expression::bindArgument(*argTypes[argIndex], ArgumentDirection::In, syntax, *ctx);
+    }
+
+    const Type& checkArguments(const BindContext& context, const Args& args,
+                               SourceRange range, const Expression*) const {
+        auto& comp = context.getCompilation();
+        if (!checkArgCount(context, false, args, range, requiredArgs, argTypes.size()))
+            return comp.getErrorType();
+
+        return *returnType;
+    }
 
     ConstantValue eval(EvalContext&, const Args&,
                        const CallExpression::SystemCallInfo&) const final {
         return nullptr;
     }
-};
 
-class CoverageGetMaxFunc : public SimpleSystemSubroutine {
-public:
-    CoverageGetMaxFunc(Compilation& comp) : SimpleSystemSubroutine("$coverage_get_max", SubroutineKind::Function, 3,
-       { &comp.getIntType(), &comp.getIntType(), &comp.getStringType() }, comp.getIntType(), false) {};
-
-    ConstantValue eval(EvalContext&, const Args&,
-                       const CallExpression::SystemCallInfo&) const final {
-        return nullptr;
+    bool verifyConstant(EvalContext& context, const Args&, SourceRange range) const final {
+        return notConst(context, range);
     }
-};
 
-class CoverageGet : public SimpleSystemSubroutine {
-public:
-    CoverageGet(Compilation& comp) : SimpleSystemSubroutine("$coverage_get", SubroutineKind::Function, 3,
-       { &comp.getIntType(), &comp.getIntType(), &comp.getStringType() }, comp.getIntType(), false) {};
-
-    ConstantValue eval(EvalContext&, const Args&,
-                       const CallExpression::SystemCallInfo&) const final {
-        return nullptr;
-    }
-};
-
-class CoverageMerge : public SimpleSystemSubroutine {
-public:
-    CoverageMerge(Compilation& comp) : SimpleSystemSubroutine("$coverage_merge", SubroutineKind::Function, 2,
-       { &comp.getIntType(), &comp.getStringType() }, comp.getIntType(), false) {};
-
-    ConstantValue eval(EvalContext&, const Args&,
-                       const CallExpression::SystemCallInfo&) const final {
-        return nullptr;
-    }
-};
-
-class CoverageSave : public SimpleSystemSubroutine {
-public:
-    CoverageSave(Compilation& comp) : SimpleSystemSubroutine("$coverage_save", SubroutineKind::Function, 2,
-       { &comp.getIntType(), &comp.getStringType() }, comp.getIntType(), false) {};
-
-    ConstantValue eval(EvalContext&, const Args&,
-                       const CallExpression::SystemCallInfo&) const final {
-        return nullptr;
-    }
-};
-
-class GetCoverage : public SimpleSystemSubroutine {
-public:
-    GetCoverage(Compilation& comp) : SimpleSystemSubroutine("$get_coverage", SubroutineKind::Function, 0,
-        {}, comp.getRealType(), false) {};
-
-    ConstantValue eval(EvalContext&, const Args&,
-                       const CallExpression::SystemCallInfo&) const final {
-        return nullptr;
-    }
-};
-
-class SetCoverageDbName : public SimpleSystemSubroutine {
-public:
-    SetCoverageDbName(Compilation& comp) : SimpleSystemSubroutine("$set_coverage_db_name", SubroutineKind::Function, 1,
-        { &comp.getStringType() }, comp.getVoidType(), false) {};
-
-    ConstantValue eval(EvalContext&, const Args&,
-                       const CallExpression::SystemCallInfo&) const final {
-        return nullptr;
-    }
-};
-
-class LoadCoverageDb : public SimpleSystemSubroutine {
-public:
-    LoadCoverageDb(Compilation& comp) : SimpleSystemSubroutine("$load_coverage_db", SubroutineKind::Function, 1,
-        { &comp.getStringType() }, comp.getVoidType(), false) {};
-
-    ConstantValue eval(EvalContext&, const Args&,
-                       const CallExpression::SystemCallInfo&) const final {
-        return nullptr;
-    }
+private:
+    std::vector<const Type*> argTypes;
+    const Type* returnType;
+    unsigned int nameOrHierIndex;
+    size_t requiredArgs;
 };
 
 void registerCoverageFuncs(Compilation& c) {
 #define REGISTER(name, ...) \
     c.addSystemSubroutine(std::make_unique<name>(__VA_ARGS__))
-    REGISTER(CoverageControlFunc, c);
-    REGISTER(CoverageGetMaxFunc, c);
-    REGISTER(CoverageGet, c);
-    REGISTER(CoverageMerge, c);
-    REGISTER(CoverageSave, c);
-    REGISTER(GetCoverage, c);
-    REGISTER(SetCoverageDbName, c);
-    REGISTER(LoadCoverageDb, c);
+    REGISTER(CoverageNameOrHierFunc, "$coverage_control", c.getIntType(), 3, 4,
+             std::vector{ &c.getIntType(), &c.getIntType(), &c.getIntType(), &c.getStringType() });
+    REGISTER(CoverageNameOrHierFunc, "$coverage_get_max", c.getIntType(), 2, 3,
+             std::vector{ &c.getIntType(), &c.getIntType(), &c.getStringType() });
+
+    REGISTER(NonConstantFunction, "$coverage_get", c.getIntType(), 3,
+             std::vector{ &c.getIntType(), &c.getIntType(), &c.getIntType() });
+    REGISTER(NonConstantFunction, "$coverage_merge", c.getIntType(), 2,
+             std::vector{ &c.getIntType(), &c.getStringType() });
+    REGISTER(NonConstantFunction, "$coverage_save", c.getIntType(), 2,
+             std::vector{ &c.getIntType(), &c.getStringType() });
+    REGISTER(NonConstantFunction, "$get_coverage", c.getIntType());
+    REGISTER(NonConstantFunction, "$set_coverage_db_name", c.getVoidType(), 1,
+             std::vector{ &c.getStringType() });
+    REGISTER(NonConstantFunction, "$load_coverage_db", c.getVoidType(), 1,
+             std::vector{ &c.getStringType() });
 #undef REGISTER
 }
 

--- a/source/parsing/Preprocessor.cpp
+++ b/source/parsing/Preprocessor.cpp
@@ -87,6 +87,22 @@ void Preprocessor::undefineAll() {
               options.predefineSource);
     predefine("__slang_rev__ "s + std::string(VersionInfo::getRevision()), options.predefineSource);
 
+    predefine("SV_COV_START 0"s,      options.predefineSource);
+    predefine("SV_COV_STOP 1"s,       options.predefineSource);
+    predefine("SV_COV_RESET 2"s,      options.predefineSource);
+    predefine("SV_COV_CHECK 3"s,      options.predefineSource);
+    predefine("SV_COV_MODULE 10"s,    options.predefineSource);
+    predefine("SV_COV_HIER 11"s,      options.predefineSource);
+    predefine("SV_COV_ASSERTION 20"s, options.predefineSource);
+    predefine("SV_COV_FSM_STATE 21"s, options.predefineSource);
+    predefine("SV_COV_STATEMENT 22"s, options.predefineSource);
+    predefine("SV_COV_TOGGLE 23"s,    options.predefineSource);
+    predefine("SV_COV_OVERFLOW -2"s,  options.predefineSource);
+    predefine("SV_COV_ERROR -1"s,     options.predefineSource);
+    predefine("SV_COV_NOCOV 0"s,      options.predefineSource);
+    predefine("SV_COV_OK 1"s,         options.predefineSource);
+    predefine("SV_COV_PARTIAL 2"s,    options.predefineSource);
+
     // All macros we've defined thus far should be marked as built-ins so they can't be undefined.
     for (auto& [name, macro] : macros)
         macro.builtIn = true;

--- a/tests/unittests/PreprocessorTests.cpp
+++ b/tests/unittests/PreprocessorTests.cpp
@@ -1098,6 +1098,34 @@ TEST_CASE("Invalid `line directive") {
     CHECK(diagnostics[0].code == diag::InvalidLineDirectiveLevel);
 }
 
+TEST_CASE("Coverage macros") {
+    PreprocessorOptions ppOptions;
+    Bag options;
+    options.set(ppOptions);
+    Preprocessor pp(getSourceManager(), alloc, diagnostics, options);
+
+    CHECK(pp.isDefined("SV_COV_START"));
+    CHECK(pp.isDefined("SV_COV_STOP"));
+    CHECK(pp.isDefined("SV_COV_RESET"));
+    CHECK(pp.isDefined("SV_COV_CHECK"));
+    CHECK(pp.isDefined("SV_COV_MODULE"));
+    CHECK(pp.isDefined("SV_COV_HIER"));
+    CHECK(pp.isDefined("SV_COV_ASSERTION"));
+    CHECK(pp.isDefined("SV_COV_FSM_STATE"));
+    CHECK(pp.isDefined("SV_COV_STATEMENT"));
+    CHECK(pp.isDefined("SV_COV_TOGGLE"));
+    CHECK(pp.isDefined("SV_COV_OVERFLOW"));
+    CHECK(pp.isDefined("SV_COV_ERROR"));
+    CHECK(pp.isDefined("SV_COV_NOCOV"));
+    CHECK(pp.isDefined("SV_COV_OK"));
+    CHECK(pp.isDefined("SV_COV_PARTIAL"));
+
+    auto& text = "`SV_COV_OK\n";
+    Token token = lexToken(text);
+    REQUIRE(token.kind == TokenKind::IntegerLiteral);
+    CHECK_DIAGNOSTICS_EMPTY;
+}
+
 TEST_CASE("undef Directive") {
     auto& text = "`define FOO 45\n"
                  "`undef FOO\n"
@@ -1337,7 +1365,7 @@ TEST_CASE("Preprocessor API") {
     CHECK(!pp.isDefined("BUZ"));
 
     pp.setKeywordVersion(KeywordVersion::v1364_2001);
-    CHECK(pp.getDefinedMacros().size() == 5);
+    CHECK(pp.getDefinedMacros().size() == 20);
 }
 
 TEST_CASE("Undef builtin") {

--- a/tests/unittests/SystemFuncTests.cpp
+++ b/tests/unittests/SystemFuncTests.cpp
@@ -901,22 +901,33 @@ module A(input logic x, input logic y);
 endmodule
 
 module top;
+    string modName = "A";
+    string hierString = "top.a";
     string bad;
     logic x, y;
 
     A a(.*);
+    A b(.*);
 
     initial begin
         int unsigned result, max;
         real r;
-        result = $coverage_control(`SV_COV_RESET, `SV_COV_TOGGLE, `SV_COV_MODULE, "A", "B");
+        result = $coverage_control(`SV_COV_RESET, `SV_COV_TOGGLE, `SV_COV_MODULE, "A", "B"); // too many args
+        result = $coverage_control(`SV_COV_RESET, `SV_COV_TOGGLE, `SV_COV_MODULE, 4);        // bad type
+        result = $coverage_control(`SV_COV_RESET, `SV_COV_TOGGLE, `SV_COV_MODULE, modName);
+        result = $coverage_control(`SV_COV_RESET, `SV_COV_TOGGLE, `SV_COV_MODULE, hierString);
         result = $coverage_control(`SV_COV_RESET, `SV_COV_TOGGLE, `SV_COV_MODULE, "A");
-        result = $coverage_control(`SV_COV_RESET, `SV_COV_TOGGLE, `SV_COV_MODULE, 4);
+        result = $coverage_control(`SV_COV_RESET, `SV_COV_TOGGLE, `SV_COV_MODULE, "B");
+        result = $coverage_control(`SV_COV_RESET, `SV_COV_TOGGLE, `SV_COV_MODULE, "top.a");
+        result = $coverage_control(`SV_COV_RESET, `SV_COV_TOGGLE, `SV_COV_MODULE, "top.b");
+        result = $coverage_control(`SV_COV_RESET, `SV_COV_TOGGLE, `SV_COV_MODULE, "top.c");
         result = $coverage_control(`SV_COV_RESET, `SV_COV_TOGGLE, `SV_COV_MODULE, top.a);
         result = $coverage_control(`SV_COV_RESET, `SV_COV_TOGGLE, `SV_COV_MODULE, top.b);
-        bad = $coverage_get_max(23, 10, "top");
-        result = $coverage_get_max(23, 10, "top");
-        result = $coverage_get(23, 10, "top");
+        result = $coverage_control(`SV_COV_RESET, `SV_COV_TOGGLE, `SV_COV_MODULE, top.c);   // bad hierarchy
+        result = $coverage_control(`SV_COV_RESET, `SV_COV_TOGGLE, `SV_COV_MODULE, d);   // bad hierarchy
+        bad = $coverage_get_max(23, 10, "top"); // bad return type
+        result = $coverage_get_max(23, 10, a);
+        result = $coverage_get(23, 10, b);
         result = $coverage_merge(23, "merged_cov");
         result = $coverage_save(23, "merged_cov");
         r = $get_coverage();
@@ -931,10 +942,11 @@ endmodule
     compilation.addSyntaxTree(tree);
 
     auto& diags = compilation.getAllDiagnostics();
-    REQUIRE(diags.size() == 5);
+    REQUIRE(diags.size() == 6);
     CHECK(diags[0].code == diag::UndefineBuiltinDirective);
     CHECK(diags[1].code == diag::TooManyArguments);
     CHECK(diags[2].code == diag::NoImplicitConversion);
     CHECK(diags[3].code == diag::CouldNotResolveHierarchicalPath);
-    CHECK(diags[4].code == diag::NoImplicitConversion);
+    CHECK(diags[4].code == diag::UndeclaredIdentifier);
+    CHECK(diags[5].code == diag::NoImplicitConversion);
 }

--- a/tests/unittests/SystemFuncTests.cpp
+++ b/tests/unittests/SystemFuncTests.cpp
@@ -897,14 +897,23 @@ TEST_CASE("Coverage system functions") {
     auto tree = SyntaxTree::fromText(R"(
 `undef SV_COV_START
 
+module A(input logic x, input logic y);
+endmodule
+
 module top;
     string bad;
+    logic x, y;
+
+    A a(.*);
 
     initial begin
         int unsigned result, max;
         real r;
-        result = $coverage_control(`SV_COV_RESET, `SV_COV_TOGGLE, `SV_COV_MODULE, "a", "b");
-        result = $coverage_control(`SV_COV_RESET, `SV_COV_TOGGLE, `SV_COV_MODULE, "a");
+        result = $coverage_control(`SV_COV_RESET, `SV_COV_TOGGLE, `SV_COV_MODULE, "A", "B");
+        result = $coverage_control(`SV_COV_RESET, `SV_COV_TOGGLE, `SV_COV_MODULE, "A");
+        result = $coverage_control(`SV_COV_RESET, `SV_COV_TOGGLE, `SV_COV_MODULE, 4);
+        result = $coverage_control(`SV_COV_RESET, `SV_COV_TOGGLE, `SV_COV_MODULE, top.a);
+        result = $coverage_control(`SV_COV_RESET, `SV_COV_TOGGLE, `SV_COV_MODULE, top.b);
         bad = $coverage_get_max(23, 10, "top");
         result = $coverage_get_max(23, 10, "top");
         result = $coverage_get(23, 10, "top");
@@ -922,8 +931,10 @@ endmodule
     compilation.addSyntaxTree(tree);
 
     auto& diags = compilation.getAllDiagnostics();
-    REQUIRE(diags.size() == 3);
+    REQUIRE(diags.size() == 5);
     CHECK(diags[0].code == diag::UndefineBuiltinDirective);
     CHECK(diags[1].code == diag::TooManyArguments);
     CHECK(diags[2].code == diag::NoImplicitConversion);
+    CHECK(diags[3].code == diag::CouldNotResolveHierarchicalPath);
+    CHECK(diags[4].code == diag::NoImplicitConversion);
 }

--- a/tests/unittests/SystemFuncTests.cpp
+++ b/tests/unittests/SystemFuncTests.cpp
@@ -900,6 +900,9 @@ TEST_CASE("Coverage system functions") {
 module A(input logic x, input logic y);
 endmodule
 
+interface Z(input logic x);
+endinterface
+
 module top;
     string modName = "A";
     string hierString = "top.a";
@@ -908,6 +911,7 @@ module top;
 
     A a(.*);
     A b(.*);
+    Z z(.*);
 
     initial begin
         int unsigned result, max;
@@ -924,7 +928,8 @@ module top;
         result = $coverage_control(`SV_COV_RESET, `SV_COV_TOGGLE, `SV_COV_MODULE, top.a);
         result = $coverage_control(`SV_COV_RESET, `SV_COV_TOGGLE, `SV_COV_MODULE, top.b);
         result = $coverage_control(`SV_COV_RESET, `SV_COV_TOGGLE, `SV_COV_MODULE, top.c);   // bad hierarchy
-        result = $coverage_control(`SV_COV_RESET, `SV_COV_TOGGLE, `SV_COV_MODULE, d);   // bad hierarchy
+        result = $coverage_control(`SV_COV_RESET, `SV_COV_TOGGLE, `SV_COV_MODULE, d);       // undeclared
+        result = $coverage_control(`SV_COV_RESET, `SV_COV_TOGGLE, `SV_COV_MODULE, z);       // not a module instance
         bad = $coverage_get_max(23, 10, "top"); // bad return type
         result = $coverage_get_max(23, 10, a);
         result = $coverage_get(23, 10, b);
@@ -942,11 +947,12 @@ endmodule
     compilation.addSyntaxTree(tree);
 
     auto& diags = compilation.getAllDiagnostics();
-    REQUIRE(diags.size() == 6);
+    REQUIRE(diags.size() == 7);
     CHECK(diags[0].code == diag::UndefineBuiltinDirective);
     CHECK(diags[1].code == diag::TooManyArguments);
     CHECK(diags[2].code == diag::NoImplicitConversion);
     CHECK(diags[3].code == diag::CouldNotResolveHierarchicalPath);
     CHECK(diags[4].code == diag::UndeclaredIdentifier);
-    CHECK(diags[5].code == diag::NoImplicitConversion);
+    CHECK(diags[5].code == diag::ExpectedModuleInstance);
+    CHECK(diags[6].code == diag::NoImplicitConversion);
 }


### PR DESCRIPTION
This PR adds parsing support for the coverage control functions and coverage macros specified in 20.14, 40.3.1, and 40.3.2