### PR TITLE
Optionally enable duplicate primitives

### DIFF
--- a/source/ast/Compilation.cpp
+++ b/source/ast/Compilation.cpp
@@ -512,15 +512,12 @@ const PrimitiveSymbol& Compilation::createPrimitive(const Scope& scope,
                                                     const UdpDeclarationSyntax& syntax) {
     auto& prim = PrimitiveSymbol::fromSyntax(scope, syntax);
     if (!prim.name.empty()) {
-        auto [it, inserted] = udpMap.emplace(prim.name, &prim);
-        if (!inserted) {
-            auto& diag = root->addDiag(diag::Redefinition, prim.location);
-            diag << prim.name;
-            diag.addNote(diag::NotePreviousDefinition, it->second->location);
-        }
+        if (auto ps = getPrimitive(prim.name))
+            reportRedefinition(*root, prim, *ps, diag::DuplicateDefinition);
         else if (auto defIt = topDefinitions.find(prim.name); defIt != topDefinitions.end()) {
             reportRedefinition(*root, prim, *defIt->second.first);
         }
+        udpMap[prim.name] = &prim;
     }
 
     return prim;

--- a/tests/unittests/MemberTests.cpp
+++ b/tests/unittests/MemberTests.cpp
@@ -1750,7 +1750,7 @@ endprimitive
     REQUIRE(diags.size() == 20);
     CHECK(diags[0].code == diag::PrimitiveOutputFirst);
     CHECK(diags[1].code == diag::PrimitiveAnsiMix);
-    CHECK(diags[2].code == diag::Redefinition);
+    CHECK(diags[2].code == diag::DuplicateDefinition);
     CHECK(diags[3].code == diag::PrimitiveTwoPorts);
     CHECK(diags[4].code == diag::PrimitivePortDup);
     CHECK(diags[5].code == diag::PrimitiveRegDup);


### PR DESCRIPTION
Some commercial tools allows redefining primitives (only if invoking the specific command line flag allowing this).
In order to allow such a behavior, the `-Wno-duplicate-definition` flag can be used.
