### PR TITLE
Enhance SyntaxVisitor functionality, let it support non-const lvalue object

### DIFF
--- a/include/slang/syntax/SyntaxNode.h
+++ b/include/slang/syntax/SyntaxNode.h
@@ -40,10 +40,6 @@ struct TokenOrSyntaxBase : public std::variant<Token, TNode> {
 
     /// Gets access to the object as a syntax node (throwing an exception
     /// if it's not actually a syntax node).
-    TNode node() { return std::get<1>(*this); }
-
-    /// Gets access to the object as a syntax node (throwing an exception
-    /// if it's not actually a syntax node).
     TNode node() const { return std::get<1>(*this); }
 
 protected:

--- a/include/slang/syntax/SyntaxNode.h
+++ b/include/slang/syntax/SyntaxNode.h
@@ -40,6 +40,10 @@ struct TokenOrSyntaxBase : public std::variant<Token, TNode> {
 
     /// Gets access to the object as a syntax node (throwing an exception
     /// if it's not actually a syntax node).
+    TNode node() { return std::get<1>(*this); }
+
+    /// Gets access to the object as a syntax node (throwing an exception
+    /// if it's not actually a syntax node).
     TNode node() const { return std::get<1>(*this); }
 
 protected:
@@ -83,6 +87,10 @@ public:
     /// Gets the child syntax node at the specified index. If the child at
     /// the given index is not a node (probably a token) then this returns null.
     const SyntaxNode* childNode(size_t index) const;
+
+    /// Gets the child syntax node at the specified index. If the child at
+    /// the given index is not a node (probably a token) then this returns null.
+    SyntaxNode* childNode(size_t index);
 
     /// Gets the child token at the specified index. If the child at
     /// the given index is not a token (probably a node) then this returns
@@ -128,6 +136,7 @@ protected:
 
 private:
     ConstTokenOrSyntax getChild(size_t index) const;
+    TokenOrSyntax getChild(size_t index);
 };
 
 /// A base class for syntax nodes that represent a list of items.

--- a/include/slang/syntax/SyntaxVisitor.h
+++ b/include/slang/syntax/SyntaxVisitor.h
@@ -24,12 +24,12 @@ namespace slang {
 template<typename TDerived>
 class SyntaxVisitor {
     template<typename T, typename Arg>
-    using handle_t = decltype(std::declval<T>().handle(std::declval<Arg>()));
+    using handle_t = decltype(std::declval<T>().handle(std::declval<Arg&&>()));
 
 public:
     /// Visit the provided node, of static type T.
     template<typename T>
-    void visit(const T& t) {
+    void visit(T&& t) {
         if constexpr (is_detected_v<handle_t, TDerived, T>)
             DERIVED->handle(t);
         else
@@ -38,7 +38,8 @@ public:
 
     /// The default handler invoked when no visit() method is overridden for a particular type.
     /// Will visit all child nodes by default.
-    void visitDefault(const SyntaxNode& node) {
+    template<typename T>
+    void visitDefault(T&& node) {
         for (uint32_t i = 0; i < node.getChildCount(); i++) {
             auto child = node.childNode(i);
             if (child)

--- a/source/syntax/SyntaxNode.cpp
+++ b/source/syntax/SyntaxNode.cpp
@@ -14,13 +14,22 @@ namespace {
 
 using namespace slang;
 
-struct GetChildVisitor {
+struct ConstGetChildVisitor {
     template<typename T>
     ConstTokenOrSyntax visit(const T& node, size_t index) {
         return node.getChild(index);
     }
 
     ConstTokenOrSyntax visitInvalid(const SyntaxNode&, size_t) { return nullptr; }
+};
+
+struct GetChildVisitor {
+    template<typename T>
+    TokenOrSyntax visit(T& node, size_t index) {
+        return node.getChild(index);
+    }
+
+    TokenOrSyntax visitInvalid(SyntaxNode&, size_t) { return nullptr; }
 };
 
 } // namespace
@@ -79,11 +88,23 @@ SourceRange SyntaxNode::sourceRange() const {
 }
 
 ConstTokenOrSyntax SyntaxNode::getChild(size_t index) const {
+    ConstGetChildVisitor visitor;
+    return visit(visitor, index);
+}
+
+TokenOrSyntax SyntaxNode::getChild(size_t index) {
     GetChildVisitor visitor;
     return visit(visitor, index);
 }
 
 const SyntaxNode* SyntaxNode::childNode(size_t index) const {
+    auto child = getChild(index);
+    if (child.isToken())
+        return nullptr;
+    return child.node();
+}
+
+SyntaxNode* SyntaxNode::childNode(size_t index) {
     auto child = getChild(index);
     if (child.isToken())
         return nullptr;


### PR DESCRIPTION
I  want this functionality.
``` cpp
struct Visitor {
   // ignored
};
MemberSyntax *ptr = ....;
MemberSyntax *clone_ptr = ptr->clone(alloc); // It should be deepClone, but assume it works
clone_ptr->visit(Visitor{});
```
I want to reuse to logic on `SyntaxVisitor`, like this.
``` cpp
struct Visitor  : public slang::SyntaxVisitor<Visitor> {
    void handle(IdentifierNameSyntax& decl) {
           // ignored
    }
    void handle(DeclaratorSyntax& decl) {
           // ignored
    }
};
```
it modified the cloned_object directly, but the current implementation doesn't support it.
