### PR TITLE
Remove specialization of std::hash for std::tuple

### DIFF
--- a/external/flat_hash_map.hpp
+++ b/external/flat_hash_map.hpp
@@ -1496,5 +1496,3 @@ struct power_of_two_std_hash : std::hash<T>
 };
 
 } // end namespace ska
-
-using ska::flat_hash_set;

--- a/external/flat_hash_map.hpp
+++ b/external/flat_hash_map.hpp
@@ -1497,5 +1497,4 @@ struct power_of_two_std_hash : std::hash<T>
 
 } // end namespace ska
 
-using ska::flat_hash_map;
 using ska::flat_hash_set;

--- a/include/slang/binding/BindContext.h
+++ b/include/slang/binding/BindContext.h
@@ -6,12 +6,12 @@
 //------------------------------------------------------------------------------
 #pragma once
 
-#include <flat_hash_map.hpp>
 #include <tuple>
 
 #include "slang/binding/EvalContext.h"
 #include "slang/binding/Lookup.h"
 #include "slang/numeric/ConstantValue.h"
+#include "slang/util/FlatHashMap.h"
 #include "slang/util/Util.h"
 
 namespace slang {

--- a/include/slang/binding/BindContext.h
+++ b/include/slang/binding/BindContext.h
@@ -11,7 +11,7 @@
 #include "slang/binding/EvalContext.h"
 #include "slang/binding/Lookup.h"
 #include "slang/numeric/ConstantValue.h"
-#include "slang/util/FlatHashMap.h"
+#include "slang/util/Hash.h"
 #include "slang/util/Util.h"
 
 namespace slang {

--- a/include/slang/codegen/CodeGenerator.h
+++ b/include/slang/codegen/CodeGenerator.h
@@ -7,11 +7,11 @@
 //------------------------------------------------------------------------------
 #pragma once
 
-#include <flat_hash_map.hpp>
 #include <memory>
 #include <string>
 #include <vector>
 
+#include "slang/util/FlatHashMap.h"
 #include "slang/util/Function.h"
 #include "slang/util/Util.h"
 

--- a/include/slang/codegen/CodeGenerator.h
+++ b/include/slang/codegen/CodeGenerator.h
@@ -11,8 +11,8 @@
 #include <string>
 #include <vector>
 
-#include "slang/util/FlatHashMap.h"
 #include "slang/util/Function.h"
+#include "slang/util/Hash.h"
 #include "slang/util/Util.h"
 
 namespace llvm {

--- a/include/slang/compilation/Definition.h
+++ b/include/slang/compilation/Definition.h
@@ -6,10 +6,10 @@
 //------------------------------------------------------------------------------
 #pragma once
 
-#include <flat_hash_map.hpp>
 
 #include "slang/binding/Lookup.h"
 #include "slang/symbols/SemanticFacts.h"
+#include "slang/util/FlatHashMap.h"
 #include "slang/util/SmallVector.h"
 #include "slang/util/Util.h"
 

--- a/include/slang/compilation/Definition.h
+++ b/include/slang/compilation/Definition.h
@@ -6,10 +6,9 @@
 //------------------------------------------------------------------------------
 #pragma once
 
-
 #include "slang/binding/Lookup.h"
 #include "slang/symbols/SemanticFacts.h"
-#include "slang/util/FlatHashMap.h"
+#include "slang/util/Hash.h"
 #include "slang/util/SmallVector.h"
 #include "slang/util/Util.h"
 

--- a/include/slang/compilation/SemanticModel.h
+++ b/include/slang/compilation/SemanticModel.h
@@ -6,13 +6,12 @@
 //------------------------------------------------------------------------------
 #pragma once
 
-
-#include "slang/types/AllTypes.h"
 #include "slang/symbols/BlockSymbols.h"
 #include "slang/symbols/CompilationUnitSymbols.h"
 #include "slang/symbols/InstanceSymbols.h"
 #include "slang/symbols/SubroutineSymbols.h"
-#include "slang/util/FlatHashMap.h"
+#include "slang/types/AllTypes.h"
+#include "slang/util/Hash.h"
 
 namespace slang {
 

--- a/include/slang/compilation/SemanticModel.h
+++ b/include/slang/compilation/SemanticModel.h
@@ -6,13 +6,13 @@
 //------------------------------------------------------------------------------
 #pragma once
 
-#include <flat_hash_map.hpp>
 
 #include "slang/types/AllTypes.h"
 #include "slang/symbols/BlockSymbols.h"
 #include "slang/symbols/CompilationUnitSymbols.h"
 #include "slang/symbols/InstanceSymbols.h"
 #include "slang/symbols/SubroutineSymbols.h"
+#include "slang/util/FlatHashMap.h"
 
 namespace slang {
 

--- a/include/slang/diagnostics/DiagnosticEngine.h
+++ b/include/slang/diagnostics/DiagnosticEngine.h
@@ -12,7 +12,7 @@
 #include <typeinfo>
 
 #include "slang/diagnostics/Diagnostics.h"
-#include "slang/util/FlatHashMap.h"
+#include "slang/util/Hash.h"
 
 namespace slang {
 

--- a/include/slang/diagnostics/DiagnosticEngine.h
+++ b/include/slang/diagnostics/DiagnosticEngine.h
@@ -6,13 +6,13 @@
 //------------------------------------------------------------------------------
 #pragma once
 
-#include <flat_hash_map.hpp>
 #include <memory>
 #include <string>
 #include <typeindex>
 #include <typeinfo>
 
 #include "slang/diagnostics/Diagnostics.h"
+#include "slang/util/FlatHashMap.h"
 
 namespace slang {
 

--- a/include/slang/mir/MIRBuilder.h
+++ b/include/slang/mir/MIRBuilder.h
@@ -10,7 +10,7 @@
 
 #include "slang/mir/Instr.h"
 #include "slang/util/BumpAllocator.h"
-#include "slang/util/FlatHashMap.h"
+#include "slang/util/Hash.h"
 
 namespace slang {
 

--- a/include/slang/mir/MIRBuilder.h
+++ b/include/slang/mir/MIRBuilder.h
@@ -6,11 +6,11 @@
 //------------------------------------------------------------------------------
 #pragma once
 
-#include <flat_hash_map.hpp>
 #include <vector>
 
 #include "slang/mir/Instr.h"
 #include "slang/util/BumpAllocator.h"
+#include "slang/util/FlatHashMap.h"
 
 namespace slang {
 

--- a/include/slang/parsing/Parser.h
+++ b/include/slang/parsing/Parser.h
@@ -6,7 +6,6 @@
 //------------------------------------------------------------------------------
 #pragma once
 
-#include <flat_hash_map.hpp>
 
 #include "slang/parsing/NumberParser.h"
 #include "slang/parsing/ParserBase.h"
@@ -14,6 +13,7 @@
 #include "slang/syntax/AllSyntax.h"
 #include "slang/syntax/SyntaxFacts.h"
 #include "slang/util/Bag.h"
+#include "slang/util/FlatHashMap.h"
 
 namespace slang {
 

--- a/include/slang/parsing/Parser.h
+++ b/include/slang/parsing/Parser.h
@@ -6,14 +6,13 @@
 //------------------------------------------------------------------------------
 #pragma once
 
-
 #include "slang/parsing/NumberParser.h"
 #include "slang/parsing/ParserBase.h"
 #include "slang/parsing/Token.h"
 #include "slang/syntax/AllSyntax.h"
 #include "slang/syntax/SyntaxFacts.h"
 #include "slang/util/Bag.h"
-#include "slang/util/FlatHashMap.h"
+#include "slang/util/Hash.h"
 
 namespace slang {
 

--- a/include/slang/symbols/ClassSymbols.h
+++ b/include/slang/symbols/ClassSymbols.h
@@ -6,12 +6,12 @@
 //------------------------------------------------------------------------------
 #pragma once
 
-#include <flat_hash_map.hpp>
 
 #include "slang/compilation/Definition.h"
 #include "slang/symbols/Scope.h"
 #include "slang/symbols/VariableSymbols.h"
 #include "slang/types/Type.h"
+#include "slang/util/FlatHashMap.h"
 #include "slang/util/Function.h"
 
 namespace slang {

--- a/include/slang/symbols/ClassSymbols.h
+++ b/include/slang/symbols/ClassSymbols.h
@@ -6,13 +6,12 @@
 //------------------------------------------------------------------------------
 #pragma once
 
-
 #include "slang/compilation/Definition.h"
 #include "slang/symbols/Scope.h"
 #include "slang/symbols/VariableSymbols.h"
 #include "slang/types/Type.h"
-#include "slang/util/FlatHashMap.h"
 #include "slang/util/Function.h"
+#include "slang/util/Hash.h"
 
 namespace slang {
 

--- a/include/slang/symbols/Scope.h
+++ b/include/slang/symbols/Scope.h
@@ -6,12 +6,12 @@
 //------------------------------------------------------------------------------
 #pragma once
 
-#include <flat_hash_map.hpp>
 
 #include "slang/binding/Lookup.h"
 #include "slang/diagnostics/Diagnostics.h"
 #include "slang/symbols/SemanticFacts.h"
 #include "slang/symbols/Symbol.h"
+#include "slang/util/FlatHashMap.h"
 #include "slang/util/Iterator.h"
 #include "slang/util/Util.h"
 

--- a/include/slang/symbols/Scope.h
+++ b/include/slang/symbols/Scope.h
@@ -6,12 +6,11 @@
 //------------------------------------------------------------------------------
 #pragma once
 
-
 #include "slang/binding/Lookup.h"
 #include "slang/diagnostics/Diagnostics.h"
 #include "slang/symbols/SemanticFacts.h"
 #include "slang/symbols/Symbol.h"
-#include "slang/util/FlatHashMap.h"
+#include "slang/util/Hash.h"
 #include "slang/util/Iterator.h"
 #include "slang/util/Util.h"
 

--- a/include/slang/syntax/SyntaxVisitor.h
+++ b/include/slang/syntax/SyntaxVisitor.h
@@ -10,7 +10,7 @@
 
 #include "slang/syntax/AllSyntax.h"
 #include "slang/syntax/SyntaxTree.h"
-#include "slang/util/FlatHashMap.h"
+#include "slang/util/Hash.h"
 #include "slang/util/TypeTraits.h"
 
 namespace slang {

--- a/include/slang/syntax/SyntaxVisitor.h
+++ b/include/slang/syntax/SyntaxVisitor.h
@@ -6,11 +6,11 @@
 //------------------------------------------------------------------------------
 #pragma once
 
-#include <flat_hash_map.hpp>
 #include <vector>
 
 #include "slang/syntax/AllSyntax.h"
 #include "slang/syntax/SyntaxTree.h"
+#include "slang/util/FlatHashMap.h"
 #include "slang/util/TypeTraits.h"
 
 namespace slang {

--- a/include/slang/text/SourceManager.h
+++ b/include/slang/text/SourceManager.h
@@ -18,7 +18,7 @@
 #include <vector>
 
 #include "slang/text/SourceLocation.h"
-#include "slang/util/FlatHashMap.h"
+#include "slang/util/Hash.h"
 #include "slang/util/Util.h"
 
 namespace fs = std::filesystem;

--- a/include/slang/text/SourceManager.h
+++ b/include/slang/text/SourceManager.h
@@ -9,7 +9,6 @@
 #include <atomic>
 #include <deque>
 #include <filesystem>
-#include <flat_hash_map.hpp>
 #include <memory>
 #include <mutex>
 #include <set>
@@ -19,6 +18,7 @@
 #include <vector>
 
 #include "slang/text/SourceLocation.h"
+#include "slang/util/FlatHashMap.h"
 #include "slang/util/Util.h"
 
 namespace fs = std::filesystem;

--- a/include/slang/util/Bag.h
+++ b/include/slang/util/Bag.h
@@ -7,9 +7,10 @@
 #pragma once
 
 #include <any>
-#include <flat_hash_map.hpp>
 #include <typeindex>
 #include <typeinfo>
+
+#include "slang/util/FlatHashMap.h"
 
 namespace slang {
 

--- a/include/slang/util/Bag.h
+++ b/include/slang/util/Bag.h
@@ -10,7 +10,7 @@
 #include <typeindex>
 #include <typeinfo>
 
-#include "slang/util/FlatHashMap.h"
+#include "slang/util/Hash.h"
 
 namespace slang {
 

--- a/include/slang/util/FlatHashMap.h
+++ b/include/slang/util/FlatHashMap.h
@@ -1,0 +1,5 @@
+#include <flat_hash_map.hpp>
+
+#include "slang/util/Hash.h"
+template<typename K, typename V, typename H = slang::Hasher<K>, typename E = std::equal_to<K>,
+         typename A = std::allocator<std::pair<K, V>>> using flat_hash_map = ska::flat_hash_map<K, V, H, E, A>;

--- a/include/slang/util/FlatHashMap.h
+++ b/include/slang/util/FlatHashMap.h
@@ -1,5 +1,0 @@
-#include <flat_hash_map.hpp>
-
-#include "slang/util/Hash.h"
-template<typename K, typename V, typename H = slang::Hasher<K>, typename E = std::equal_to<K>,
-         typename A = std::allocator<std::pair<K, V>>> using flat_hash_map = ska::flat_hash_map<K, V, H, E, A>;

--- a/include/slang/util/Hash.h
+++ b/include/slang/util/Hash.h
@@ -6,6 +6,8 @@
 //------------------------------------------------------------------------------
 #pragma once
 
+#include <flat_hash_map.hpp>
+
 #include "slang/util/Util.h"
 
 extern "C" uint64_t XXH3_64bits(const void* data, size_t len);
@@ -52,11 +54,9 @@ struct HashValueImpl<Tuple, 0> {
 namespace slang {
 
 // Specialize a user-defined type instead of std::hash
-template <typename T> struct Hasher
-{
-    size_t operator()(const T& t) const {
-        return std::hash<T>()(t);
-    }
+template<typename T>
+struct Hasher {
+    size_t operator()(const T& t) const { return std::hash<T>()(t); }
 };
 
 template<typename... TT>
@@ -68,4 +68,11 @@ struct Hasher<std::tuple<TT...>> {
     }
 };
 
+template<typename K, typename V, typename H = slang::Hasher<K>, typename E = std::equal_to<K>,
+         typename A = std::allocator<std::pair<K, V>>>
+using flat_hash_map = ska::flat_hash_map<K, V, H, E, A>;
+
+template<typename T, typename H = slang::Hasher<T>, typename E = std::equal_to<T>,
+         typename A = std::allocator<T>>
+using flat_hash_set = ska::flat_hash_set<T, H, E, A>;
 } // namespace slang

--- a/include/slang/util/Hash.h
+++ b/include/slang/util/Hash.h
@@ -49,11 +49,18 @@ struct HashValueImpl<Tuple, 0> {
 
 } // namespace slang
 
-namespace std {
+namespace slang {
 
-// Specialization of std::hash for all std::tuples. Why isn't this built in?
+// Specialize a user-defined type instead of std::hash
+template <typename T> struct Hasher
+{
+    size_t operator()(const T& t) const {
+        return std::hash<T>()(t);
+    }
+};
+
 template<typename... TT>
-struct hash<std::tuple<TT...>> {
+struct Hasher<std::tuple<TT...>> {
     size_t operator()(const std::tuple<TT...>& tt) const {
         size_t seed = 0;
         slang::detail::HashValueImpl<std::tuple<TT...>>::apply(seed, tt);
@@ -61,4 +68,4 @@ struct hash<std::tuple<TT...>> {
     }
 };
 
-} // namespace std
+} // namespace slang

--- a/include/slang/util/StackContainer.h
+++ b/include/slang/util/StackContainer.h
@@ -6,7 +6,7 @@
 //------------------------------------------------------------------------------
 #pragma once
 
-#include "slang/util/FlatHashMap.h"
+#include "slang/util/Hash.h"
 
 namespace slang {
 

--- a/include/slang/util/StackContainer.h
+++ b/include/slang/util/StackContainer.h
@@ -6,7 +6,7 @@
 //------------------------------------------------------------------------------
 #pragma once
 
-#include <flat_hash_map.hpp>
+#include "slang/util/FlatHashMap.h"
 
 namespace slang {
 

--- a/scripts/diagnostic_gen.py
+++ b/scripts/diagnostic_gen.py
@@ -133,7 +133,7 @@ def createsource(path, diags, groups):
 
 #include <ostream>
 
-#include "slang/util/FlatHashMap.h"
+#include "slang/util/Hash.h"
 
 namespace slang {
 

--- a/scripts/diagnostic_gen.py
+++ b/scripts/diagnostic_gen.py
@@ -133,7 +133,7 @@ def createsource(path, diags, groups):
 
 #include <ostream>
 
-#include <flat_hash_map.hpp>
+#include "slang/util/FlatHashMap.h"
 
 namespace slang {
 

--- a/source/codegen/CodeGenFunction.cpp
+++ b/source/codegen/CodeGenFunction.cpp
@@ -10,8 +10,8 @@
 
 #include "slang/codegen/CodeGenerator.h"
 #include "slang/mir/Procedure.h"
-#include "slang/types/AllTypes.h"
 #include "slang/symbols/VariableSymbols.h"
+#include "slang/types/AllTypes.h"
 
 namespace slang {
 

--- a/source/codegen/CodeGenTypes.h
+++ b/source/codegen/CodeGenTypes.h
@@ -6,8 +6,9 @@
 //------------------------------------------------------------------------------
 #pragma once
 
-#include "slang/util/FlatHashMap.h"
 #include <llvm/Support/Alignment.h>
+
+#include "slang/util/Hash.h"
 
 namespace llvm {
 

--- a/source/codegen/CodeGenTypes.h
+++ b/source/codegen/CodeGenTypes.h
@@ -6,7 +6,7 @@
 //------------------------------------------------------------------------------
 #pragma once
 
-#include <flat_hash_map.hpp>
+#include "slang/util/FlatHashMap.h"
 #include <llvm/Support/Alignment.h>
 
 namespace llvm {

--- a/source/mir/MIRPrinter.cpp
+++ b/source/mir/MIRPrinter.cpp
@@ -8,8 +8,8 @@
 
 #include <fmt/format.h>
 
-#include "slang/types/Type.h"
 #include "slang/symbols/VariableSymbols.h"
+#include "slang/types/Type.h"
 
 namespace slang::mir {
 


### PR DESCRIPTION
The current specialization makes slang incompatible with other libraries that also include one, such as folly.