### PR TITLE
Bugfix, fix deepClone crash issue on token copy

### DIFF
--- a/include/slang/parsing/Token.h
+++ b/include/slang/parsing/Token.h
@@ -114,6 +114,8 @@ public:
     /// If the trivia represents skipped tokens, returns the list of tokens that were
     /// skipped. Otherwise returns an empty span.
     span<Token const> getSkippedTokens() const;
+
+    Trivia clone(BumpAllocator& alloc) const;
 };
 #if !defined(_M_IX86)
 static_assert(sizeof(Trivia) == 16);
@@ -188,6 +190,7 @@ public:
     [[nodiscard]] Token withRawText(BumpAllocator& alloc, string_view rawText) const;
     [[nodiscard]] Token clone(BumpAllocator& alloc, span<Trivia const> trivia, string_view rawText,
                               SourceLocation location) const;
+    [[nodiscard]] Token deepClone(BumpAllocator& alloc) const;
 
     static Token createMissing(BumpAllocator& alloc, TokenKind kind, SourceLocation location);
     static Token createExpected(BumpAllocator& alloc, Diagnostics& diagnostics, Token actual,

--- a/include/slang/syntax/SyntaxNode.h
+++ b/include/slang/syntax/SyntaxNode.h
@@ -354,7 +354,7 @@ SeparatedSyntaxList<T>* deepClone(const SeparatedSyntaxList<T>& node, BumpAlloca
     SmallVectorSized<TokenOrSyntax, 8> buffer(node.size());
     for (const auto& ele : node.elems()) {
         if (ele.isToken())
-            buffer.append(ele.token());
+            buffer.append(ele.token().deepClone(alloc));
         else
             buffer.append(static_cast<T*>(deepClone(*ele.node(), alloc)));
     }

--- a/scripts/syntax_gen.py
+++ b/scripts/syntax_gen.py
@@ -773,6 +773,8 @@ SyntaxNode* clone(const SyntaxListBase&, BumpAllocator&) {
                     "SeparatedSyntaxList"
                 ):
                     clonef.write("        *deepClone(node.{0}, alloc)".format(m[1]))
+                elif m[0] == "Token":
+                    clonef.write("        node.{0}.deepClone(alloc)".format(m[1]))
                 else:
                     clonef.write("        node.{0}".format(m[1]))
                 if i != len(v.combinedMembers) - 1:


### PR DESCRIPTION
This is a bugfix for deepClone.
In the previous implementation, token would adopt shallow copy.
So with different life cycle BumpAllocators, it would crash.
Here is my test case.
``` cpp
        auto tree = SyntaxTree::fromText(R"(module m; reg tmp; endmodule)");
        class CloneRewriter : public SyntaxVisitor<CloneRewriter> {
            std::shared_ptr<SyntaxTree>& tree;

        public:
            CloneRewriter(std::shared_ptr<SyntaxTree>& tree) : tree(tree) {}
            void handle(const ModuleDeclarationSyntax& decl) {
                BumpAllocator newAlloc;
                auto newModule = slang::syntax::deepClone(decl, newAlloc);
                tree = std::make_shared<SyntaxTree>(newModule, tree->sourceManager(),
                                                    std::move(newAlloc));
            }
        };
        CloneRewriter visitor(tree);
        tree->root().visit(visitor);
```
Without modification, the original BumpAllocator would be destroyed, and it would meet use-after-free issue.
