### PR TITLE
Add pkg-config input file

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,8 @@
 # slang - cmake entry point
 cmake_minimum_required(VERSION 3.15)
-project(slang VERSION 2.0.0 LANGUAGES CXX)
+project(slang VERSION 2.0.0 LANGUAGES CXX
+        HOMEPAGE_URL https://sv-lang.com/
+        DESCRIPTION "SystemVerilog compiler and language services")
 
 option(SLANG_COVERAGE "Enable code coverage" OFF)
 option(CI_BUILD "Enable longer running tests for CI builds" OFF)
@@ -214,4 +216,13 @@ endif()
 
 if(SLANG_INCLUDE_DOCS)
     add_subdirectory(docs)
+endif()
+
+if(UNIX)
+  # Install pkg-config input file
+  configure_file(${CMAKE_CURRENT_SOURCE_DIR}/scripts/sv-lang.pc.in
+                 ${CMAKE_CURRENT_BINARY_DIR}/sv-lang.pc
+                 @ONLY)
+  install(FILES ${CMAKE_CURRENT_BINARY_DIR}/sv-lang.pc
+          DESTINATION ${CMAKE_INSTALL_PREFIX}/share/pkgconfig)
 endif()

--- a/scripts/sv-lang.pc.in
+++ b/scripts/sv-lang.pc.in
@@ -1,0 +1,10 @@
+prefix=@CMAKE_INSTALL_PREFIX@
+includedir="${prefix}/include"
+libdir="${prefix}/lib"
+
+Name: @PROJECT_NAME@
+Description: @PROJECT_DESCRIPTION@
+URL: @PROJECT_HOMEPAGE_URL@
+Version: @PROJECT_VERSION@
+Cflags: -I"${includedir}"
+Libs: -L"${libdir}" -lslangcore -lslangruntime -lslangcompiler -lslangparser


### PR DESCRIPTION
I'm trying to link against slang from another program but it doesn't currently provide the customary `pkg-config` configuration file to automatically set the necessary include directories, link libraries, etc. 

Note the file name here is `sv-lang.pc` to avoid potential conflicts because `slang.pc` is already taken by the unrelated `libslang2-dev` (in Debian at least).