### PR TITLE
Bugfix, fix deepClone crash issue for directly copy raw pointer

### DIFF
--- a/scripts/syntax_gen.py
+++ b/scripts/syntax_gen.py
@@ -763,6 +763,12 @@ SyntaxNode* clone(const SyntaxListBase&, BumpAllocator&) {
                             m[0][9:-2], m[1]
                         )
                     )
+                elif m[1] in v.optionalMembers:
+                    clonef.write(
+                        "        node.{0} ? deepClone(*node.{0}, alloc) : nullptr".format(
+                            m[1]
+                        )
+                    )
                 elif m[0].startswith("SyntaxList") or m[0].startswith(
                     "SeparatedSyntaxList"
                 ):


### PR DESCRIPTION
These issue is different from #624 
The root cause is 
``` cpp
struct ModuleHeaderSyntax : public SyntaxNode {
    Token moduleKeyword;
    Token lifetime;
    Token name;
    SyntaxList<PackageImportDeclarationSyntax> imports;
    ParameterPortListSyntax* parameters;
    PortListSyntax* ports;
    Token semi;
};
```
It owns raw pointer, and  it should be deepClone either, but the original script doesn't handle it.
Since the raw pointer maybe nullptr, the generated code looks similar
``` cpp
node.parameters ? deepClone(*node.parameters, alloc) : nullptr,
```