### PR TITLE
update python bindings in response to overloaded setMappingsFromPragmas()

### DIFF
--- a/bindings/python/util.cpp
+++ b/bindings/python/util.cpp
@@ -231,7 +231,8 @@ void registerUtil(py::module_& m) {
         .def("formatMessage", &DiagnosticEngine::formatMessage)
         .def("setDefaultWarnings", &DiagnosticEngine::setDefaultWarnings)
         .def("setWarningOptions", &DiagnosticEngine::setWarningOptions)
-        .def("setMappingsFromPragmas", &DiagnosticEngine::setMappingsFromPragmas)
+        .def("setMappingsFromPragmas", py::overload_cast<BufferId>(&DiagnosticEngine::setMappingsFromPragmas))
+        .def("setMappingsFromPragmas", py::overload_cast<>(&DiagnosticEngine::setMappingsFromPragmas))
         .def_static("reportAll", &DiagnosticEngine::reportAll);
 
     py::class_<ReportedDiagnostic>(m, "ReportedDiagnostic")

--- a/bindings/python/util.cpp
+++ b/bindings/python/util.cpp
@@ -231,8 +231,10 @@ void registerUtil(py::module_& m) {
         .def("formatMessage", &DiagnosticEngine::formatMessage)
         .def("setDefaultWarnings", &DiagnosticEngine::setDefaultWarnings)
         .def("setWarningOptions", &DiagnosticEngine::setWarningOptions)
-        .def("setMappingsFromPragmas", py::overload_cast<BufferId>(&DiagnosticEngine::setMappingsFromPragmas))
-        .def("setMappingsFromPragmas", py::overload_cast<>(&DiagnosticEngine::setMappingsFromPragmas))
+        .def("setMappingsFromPragmas",
+             py::overload_cast<BufferId>(&DiagnosticEngine::setMappingsFromPragmas))
+        .def("setMappingsFromPragmas",
+             py::overload_cast<>(&DiagnosticEngine::setMappingsFromPragmas))
         .def_static("reportAll", &DiagnosticEngine::reportAll);
 
     py::class_<ReportedDiagnostic>(m, "ReportedDiagnostic")


### PR DESCRIPTION
Restore buildability of pyslang after setMappingsFromPragmas(BufferID id)