### PR TITLE
scripts/sv-lang.pc.in: fix includedir and libdir when generate sv-lang.pc

### DIFF
--- a/scripts/sv-lang.pc.in
+++ b/scripts/sv-lang.pc.in
@@ -1,6 +1,6 @@
 prefix=@CMAKE_INSTALL_PREFIX@
-includedir="${prefix}/include"
-libdir="${prefix}/lib"
+includedir="${prefix}/@CMAKE_INSTALL_INCLUDEDIR@"
+libdir="${prefix}/@CMAKE_INSTALL_LIBDIR@"
 
 Name: @PROJECT_NAME@
 Description: @PROJECT_DESCRIPTION@


### PR DESCRIPTION
Don't hardcode path here, will introduce trouble on different platforms.

Fix includedir and libdir, lib or lib64 or lib/<multiarch-tuple> by different target environment.

Before fix (on gentoo amd64)
file sv-lang.pc
```c
prefix=/usr/local
includedir="${prefix}/include"
libdir="${prefix}/lib"

Name: slang
Description: SystemVerilog compiler and language services
URL: https://sv-lang.com/
Version: 1.0.346
Cflags: -I"${includedir}"
Libs: -L"${libdir}" -lslang

```

The ``${prefix}/lib`` is the wrong lib path.

After fix (on gentoo amd64)
file sv-lang.pc
```c
prefix=/usr/local
includedir="${prefix}/include"
libdir="${prefix}/lib64"

Name: slang
Description: SystemVerilog compiler and language services
URL: https://sv-lang.com/
Version: 1.0.346
Cflags: -I"${includedir}"
Libs: -L"${libdir}" -lslang

```
