### PR TITLE
Implement PLA tasks

### DIFF
--- a/scripts/diagnostics.txt
+++ b/scripts/diagnostics.txt
@@ -703,6 +703,7 @@ error SampledValueLocalVar "local variables cannot be used in sampled value syst
 error SampledValueMatched "'matched' method cannot be used in sampled value system functions"
 error GlobalSampledValueAssertionExpr "global clocking future sampled value functions may be invoked only in sequence and property expressions"
 error SequenceMethodLocalVar "local variables can only be passed to sequences on which '{}' is called if they are the entire argument and not a sub-expression"
+error PlaRangeInAscendingOrder "Must specify dimensions in ascending order for PLA input type {}"
 warning format-real FormatRealInt "real value provided for integer format specifier '%{}'"
 warning finish-num BadFinishNum "finish argument must have value of 0, 1, or 2"
 warning missing-format MissingFormatSpecifier "missing format specifier"

--- a/scripts/diagnostics.txt
+++ b/scripts/diagnostics.txt
@@ -703,7 +703,7 @@ error SampledValueLocalVar "local variables cannot be used in sampled value syst
 error SampledValueMatched "'matched' method cannot be used in sampled value system functions"
 error GlobalSampledValueAssertionExpr "global clocking future sampled value functions may be invoked only in sequence and property expressions"
 error SequenceMethodLocalVar "local variables can only be passed to sequences on which '{}' is called if they are the entire argument and not a sub-expression"
-error PlaRangeInAscendingOrder "Must specify dimensions in ascending order for PLA input type {}"
+error PlaRangeInAscendingOrder "must specify dimensions in ascending order for PLA input type {}"
 warning format-real FormatRealInt "real value provided for integer format specifier '%{}'"
 warning finish-num BadFinishNum "finish argument must have value of 0, 1, or 2"
 warning missing-format MissingFormatSpecifier "missing format specifier"

--- a/source/compilation/builtins/SystemTasks.cpp
+++ b/source/compilation/builtins/SystemTasks.cpp
@@ -614,7 +614,7 @@ public:
         SystemTaskBase(name) {};
 
     const Type& checkArguments(const BindContext& context, const Args& args, SourceRange range,
-                               const Expression*) const override {
+                               const Expression*) const final {
         auto& comp = context.getCompilation();
 
         if (!checkArgCount(context, false, args, range, 3, 3))
@@ -651,13 +651,13 @@ public:
         return comp.getVoidType();
     }
 
-protected:
-    bool isValidRange(const Type& type) const {
+private:
+    static bool isValidRange(const Type& type) {
         ConstantRange range = type.getFixedRange();
         return range.right >= range.left;
     }
 
-    const Type& badRange(const BindContext& context, const Expression& arg) const {
+    static const Type& badRange(const BindContext& context, const Expression& arg) {
         context.addDiag(diag::PlaRangeInAscendingOrder, arg.sourceRange) << *arg.type;
         return context.getCompilation().getErrorType();
     }

--- a/tests/unittests/SystemFuncTests.cpp
+++ b/tests/unittests/SystemFuncTests.cpp
@@ -965,24 +965,23 @@ module m;
     logic [0:3] out;
     logic [7:0] memBadOrder1[0:3];
     logic [0:7] memBadOrder2[3:0];
+    string      memString[0:3];
     logic [7:0] inBadOrder;
     logic [3:0] outBadOrder;
-    string error;
     int i;
     real r;
     logic a;
 
-    // TODO: memory, input, and output terms must be specified in ascending order
-    //       need an error if they are not.
     initial begin
-        $async$and$array(mem, in, out);
-        $async$and$array(a, in, out);            // Bad arg (mem)
-        $async$and$array(mem, i, out);           // Bad arg (input)
-        $async$and$array(mem, in, r);            // Bad arg (output)
-        $async$and$array(memBadOrder1, in, out); // Bad mem bit ordering
-        // $async$and$array(memBadOrder2, in, out); // Bad mem bit ordering
-        $async$and$array(mem, inBadOrder, out);  // Bad input bit ordering
-        $async$and$array(mem, in, outBadOrder);  // Bad output bit ordering
+        $async$and$plane(mem, in, out);
+        $sync$or$array(a, in, out);               // Bad mem type
+        $async$nand$plane(memString, in, out);    // Bad mem type
+        $sync$nor$array(mem, i, out);             // Bad input type
+        $async$and$plane(mem, in, r);             // Bad output type
+        $sync$or$array(memBadOrder1, in, out);    // Bad mem bit ordering
+        $async$nand$plane(memBadOrder2, in, out); // Bad mem bit ordering
+        $sync$nor$array(mem, inBadOrder, out);    // Bad input bit ordering
+        $async$and$plane(mem, in, outBadOrder);   // Bad output bit ordering
     end
 endmodule
 )");
@@ -991,11 +990,13 @@ endmodule
     compilation.addSyntaxTree(tree);
 
     auto& diags = compilation.getAllDiagnostics();
-    REQUIRE(diags.size() == 6);
+    REQUIRE(diags.size() == 8);
     CHECK(diags[0].code == diag::BadSystemSubroutineArg);
     CHECK(diags[1].code == diag::BadSystemSubroutineArg);
     CHECK(diags[2].code == diag::BadSystemSubroutineArg);
-    CHECK(diags[3].code == diag::PlaRangeInAscendingOrder);
+    CHECK(diags[3].code == diag::BadSystemSubroutineArg);
     CHECK(diags[4].code == diag::PlaRangeInAscendingOrder);
     CHECK(diags[5].code == diag::PlaRangeInAscendingOrder);
+    CHECK(diags[6].code == diag::PlaRangeInAscendingOrder);
+    CHECK(diags[7].code == diag::PlaRangeInAscendingOrder);
 }

--- a/tests/unittests/SystemFuncTests.cpp
+++ b/tests/unittests/SystemFuncTests.cpp
@@ -974,6 +974,7 @@ module m;
 
     initial begin
         $async$and$plane(mem, in, out);
+        $sync$and$array(mem, in, out, r);         // Too many arguments
         $sync$or$array(a, in, out);               // Bad mem type
         $async$nand$plane(memString, in, out);    // Bad mem type
         $sync$nor$array(mem, i, out);             // Bad input type
@@ -990,13 +991,14 @@ endmodule
     compilation.addSyntaxTree(tree);
 
     auto& diags = compilation.getAllDiagnostics();
-    REQUIRE(diags.size() == 8);
-    CHECK(diags[0].code == diag::BadSystemSubroutineArg);
+    REQUIRE(diags.size() == 9);
+    CHECK(diags[0].code == diag::TooManyArguments);
     CHECK(diags[1].code == diag::BadSystemSubroutineArg);
     CHECK(diags[2].code == diag::BadSystemSubroutineArg);
     CHECK(diags[3].code == diag::BadSystemSubroutineArg);
-    CHECK(diags[4].code == diag::PlaRangeInAscendingOrder);
+    CHECK(diags[4].code == diag::BadSystemSubroutineArg);
     CHECK(diags[5].code == diag::PlaRangeInAscendingOrder);
     CHECK(diags[6].code == diag::PlaRangeInAscendingOrder);
     CHECK(diags[7].code == diag::PlaRangeInAscendingOrder);
+    CHECK(diags[8].code == diag::PlaRangeInAscendingOrder);
 }

--- a/tests/unittests/SystemFuncTests.cpp
+++ b/tests/unittests/SystemFuncTests.cpp
@@ -956,3 +956,46 @@ endmodule
     CHECK(diags[5].code == diag::ExpectedModuleInstance);
     CHECK(diags[6].code == diag::NoImplicitConversion);
 }
+
+TEST_CASE("PLA system tasks") {
+    auto tree = SyntaxTree::fromText(R"(
+module m;
+    logic [0:7] mem[0:3];
+    logic [0:7] in;
+    logic [0:3] out;
+    logic [7:0] memBadOrder1[0:3];
+    logic [0:7] memBadOrder2[3:0];
+    logic [7:0] inBadOrder;
+    logic [3:0] outBadOrder;
+    string error;
+    int i;
+    real r;
+    logic a;
+
+    // TODO: memory, input, and output terms must be specified in ascending order
+    //       need an error if they are not.
+    initial begin
+        $async$and$array(mem, in, out);
+        $async$and$array(a, in, out);            // Bad arg (mem)
+        $async$and$array(mem, i, out);           // Bad arg (input)
+        $async$and$array(mem, in, r);            // Bad arg (output)
+        $async$and$array(memBadOrder1, in, out); // Bad mem bit ordering
+        // $async$and$array(memBadOrder2, in, out); // Bad mem bit ordering
+        $async$and$array(mem, inBadOrder, out);  // Bad input bit ordering
+        $async$and$array(mem, in, outBadOrder);  // Bad output bit ordering
+    end
+endmodule
+)");
+
+    Compilation compilation;
+    compilation.addSyntaxTree(tree);
+
+    auto& diags = compilation.getAllDiagnostics();
+    REQUIRE(diags.size() == 6);
+    CHECK(diags[0].code == diag::BadSystemSubroutineArg);
+    CHECK(diags[1].code == diag::BadSystemSubroutineArg);
+    CHECK(diags[2].code == diag::BadSystemSubroutineArg);
+    CHECK(diags[3].code == diag::PlaRangeInAscendingOrder);
+    CHECK(diags[4].code == diag::PlaRangeInAscendingOrder);
+    CHECK(diags[5].code == diag::PlaRangeInAscendingOrder);
+}


### PR DESCRIPTION
The implementation isn't complete, but creating the PR to facilitate some questions and review.

For the PLA tasks, $20.17.3 lists the following requirement:
> As shown in the examples in 20.17, PLA input terms, output terms, and memory shall be specified in ascending order.`

e.g. `logic [0:7] mem [0:7]`

I've implemented this check for the input and output args, but only partially for the mem arg.   I'm sure I've missed something obvious, but can you point me in the right direction for getting the dimensions of an array?