### PR TITLE
Add new diagnostic: Register only assigned on reset

### DIFF
--- a/include/slang/symbols/ValueSymbol.h
+++ b/include/slang/symbols/ValueSymbol.h
@@ -83,6 +83,7 @@ public:
         bool isInSingleDriverProcedure() const;
         bool isInSubroutine() const;
         bool isInInitialBlock() const;
+        bool isInAlwaysFFBlock() const;
 
         bool overlaps(const Driver& other) const;
 

--- a/scripts/diagnostics.txt
+++ b/scripts/diagnostics.txt
@@ -429,6 +429,7 @@ warning dpi-spec DPISpecDisallowed "'DPI' specified subroutines are not supporte
 warning udp-port-empty EmptyUdpPort "primitive port connection is empty"
 warning net-inconsistent NetInconsistent "net type '{}' of connection is inconsistent with net type '{}' of port"
 warning net-inconsistent NetRangeInconsistent "net type '{}' of connection bits [{}:{}] is inconsistent with net type '{}' of corresponding port range"
+warning only-assigned-on-reset OnlyAssignedOnReset "register '{}' is only assigned on reset. This will cause warnings or errors in synthesis tools"
 
 subsystem Expressions
 error BadUnaryExpression "invalid operand type {} to unary expression"
@@ -903,7 +904,7 @@ group default = { real-underflow real-overflow vector-overflow int-overflow unco
                   unknown-escape-code missing-top warning-task unsized-concat finish-num implicit-conv
                   nonblocking-final constraint-missing missing-format dpi-spec enum-range udp-port-empty
                   lifetime-prototype net-inconsistent port-coercion empty-body reversed-range
-                  invalid-source-encoding }
+                  invalid-source-encoding only-assigned-on-reset }
 
 group extra = { empty-member empty-stmt dup-import pointless-void-cast case-gen-none case-gen-dup
                 unused-result format-real ignored-slice task-ignored width-trunc dup-attr event-const

--- a/source/compilation/Compilation.cpp
+++ b/source/compilation/Compilation.cpp
@@ -912,6 +912,9 @@ const Diagnostics& Compilation::getSemanticDiagnostics() {
         }
     }
 
+    OnlyResetAssignment reg_visitor;
+    getRoot().visit(reg_visitor);
+
     Diagnostics results;
     for (auto& [key, diagList] : diagMap) {
         // If the location is NoLocation, just issue each diagnostic.

--- a/source/symbols/ValueSymbol.cpp
+++ b/source/symbols/ValueSymbol.cpp
@@ -163,6 +163,12 @@ bool ValueSymbol::Driver::isInInitialBlock() const {
                ProceduralBlockKind::Initial;
 }
 
+bool ValueSymbol::Driver::isInAlwaysFFBlock() const {
+    return containingSymbol->kind == SymbolKind::ProceduralBlock &&
+           containingSymbol->as<ProceduralBlockSymbol>().procedureKind ==
+               ProceduralBlockKind::AlwaysFF;
+}
+
 span<const ConstantRange> ValueSymbol::Driver::getPrefix() const {
     return { reinterpret_cast<const ConstantRange*>(this + 1), numPrefixEntries };
 }


### PR DESCRIPTION
Added a new warning which triggers when a register is only assigned while the design is on reset.