### PR TITLE
Parse legacy vendor worflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,7 @@ jobs:
       run: |
         mkdir build
         cd build
-        cmake .. -G "Visual Studio 17 2022" -DCMAKE_INSTALL_PREFIX=$HOME/slang/
+        cmake .. -G "Visual Studio 17 2022" -DCMAKE_INSTALL_PREFIX=$HOME/slang/ -DSLANG_INCLUDE_PYLIB=ON
     - name: Build
       run: msbuild build/INSTALL.vcxproj -m -p:configuration=release -p:platform=x64
     - name: Run tests

--- a/include/slang/driver/Driver.h
+++ b/include/slang/driver/Driver.h
@@ -64,9 +64,8 @@ public:
 
         // What we don't need:
         // A map of commands to be renameded, with next argument merged into a plusArg format
-        // (because all slang's plusargs have non plusargs aliases, so no reason to create a plusArg)
-        // What we MIGHT need:
-        // Split a vendor's plusArg into regular arguments
+        // (because all slang's plusargs have non plusargs aliases, so no reason to create a
+        // plusArg) What we MIGHT need: Split a vendor's plusArg into regular arguments
 
         /// @name Include paths
         /// @{

--- a/include/slang/driver/Driver.h
+++ b/include/slang/driver/Driver.h
@@ -47,26 +47,6 @@ public:
     /// A container for various options that can be parsed and applied
     /// to the compilation process.
     struct Options {
-        /// @name Command line transformation from Vendor arguments to slang arguments
-        /// @{
-
-        /// A map of commands to be ignored.
-        /// key is the command name (including any leading +/- symbols)
-        /// value is an the number of arguments to be skipped (int)
-        /// If argument begins with a '+' then matching will ignore anything after a 2nd '+'
-        /// so that +vendorXYZ+vendorARG can be ignored by matching against +vendorXYZ
-        std::map<std::string, int> cmdIgnore;
-
-        /// A map of commands to be renamed, pointing to new name
-        /// key is the vendor command name (including any leading +/- symbols)
-        /// value is the slang command name to be used instead
-        std::map<std::string, std::string> cmdRename;
-
-        // What we don't need:
-        // A map of commands to be renameded, with next argument merged into a plusArg format
-        // (because all slang's plusargs have non plusargs aliases, so no reason to create a
-        // plusArg) What we MIGHT need: Split a vendor's plusArg into regular arguments
-
         /// @name Include paths
         /// @{
 
@@ -84,7 +64,9 @@ public:
 
         /// A list of extensions that will be used to exclude files.
         std::vector<std::string> excludeExts;
-        // same, mapped to a set
+        // defaults to false, cleared after copying to uniqueExcludeExtensions
+        bool excludeExtDone;
+        // same as excludeExts, but mapped to a set
         flat_hash_set<string_view> uniqueExcludeExtensions;
 
         /// @}

--- a/include/slang/driver/Driver.h
+++ b/include/slang/driver/Driver.h
@@ -62,12 +62,8 @@ public:
         /// A list of extensions that will be used to search for library files.
         std::vector<std::string> libExts;
 
-        /// A list of extensions that will be used to exclude files.
-        std::vector<std::string> excludeExts;
-        // defaults to false, cleared after copying to uniqueExcludeExtensions
-        bool excludeExtDone;
-        // same as excludeExts, but mapped to a set
-        flat_hash_set<string_view> uniqueExcludeExtensions;
+        // A set of extensions that will be used to exclude files.
+        flat_hash_set<string_view> excludeExts;
 
         /// @}
         /// @name Preprocessing

--- a/include/slang/driver/Driver.h
+++ b/include/slang/driver/Driver.h
@@ -82,6 +82,11 @@ public:
         /// A list of extensions that will be used to search for library files.
         std::vector<std::string> libExts;
 
+        /// A list of extensions that will be used to exclude files.
+        std::vector<std::string> excludeExts;
+        // same, mapped to a set
+        flat_hash_set<string_view> uniqueExcludeExtensions;
+
         /// @}
         /// @name Preprocessing
         /// @{

--- a/include/slang/driver/Driver.h
+++ b/include/slang/driver/Driver.h
@@ -47,6 +47,27 @@ public:
     /// A container for various options that can be parsed and applied
     /// to the compilation process.
     struct Options {
+        /// @name Command line transformation from Vendor arguments to slang arguments
+        /// @{
+
+        /// A map of commands to be ignored.
+        /// key is the command name (including any leading +/- symbols)
+        /// value is an the number of arguments to be skipped (int)
+        /// If argument begins with a '+' then matching will ignore anything after a 2nd '+'
+        /// so that +vendorXYZ+vendorARG can be ignored by matching against +vendorXYZ
+        std::map<std::string, int> cmdIgnore;
+
+        /// A map of commands to be renamed, pointing to new name
+        /// key is the vendor command name (including any leading +/- symbols)
+        /// value is the slang command name to be used instead
+        std::map<std::string, std::string> cmdRename;
+
+        // What we don't need:
+        // A map of commands to be renameded, with next argument merged into a plusArg format
+        // (because all slang's plusargs have non plusargs aliases, so no reason to create a plusArg)
+        // What we MIGHT need:
+        // Split a vendor's plusArg into regular arguments
+
         /// @name Include paths
         /// @{
 

--- a/include/slang/util/CommandLine.h
+++ b/include/slang/util/CommandLine.h
@@ -226,8 +226,8 @@ public:
     /// @return true on success, false if an errors occurs.
     bool parse(int argc, const char* const argv[]);
 
-    std::string setIgnoreCommand(string_view value);
-    std::string setRenameCommand(string_view value);
+    std::string addIgnoreCommand(string_view value);
+    std::string addRenameCommand(string_view value);
 #if defined(_MSC_VER)
     /// Parse the provided command line (MSVC wchar-style).
     /// @return true on success, false if an errors occurs.
@@ -360,11 +360,6 @@ private:
     /// key is the vendor command name (including any leading +/- symbols)
     /// value is the slang command name to be used instead
     std::map<std::string, std::string> cmdRename;
-
-    // What we don't need:
-    // A map of commands to be renameded, with next argument merged into a plusArg format
-    // (because all slang's plusargs have non plusargs aliases, so no reason to create a
-    // plusArg) What we MIGHT need: Split a vendor's plusArg into regular arguments
 
     std::string programName;
     std::vector<std::string> errors;

--- a/include/slang/util/CommandLine.h
+++ b/include/slang/util/CommandLine.h
@@ -189,6 +189,32 @@ public:
     void add(string_view name, std::vector<std::string>& value, string_view desc,
              string_view valueName = {}, bool isFileName = false);
 
+    /// Register an option with @a name that will be parsed as a 2-tuple of string,int.
+    /// The tuple is stored in a map, with tuple[0] being the key, and tuple[1] the value.
+    /// The option can be invoked multiple times, to add multiple entries to the map.
+    ///
+    /// @name is a comma separated list of long form and short form names
+    /// (including the dashes) that are accepted for this option.
+    /// @a desc is a human-friendly description for printing help text.
+    /// @a valueName is an example name for the value when printing help text.
+    /// @a isFileName indicates whether the parsed string is a filename that
+    ///               might be relative to the current directory.
+    void add(string_view name, std::map<std::string, int>& value, string_view desc,
+             string_view valueName);
+
+    /// Register an option with @a name that will be parsed as a 2-tuple of string,string.
+    /// The tuple is stored in a map, with tuple[0] being the key, and tuple[1] the value.
+    /// The option can be invoked multiple times, to add multiple entries to the map.
+    ///
+    /// @name is a comma separated list of long form and short form names
+    /// (including the dashes) that are accepted for this option.
+    /// @a desc is a human-friendly description for printing help text.
+    /// @a valueName is an example name for the value when printing help text.
+    /// @a isFileName indicates whether the parsed string is a filename that
+    ///               might be relative to the current directory.
+    void add(string_view name, std::map<std::string, std::string>& value, string_view desc,
+             string_view valueName);
+
     using OptionCallback = std::function<std::string(string_view)>;
 
     /// Register an option with @a name that will be parsed as a string and
@@ -288,7 +314,7 @@ private:
                      optional<uint64_t>*, optional<double>*, optional<std::string>*,
                      std::vector<int32_t>*, std::vector<uint32_t>*, std::vector<int64_t>*,
                      std::vector<uint64_t>*, std::vector<double>*, std::vector<std::string>*,
-                     OptionCallback>;
+                     OptionCallback, std::map<std::string, int>*, std::map<std::string, std::string>* >;
 
     class Option {
     public:
@@ -317,6 +343,8 @@ private:
         std::string set(std::vector<double>& target, string_view name, string_view value);
         std::string set(std::vector<std::string>& target, string_view name, string_view value);
         std::string set(OptionCallback& target, string_view name, string_view value);
+        std::string set(std::map<std::string, int>& target, string_view name, string_view value);
+        std::string set(std::map<std::string, std::string>& target, string_view name, string_view value);
 
         template<typename T>
         static constexpr bool allowValue(const optional<T>& target) {
@@ -325,6 +353,11 @@ private:
 
         template<typename T>
         static constexpr bool allowValue(const std::vector<T>&) {
+            return true;
+        }
+
+        template<typename T1, typename T2>
+        static constexpr bool allowValue(const std::map<T1, T2>&) {
             return true;
         }
     };
@@ -339,6 +372,7 @@ private:
 
     void handlePlusArg(string_view arg, ParseOptions options, bool& hadUnknowns);
 
+    Option* findOption(string_view arg) const;
     Option* findOption(string_view arg, string_view& value) const;
     Option* tryGroupOrPrefix(string_view& arg, string_view& value, ParseOptions options);
     std::string findNearestMatch(string_view arg) const;

--- a/include/slang/util/CommandLine.h
+++ b/include/slang/util/CommandLine.h
@@ -310,7 +310,8 @@ private:
                      optional<uint64_t>*, optional<double>*, optional<std::string>*,
                      std::vector<int32_t>*, std::vector<uint32_t>*, std::vector<int64_t>*,
                      std::vector<uint64_t>*, std::vector<double>*, std::vector<std::string>*,
-                     OptionCallback, std::map<std::string, int>*, std::map<std::string, std::string>* >;
+                     OptionCallback, std::map<std::string, int>*,
+                     std::map<std::string, std::string>*>;
 
     class Option {
     public:
@@ -340,7 +341,8 @@ private:
         std::string set(std::vector<std::string>& target, string_view name, string_view value);
         std::string set(OptionCallback& target, string_view name, string_view value);
         std::string set(std::map<std::string, int>& target, string_view name, string_view value);
-        std::string set(std::map<std::string, std::string>& target, string_view name, string_view value);
+        std::string set(std::map<std::string, std::string>& target, string_view name,
+                        string_view value);
 
         template<typename T>
         static constexpr bool allowValue(const optional<T>& target) {

--- a/include/slang/util/CommandLine.h
+++ b/include/slang/util/CommandLine.h
@@ -197,8 +197,6 @@ public:
     /// (including the dashes) that are accepted for this option.
     /// @a desc is a human-friendly description for printing help text.
     /// @a valueName is an example name for the value when printing help text.
-    /// @a isFileName indicates whether the parsed string is a filename that
-    ///               might be relative to the current directory.
     void add(string_view name, std::map<std::string, int>& value, string_view desc,
              string_view valueName);
 
@@ -210,8 +208,6 @@ public:
     /// (including the dashes) that are accepted for this option.
     /// @a desc is a human-friendly description for printing help text.
     /// @a valueName is an example name for the value when printing help text.
-    /// @a isFileName indicates whether the parsed string is a filename that
-    ///               might be relative to the current directory.
     void add(string_view name, std::map<std::string, std::string>& value, string_view desc,
              string_view valueName);
 

--- a/source/driver/Driver.cpp
+++ b/source/driver/Driver.cpp
@@ -53,13 +53,15 @@ void Driver::addStandardArgs() {
                 "files. --single-unit must also be passed when this option is used.");
 
     // Legacy vendor commands support
-    cmdLine.add("--cmd_ignore", options.cmdIgnore,
-                "Define rule to ignore vendor command <vendor_cmd> with its following <N> parameters.\n"
-                "A command of the form +xyz will also match any vendor command of the form +xyz+abc,\n"
-                "as +abc is the command's argument, and doesn't need to be matched.",
-                "<vendor_cmd>,<N>");
+    cmdLine.add(
+        "--cmd_ignore", options.cmdIgnore,
+        "Define rule to ignore vendor command <vendor_cmd> with its following <N> parameters.\n"
+        "A command of the form +xyz will also match any vendor command of the form +xyz+abc,\n"
+        "as +abc is the command's argument, and doesn't need to be matched.",
+        "<vendor_cmd>,<N>");
     cmdLine.add("--cmd_rename", options.cmdRename,
-                "Define rule to rename vendor command <vendor_cmd> into existing <slang_cmd>", "<vendor_cmd>,<slang_cmd>");
+                "Define rule to rename vendor command <vendor_cmd> into existing <slang_cmd>",
+                "<vendor_cmd>,<slang_cmd>");
 
     // Parsing
     cmdLine.add("--max-parse-depth", options.maxParseDepth,

--- a/source/driver/Driver.cpp
+++ b/source/driver/Driver.cpp
@@ -152,6 +152,10 @@ void Driver::addStandardArgs() {
 
     cmdLine.setPositional(
         [this](string_view fileName) {
+            if (fileName.rfind(".e"sv) == fileName.size() - 2)
+                return "";
+            if (fileName.rfind(".vhd"sv) == fileName.size() - 4)
+                return "";
             SourceBuffer buffer = readSource(fileName);
             if (!buffer)
                 anyFailedLoads = true;

--- a/source/driver/Driver.cpp
+++ b/source/driver/Driver.cpp
@@ -61,13 +61,13 @@ void Driver::addStandardArgs() {
 
     // Legacy vendor commands support
     cmdLine.add(
-        "--cmd-ignore", [this](string_view value) { return cmdLine.setIgnoreCommand(value); },
+        "--cmd-ignore", [this](string_view value) { return cmdLine.addIgnoreCommand(value); },
         "Define rule to ignore vendor command <vendor_cmd> with its following <N> parameters.\n"
         "A command of the form +xyz will also match any vendor command of the form +xyz+abc,\n"
         "as +abc is the command's argument, and doesn't need to be matched.",
         "<vendor_cmd>,<N>");
     cmdLine.add(
-        "--cmd-rename", [this](string_view value) { return cmdLine.setRenameCommand(value); },
+        "--cmd-rename", [this](string_view value) { return cmdLine.addRenameCommand(value); },
         "Define rule to rename vendor command <vendor_cmd> into existing <slang_cmd>",
         "<vendor_cmd>,<slang_cmd>");
 

--- a/source/driver/Driver.cpp
+++ b/source/driver/Driver.cpp
@@ -41,6 +41,7 @@ void Driver::addStandardArgs() {
                 "<ext>");
     cmdLine.add("--exclude-ext", options.excludeExts, "Exclude files with these extensions",
                 "<ext>");
+    options.excludeExtDone = false;
 
     // Preprocessor
     cmdLine.add("-D,--define-macro,+define", options.defines,

--- a/source/driver/Driver.cpp
+++ b/source/driver/Driver.cpp
@@ -157,7 +157,6 @@ void Driver::addStandardArgs() {
 
     cmdLine.setPositional(
         [this](string_view fileName) {
-            // static bool excludeExtDone = false;
             if (!options.excludeExtDone) {
                 for (auto& ext : options.excludeExts)
                     this->options.uniqueExcludeExtensions.emplace(ext);

--- a/source/driver/Driver.cpp
+++ b/source/driver/Driver.cpp
@@ -52,6 +52,15 @@ void Driver::addStandardArgs() {
                 "If true, library files will inherit macro definitions from the primary source "
                 "files. --single-unit must also be passed when this option is used.");
 
+    // Legacy vendor commands support
+    cmdLine.add("--cmd_ignore", options.cmdIgnore,
+                "Define rule to ignore vendor command <vendor_cmd> with its following <N> parameters.\n"
+                "A command of the form +xyz will also match any vendor command of the form +xyz+abc,\n"
+                "as +abc is the command's argument, and doesn't need to be matched.",
+                "<vendor_cmd>,<N>");
+    cmdLine.add("--cmd_rename", options.cmdRename,
+                "Define rule to rename vendor command <vendor_cmd> into existing <slang_cmd>", "<vendor_cmd>,<slang_cmd>");
+
     // Parsing
     cmdLine.add("--max-parse-depth", options.maxParseDepth,
                 "Maximum depth of nested language constructs allowed", "<depth>");

--- a/source/driver/Driver.cpp
+++ b/source/driver/Driver.cpp
@@ -61,9 +61,10 @@ void Driver::addStandardArgs() {
         "A command of the form +xyz will also match any vendor command of the form +xyz+abc,\n"
         "as +abc is the command's argument, and doesn't need to be matched.",
         "<vendor_cmd>,<N>");
-    cmdLine.add("--cmd-rename", [this](string_view value) { return cmdLine.setRenameCommand(value); },
-                "Define rule to rename vendor command <vendor_cmd> into existing <slang_cmd>",
-                "<vendor_cmd>,<slang_cmd>");
+    cmdLine.add(
+        "--cmd-rename", [this](string_view value) { return cmdLine.setRenameCommand(value); },
+        "Define rule to rename vendor command <vendor_cmd> into existing <slang_cmd>",
+        "<vendor_cmd>,<slang_cmd>");
 
     // Parsing
     cmdLine.add("--max-parse-depth", options.maxParseDepth,
@@ -156,7 +157,7 @@ void Driver::addStandardArgs() {
 
     cmdLine.setPositional(
         [this](string_view fileName) {
-            //static bool excludeExtDone = false;
+            // static bool excludeExtDone = false;
             if (!options.excludeExtDone) {
                 for (auto& ext : options.excludeExts)
                     this->options.uniqueExcludeExtensions.emplace(ext);

--- a/source/driver/Driver.cpp
+++ b/source/driver/Driver.cpp
@@ -166,7 +166,8 @@ void Driver::addStandardArgs() {
             size_t extLength = string_view::npos;
             if (extIndex == string_view::npos) // no extension
                 extLength = 0;
-            if (this->options.uniqueExcludeExtensions.count(fileName.substr(extIndex + 1, extLength)))
+            if (this->options.uniqueExcludeExtensions.count(
+                    fileName.substr(extIndex + 1, extLength)))
                 return "";
             SourceBuffer buffer = readSource(fileName);
             if (!buffer)

--- a/source/driver/Driver.cpp
+++ b/source/driver/Driver.cpp
@@ -56,12 +56,12 @@ void Driver::addStandardArgs() {
 
     // Legacy vendor commands support
     cmdLine.add(
-        "--cmd_ignore", options.cmdIgnore,
+        "--cmd-ignore", [this](string_view value) { return cmdLine.setIgnoreCommand(value); },
         "Define rule to ignore vendor command <vendor_cmd> with its following <N> parameters.\n"
         "A command of the form +xyz will also match any vendor command of the form +xyz+abc,\n"
         "as +abc is the command's argument, and doesn't need to be matched.",
         "<vendor_cmd>,<N>");
-    cmdLine.add("--cmd_rename", options.cmdRename,
+    cmdLine.add("--cmd-rename", [this](string_view value) { return cmdLine.setRenameCommand(value); },
                 "Define rule to rename vendor command <vendor_cmd> into existing <slang_cmd>",
                 "<vendor_cmd>,<slang_cmd>");
 
@@ -156,11 +156,11 @@ void Driver::addStandardArgs() {
 
     cmdLine.setPositional(
         [this](string_view fileName) {
-            static bool excludeExtDone = false;
-            if (!excludeExtDone) {
+            //static bool excludeExtDone = false;
+            if (!options.excludeExtDone) {
                 for (auto& ext : options.excludeExts)
                     this->options.uniqueExcludeExtensions.emplace(ext);
-                excludeExtDone = true;
+                options.excludeExtDone = true;
             }
             const size_t extIndex = fileName.find_last_of('.');
             size_t extLength = string_view::npos;

--- a/source/util/CommandLine.cpp
+++ b/source/util/CommandLine.cpp
@@ -875,10 +875,11 @@ std::string CommandLine::Option::set(std::map<std::string, int>& target, string_
     value = value.substr(0, firstCommaIndex);
     std::string error;
     auto result = parseInt<int>(name, numArgs, error);
-    if (result)
+    if (result) {
         target[std::string(value)] = *result;
+        return {};
+    }
     return error;
-    return {};
 }
 
 std::string CommandLine::Option::set(std::map<std::string, std::string>& target, string_view, string_view value) {

--- a/source/util/CommandLine.cpp
+++ b/source/util/CommandLine.cpp
@@ -9,8 +9,8 @@
 #include <charconv>
 #include <cstdlib>
 #include <filesystem>
-#include <sstream>
 #include <fmt/format.h>
+#include <sstream>
 
 #include "slang/text/CharInfo.h"
 #include "slang/util/SmallVector.h"
@@ -417,14 +417,16 @@ bool CommandLine::parse(span<const string_view> args, ParseOptions options) {
         // check if arg is in the list of commands to skip
         auto cmd_ignore_option = findOption("cmd_ignore");
         if (cmd_ignore_option) {
-            std::map<std::string, int>* cmdIgnore = std::get<std::map<std::string, int>*>(cmd_ignore_option->storage);
+            std::map<std::string, int>* cmdIgnore =
+                std::get<std::map<std::string, int>*>(cmd_ignore_option->storage);
             string_view ignore_arg = arg;
             // if we ignore a vendor command of the form +xx ,
             // we match on any +xx+yyy command as +yy is the command's argument
             if (arg[0] == '+') {
                 size_t plusIndex = arg.substr(1).find_first_of('+');
                 if (plusIndex != string_view::npos)
-                    ignore_arg = arg.substr(0, plusIndex + 1); // +1 because we started from arg.substr(1)
+                    ignore_arg =
+                        arg.substr(0, plusIndex + 1); // +1 because we started from arg.substr(1)
             }
             if (auto it = cmdIgnore->find(std::string(ignore_arg)); it != cmdIgnore->end()) {
                 // if yes, find how many args to skip
@@ -436,7 +438,8 @@ bool CommandLine::parse(span<const string_view> args, ParseOptions options) {
         // check if arg is in the list of commands to translate
         auto cmd_rename_option = findOption("cmd_rename");
         if (cmd_rename_option) {
-            std::map<std::string, std::string>* cmdRename = std::get<std::map<std::string, std::string>*>(cmd_rename_option->storage);
+            std::map<std::string, std::string>* cmdRename =
+                std::get<std::map<std::string, std::string>*>(cmd_rename_option->storage);
             if (auto it = cmdRename->find(std::string(arg)); it != cmdRename->end()) {
                 // if yes, rename argument
                 arg = it->second;
@@ -552,7 +555,8 @@ std::string CommandLine::getHelpText(string_view overview) const {
                 result += '\n';
                 first = false;
             }
-        } else {
+        }
+        else {
             result += "\n";
         }
     }
@@ -866,7 +870,8 @@ std::string CommandLine::Option::set(OptionCallback& target, string_view, string
     return target(value);
 }
 
-std::string CommandLine::Option::set(std::map<std::string, int>& target, string_view name, string_view value) {
+std::string CommandLine::Option::set(std::map<std::string, int>& target, string_view name,
+                                     string_view value) {
     const size_t firstCommaIndex = value.find_first_of(',');
     const size_t lastCommaIndex = value.find_last_of(',');
     if ((firstCommaIndex == string_view::npos) || (firstCommaIndex != lastCommaIndex))
@@ -882,7 +887,8 @@ std::string CommandLine::Option::set(std::map<std::string, int>& target, string_
     return error;
 }
 
-std::string CommandLine::Option::set(std::map<std::string, std::string>& target, string_view, string_view value) {
+std::string CommandLine::Option::set(std::map<std::string, std::string>& target, string_view,
+                                     string_view value) {
     const size_t firstCommaIndex = value.find_first_of(',');
     const size_t lastCommaIndex = value.find_last_of(',');
     if ((firstCommaIndex == string_view::npos) || (firstCommaIndex != lastCommaIndex))

--- a/source/util/CommandLine.cpp
+++ b/source/util/CommandLine.cpp
@@ -847,7 +847,7 @@ std::string CommandLine::Option::set(OptionCallback& target, string_view, string
     return target(value);
 }
 
-std::string CommandLine::setIgnoreCommand(string_view value) {
+std::string CommandLine::addIgnoreCommand(string_view value) {
     const size_t firstCommaIndex = value.find_first_of(',');
     const size_t lastCommaIndex = value.find_last_of(',');
     if ((firstCommaIndex == string_view::npos) || (firstCommaIndex != lastCommaIndex))
@@ -863,7 +863,7 @@ std::string CommandLine::setIgnoreCommand(string_view value) {
     return error;
 }
 
-std::string CommandLine::setRenameCommand(string_view value) {
+std::string CommandLine::addRenameCommand(string_view value) {
     const size_t firstCommaIndex = value.find_first_of(',');
     const size_t lastCommaIndex = value.find_last_of(',');
     if ((firstCommaIndex == string_view::npos) || (firstCommaIndex != lastCommaIndex))

--- a/source/util/CommandLine.cpp
+++ b/source/util/CommandLine.cpp
@@ -89,16 +89,6 @@ void CommandLine::add(string_view name, OptionCallback cb, string_view desc, str
     addInternal(name, cb, desc, valueName, isFileName);
 }
 
-void CommandLine::add(string_view name, std::map<std::string, int>& value, string_view desc,
-                      string_view valueName) {
-    addInternal(name, &value, desc, valueName);
-}
-
-void CommandLine::add(string_view name, std::map<std::string, std::string>& value, string_view desc,
-                      string_view valueName) {
-    addInternal(name, &value, desc, valueName);
-}
-
 void CommandLine::addInternal(string_view name, OptionStorage storage, string_view desc,
                               string_view valueName, bool isFileName) {
     if (name.empty())
@@ -415,10 +405,7 @@ bool CommandLine::parse(span<const string_view> args, ParseOptions options) {
         }
 
         // check if arg is in the list of commands to skip
-        auto cmd_ignore_option = findOption("cmd_ignore");
-        if (cmd_ignore_option) {
-            std::map<std::string, int>* cmdIgnore =
-                std::get<std::map<std::string, int>*>(cmd_ignore_option->storage);
+        if (!cmdIgnore.empty()) {
             string_view ignore_arg = arg;
             // if we ignore a vendor command of the form +xx ,
             // we match on any +xx+yyy command as +yy is the command's argument
@@ -428,7 +415,7 @@ bool CommandLine::parse(span<const string_view> args, ParseOptions options) {
                     ignore_arg =
                         arg.substr(0, plusIndex + 1); // +1 because we started from arg.substr(1)
             }
-            if (auto it = cmdIgnore->find(std::string(ignore_arg)); it != cmdIgnore->end()) {
+            if (auto it = cmdIgnore.find(std::string(ignore_arg)); it != cmdIgnore.end()) {
                 // if yes, find how many args to skip
                 skip = it->second;
                 continue;
@@ -436,11 +423,8 @@ bool CommandLine::parse(span<const string_view> args, ParseOptions options) {
         }
 
         // check if arg is in the list of commands to translate
-        auto cmd_rename_option = findOption("cmd_rename");
-        if (cmd_rename_option) {
-            std::map<std::string, std::string>* cmdRename =
-                std::get<std::map<std::string, std::string>*>(cmd_rename_option->storage);
-            if (auto it = cmdRename->find(std::string(arg)); it != cmdRename->end()) {
+        if (!cmdRename.empty()) {
+            if (auto it = cmdRename.find(std::string(arg)); it != cmdRename.end()) {
                 // if yes, rename argument
                 arg = it->second;
             }
@@ -612,13 +596,6 @@ void CommandLine::handlePlusArg(string_view arg, ParseOptions options, bool& had
 
     } while (!value.empty());
 }
-
-// Use this when your command line option has no use for '='
-// and you don't want to define a dummy string_view just to call findOption()
-CommandLine::Option* CommandLine::findOption(string_view arg) const {
-    static string_view findOptDummy;
-    return findOption(arg, findOptDummy);
-};
 
 CommandLine::Option* CommandLine::findOption(string_view arg, string_view& value) const {
     // If there is an equals sign, strip off the value.
@@ -870,8 +847,7 @@ std::string CommandLine::Option::set(OptionCallback& target, string_view, string
     return target(value);
 }
 
-std::string CommandLine::Option::set(std::map<std::string, int>& target, string_view name,
-                                     string_view value) {
+std::string CommandLine::setIgnoreCommand(string_view value) {
     const size_t firstCommaIndex = value.find_first_of(',');
     const size_t lastCommaIndex = value.find_last_of(',');
     if ((firstCommaIndex == string_view::npos) || (firstCommaIndex != lastCommaIndex))
@@ -879,23 +855,22 @@ std::string CommandLine::Option::set(std::map<std::string, int>& target, string_
     const string_view numArgs = value.substr(firstCommaIndex + 1);
     value = value.substr(0, firstCommaIndex);
     std::string error;
-    auto result = parseInt<int>(name, numArgs, error);
+    auto result = parseInt<int>("", numArgs, error);
     if (result) {
-        target[std::string(value)] = *result;
+        cmdIgnore[std::string(value)] = *result;
         return {};
     }
     return error;
 }
 
-std::string CommandLine::Option::set(std::map<std::string, std::string>& target, string_view,
-                                     string_view value) {
+std::string CommandLine::setRenameCommand(string_view value) {
     const size_t firstCommaIndex = value.find_first_of(',');
     const size_t lastCommaIndex = value.find_last_of(',');
     if ((firstCommaIndex == string_view::npos) || (firstCommaIndex != lastCommaIndex))
         return fmt::format("missing or extra comma in argument '{}'", value);
     const string_view slangName = value.substr(firstCommaIndex + 1);
     value = value.substr(0, firstCommaIndex);
-    target[std::string(value)] = slangName;
+    cmdRename[std::string(value)] = slangName;
     return {};
 }
 

--- a/tests/unittests/DriverTests.cpp
+++ b/tests/unittests/DriverTests.cpp
@@ -379,7 +379,8 @@ TEST_CASE("Driver flag --exclude-ext (multiple use)") {
     auto filePath1 = findTestDir() + "test.sv";
     auto filePath2 = findTestDir() + "test.vhd";
     auto filePath3 = findTestDir() + "test.e";
-    const char* argv[] = { "testfoo", "--exclude-ext", "vhd", "--exclude-ext", "e", filePath1.c_str(), filePath2.c_str()/*, filePath3.c_str()*/ };
+    const char* argv[] = { "testfoo",         "--exclude-ext",  "vhd", "--exclude-ext", "e",
+                           filePath1.c_str(), filePath2.c_str() /*, filePath3.c_str()*/ };
     CHECK(driver.parseCommandLine(sizeof(argv) / sizeof(argv[0]), argv));
     CHECK(driver.processOptions());
 }

--- a/tests/unittests/DriverTests.cpp
+++ b/tests/unittests/DriverTests.cpp
@@ -380,7 +380,7 @@ TEST_CASE("Driver flag --exclude-ext (multiple use)") {
     auto filePath2 = findTestDir() + "test.vhd";
     auto filePath3 = findTestDir() + "test.e";
     const char* argv[] = { "testfoo",         "--exclude-ext",  "vhd", "--exclude-ext", "e",
-                           filePath1.c_str(), filePath2.c_str() /*, filePath3.c_str()*/ };
+                           filePath1.c_str(), filePath2.c_str(), filePath3.c_str() };
     CHECK(driver.parseCommandLine(sizeof(argv) / sizeof(argv[0]), argv));
     CHECK(driver.processOptions());
 }

--- a/tests/unittests/DriverTests.cpp
+++ b/tests/unittests/DriverTests.cpp
@@ -379,8 +379,10 @@ TEST_CASE("Driver flag --exclude-ext (multiple use)") {
     auto filePath1 = findTestDir() + "test.sv";
     auto filePath2 = findTestDir() + "test.vhd";
     auto filePath3 = findTestDir() + "test.e";
-    const char* argv[] = { "testfoo",         "--exclude-ext",  "vhd", "--exclude-ext", "e",
-                           filePath1.c_str(), filePath2.c_str(), filePath3.c_str() };
+    const char* argv[] = {
+        "testfoo",         "--exclude-ext",  "vhd", "--exclude-ext", "e", filePath1.c_str(),
+        filePath2.c_str(), filePath3.c_str()
+    };
     CHECK(driver.parseCommandLine(sizeof(argv) / sizeof(argv[0]), argv));
     CHECK(driver.processOptions());
 }

--- a/tests/unittests/DriverTests.cpp
+++ b/tests/unittests/DriverTests.cpp
@@ -369,3 +369,17 @@ TEST_CASE("Driver command files are processed strictly in order") {
     CHECK(fileNames.size() == 4);
     CHECK(std::is_sorted(fileNames.begin(), fileNames.end()));
 }
+
+TEST_CASE("Driver flag --exclude-ext (multiple use)") {
+    auto guard = OS::captureOutput();
+
+    Driver driver;
+    driver.addStandardArgs();
+
+    auto filePath1 = findTestDir() + "test.sv";
+    auto filePath2 = findTestDir() + "test.vhd";
+    auto filePath3 = findTestDir() + "test.e";
+    const char* argv[] = { "testfoo", "--exclude-ext", "vhd", "--exclude-ext", "e", filePath1.c_str(), filePath2.c_str()/*, filePath3.c_str()*/ };
+    CHECK(driver.parseCommandLine(sizeof(argv) / sizeof(argv[0]), argv));
+    CHECK(driver.processOptions());
+}

--- a/tests/unittests/DriverTests.cpp
+++ b/tests/unittests/DriverTests.cpp
@@ -380,7 +380,7 @@ TEST_CASE("Driver flag --exclude-ext (multiple use)") {
     auto filePath2 = findTestDir() + "test.vhd";
     auto filePath3 = findTestDir() + "test.e";
     const char* argv[] = {
-        "testfoo",         "--exclude-ext",  "vhd", "--exclude-ext", "e", filePath1.c_str(),
+        "testfoo", "--exclude-ext", "vhd", "--exclude-ext", "e", filePath1.c_str(),
         filePath2.c_str(), filePath3.c_str()
     };
     CHECK(driver.parseCommandLine(sizeof(argv) / sizeof(argv[0]), argv));

--- a/tests/unittests/DriverTests.cpp
+++ b/tests/unittests/DriverTests.cpp
@@ -380,7 +380,7 @@ TEST_CASE("Driver flag --exclude-ext (multiple use)") {
     auto filePath2 = findTestDir() + "test.vhd";
     auto filePath3 = findTestDir() + "test.e";
     const char* argv[] = {
-        "testfoo", "--exclude-ext", "vhd", "--exclude-ext", "e", filePath1.c_str(),
+        "testfoo",         "--exclude-ext",  "vhd", "--exclude-ext", "e", filePath1.c_str(),
         filePath2.c_str(), filePath3.c_str()
     };
     CHECK(driver.parseCommandLine(sizeof(argv) / sizeof(argv[0]), argv));

--- a/tests/unittests/UtilTests.cpp
+++ b/tests/unittests/UtilTests.cpp
@@ -443,11 +443,12 @@ TEST_CASE("Test CommandLine -- check setIgnoreCommand()") {
     options.ignoreDuplicates = true;
 
     CHECK(cmdLine.parse("prog --yyy --foo 456 --foo 123 --xxx", options));
-    // --foo 456 is skipped because it's not a real flag, it's --yyy's two parameters, which are ignored
+    // --foo 456 is skipped because it's not a real flag, it's --yyy's two parameters, which are
+    // ignored
     CHECK(foo == 123);
 
     auto errors = cmdLine.getErrors();
-    //std::cout << errors[0];
+    // std::cout << errors[0];
     REQUIRE(errors.size() == 0);
 }
 
@@ -467,6 +468,6 @@ TEST_CASE("Test CommandLine -- check setRenameCommand()") {
     CHECK(bar == 456);
 
     auto errors = cmdLine.getErrors();
-    //std::cout << errors[0];
+    // std::cout << errors[0];
     REQUIRE(errors.size() == 0);
 }

--- a/tests/unittests/UtilTests.cpp
+++ b/tests/unittests/UtilTests.cpp
@@ -437,8 +437,8 @@ TEST_CASE("Test CommandLine -- check setIgnoreCommand()") {
 
     CommandLine cmdLine;
     cmdLine.add("--foo", foo, "");
-    cmdLine.setIgnoreCommand("--xxx,0");
-    cmdLine.setIgnoreCommand("--yyy,2");
+    cmdLine.addIgnoreCommand("--xxx,0");
+    cmdLine.addIgnoreCommand("--yyy,2");
     CommandLine::ParseOptions options;
     options.ignoreDuplicates = true;
 
@@ -459,8 +459,8 @@ TEST_CASE("Test CommandLine -- check setRenameCommand()") {
     CommandLine cmdLine;
     cmdLine.add("--foo", foo, "");
     cmdLine.add("--bar", bar, "");
-    cmdLine.setRenameCommand("--xxx,--foo");
-    cmdLine.setRenameCommand("--yyy,--bar");
+    cmdLine.addRenameCommand("--xxx,--foo");
+    cmdLine.addRenameCommand("--yyy,--bar");
     CommandLine::ParseOptions options;
 
     CHECK(cmdLine.parse("prog --xxx 123 --yyy 456", options));


### PR DESCRIPTION
This PR intends to make it easier to work with legacy workflows. It contains 3 unrelated changes (2 of which are unfortunately on the same commit):
1. Allow long command line option descriptions to be broken by newlines and neatly indented on the help screen.
2. Ignore Specman and VHDL files given on the command line.
3. Parse legacy EDA vendor file lists (relates to item 2 above).

I really hope my coding style is OK. Reading your codebase made me do lots of C++ catch-ups, but on the other hand, I restricted myself not to use any C++ 20 construct (`string_view::ends_with()` for example).

**As for the PR itself:**
A legacy codebase might contain for example thousands of files, split across dozens of file lists,
each one holding a separate block of 3rd party IP.

Unfortunately, each vendor tool has a unique command line interface, sometimes with thousands of possible flags.
`slang` cannot parse these file lists as-is.

Instead of taking a large effort , going over the file lists and converting those into equivalent `slang` file lists, this PR does the opposite - it allows us to define the vendor commands which we want to ignore and the vendor commands we want to rename into equivalent `slang` commands.

We define two new `slang` command line options:
```
  --cmd_ignore <vendor_cmd>,<N>            Define rule to ignore vendor command <vendor_cmd> with its following <N> parameters.
                                           A command of the form +xyz will also match any vendor command of the form +xyz+abc,
                                           as +abc is the command's argument, and doesn't need to be matched.
  --cmd_rename <vendor_cmd>,<slang_cmd>    Define rule to rename vendor command <vendor_cmd> into existing <slang_cmd>
```

Here is an example, combining all new features:
```
slang --cmd_ignore --xx,1 --cmd_ignore --ww,0 --cmd_ignore +abc,0 --cmd_rename --yy,--version --cmd_rename --zz,--help --xx 12121 --ww +abc+xyz x.vhd x.e x.v
```
First we define the `--xx` command to be ignored with it's 1 extra parameter.
Next we define the `+abc` command to be ignored too, which has no parameters.
Next we define the vendor command `--yy` to bre renamed into `slang`'s `--version` option.
Next we define the vendor command `--zz` to bre renamed into `slang`'s `--help` option.
Next we use the vendor `--xx 12121` option, which is ignored with its parameter.
Next we use the vendor `--ww` command which is also ignored (no parameter)
Finally, we ignore the vendor `+abc` command which has an embedded `+xyz` parameter.
Now we get 3 files, `x.vhd` , `x.e`,  (which we both ignore) and `x.v` which we read.

A typical usage would be to run the top level file list of your legacy code, see which commands `slang` is complaining about, and add them to your custom `vendor.f` file. once you are done, you can simply run:

```
slang -f vendor.f -f legacy_filelist.f
```

Using this technique, I was able to parse my legacy codebase without any unknown vendor command, but unfortunately `slang` has a few language coverage holes, and maybe a bug or two (one of the `` `define``'s is not detected, which is I know to be false, as other tools reads this design just fine).
I'll try to get to those bugs next week.
