### PR TITLE
Fix "use of bitwise '|' with boolean operands"

### DIFF
--- a/source/binding/Statements.cpp
+++ b/source/binding/Statements.cpp
@@ -2436,7 +2436,10 @@ Statement& RandCaseStatement::fromSyntax(Compilation& compilation,
         auto& stmt = Statement::bind(*item->statement, context, stmtCtx);
         items.append({ &expr, &stmt });
 
-        bad |= expr.bad() | stmt.bad();
+        if (expr.bad() || stmt.bad()) {
+            bad = true;
+        }
+
         if (!expr.bad() && !expr.type->isIntegral()) {
             context.addDiag(diag::ExprMustBeIntegral, expr.sourceRange) << *expr.type;
             bad = true;


### PR DESCRIPTION
Newer clang complains:

source/binding/Statements.cpp:2439:16: error: use of bitwise '|' with boolean operands [-Werror,-Wbitwise-instead-of-logical]
        bad |= expr.bad() | stmt.bad();
               ^~~~~~~~~~~~~~~~~~~~~~~
                          ||
source/binding/Statements.cpp:2439:16: note: cast one or both operands to int to silence this warning

Ref: https://wiki.sei.cmu.edu/confluence/display/c/EXP46-C.+Do+not+use+a+bitwise+operator+with+a+Boolean-like+operand