### PR TITLE
Improve parseability of type and constant string representations

### DIFF
--- a/bindings/python/types.cpp
+++ b/bindings/python/types.cpp
@@ -118,7 +118,9 @@ void registerTypes(py::module_& m) {
     typePrintingOptions.def_readwrite("addSingleQuotes", &TypePrintingOptions::addSingleQuotes)
         .def_readwrite("elideScopeNames", &TypePrintingOptions::elideScopeNames)
         .def_readwrite("printAKA", &TypePrintingOptions::printAKA)
-        .def_readwrite("anonymousTypeStyle", &TypePrintingOptions::anonymousTypeStyle);
+        .def_readwrite("anonymousTypeStyle", &TypePrintingOptions::anonymousTypeStyle)
+        .def_readwrite("skipScopedTypeNames", &TypePrintingOptions::anonymousTypeStyle)
+        .def_readwrite("fullEnumType", &TypePrintingOptions::anonymousTypeStyle);
 
     py::enum_<TypePrintingOptions::AnonymousTypeStyle>(typePrintingOptions, "AnonymousTypeStyle")
         .value("SystemName", TypePrintingOptions::SystemName)

--- a/include/slang/ast/types/TypePrinter.h
+++ b/include/slang/ast/types/TypePrinter.h
@@ -25,6 +25,7 @@ struct SLANG_EXPORT TypePrintingOptions {
     bool addSingleQuotes = false;
     bool elideScopeNames = false;
     bool printAKA = false;
+    bool skipScopedTypeNames = false;
 
     enum AnonymousTypeStyle { SystemName, FriendlyName } anonymousTypeStyle = SystemName;
 };

--- a/include/slang/ast/types/TypePrinter.h
+++ b/include/slang/ast/types/TypePrinter.h
@@ -26,6 +26,7 @@ struct SLANG_EXPORT TypePrintingOptions {
     bool elideScopeNames = false;
     bool printAKA = false;
     bool skipScopedTypeNames = false;
+    bool fullEnumType = false;
 
     enum AnonymousTypeStyle { SystemName, FriendlyName } anonymousTypeStyle = SystemName;
 };

--- a/include/slang/numeric/ConstantValue.h
+++ b/include/slang/numeric/ConstantValue.h
@@ -147,7 +147,8 @@ public:
     Variant& getVariant() { return value; }
     const Variant& getVariant() const { return value; }
 
-    std::string toString() const;
+    std::string toString(bitwidth_t abbreviateThresholdBits =
+            SVInt::DefaultStringAbbreviationThresholdBits) const;
     size_t hash() const;
 
     [[nodiscard]] bool empty() const;

--- a/include/slang/numeric/ConstantValue.h
+++ b/include/slang/numeric/ConstantValue.h
@@ -147,8 +147,8 @@ public:
     Variant& getVariant() { return value; }
     const Variant& getVariant() const { return value; }
 
-    std::string toString(bitwidth_t abbreviateThresholdBits =
-            SVInt::DefaultStringAbbreviationThresholdBits, bool exactUnknowns = false) const;
+    std::string toString(bitwidth_t abbreviateThresholdBits = SVInt::DefaultStringAbbreviationThresholdBits,
+                         bool exactUnknowns = false, bool useAssignmentPatterns = false) const;
     size_t hash() const;
 
     [[nodiscard]] bool empty() const;

--- a/include/slang/numeric/ConstantValue.h
+++ b/include/slang/numeric/ConstantValue.h
@@ -148,7 +148,7 @@ public:
     const Variant& getVariant() const { return value; }
 
     std::string toString(bitwidth_t abbreviateThresholdBits =
-            SVInt::DefaultStringAbbreviationThresholdBits) const;
+            SVInt::DefaultStringAbbreviationThresholdBits, bool exactUnknowns = false) const;
     size_t hash() const;
 
     [[nodiscard]] bool empty() const;

--- a/include/slang/numeric/ConstantValue.h
+++ b/include/slang/numeric/ConstantValue.h
@@ -147,8 +147,9 @@ public:
     Variant& getVariant() { return value; }
     const Variant& getVariant() const { return value; }
 
-    std::string toString(bitwidth_t abbreviateThresholdBits = SVInt::DefaultStringAbbreviationThresholdBits,
-                         bool exactUnknowns = false, bool useAssignmentPatterns = false) const;
+    std::string toString(
+        bitwidth_t abbreviateThresholdBits = SVInt::DefaultStringAbbreviationThresholdBits,
+        bool exactUnknowns = false, bool useAssignmentPatterns = false) const;
     size_t hash() const;
 
     [[nodiscard]] bool empty() const;

--- a/include/slang/numeric/SVInt.h
+++ b/include/slang/numeric/SVInt.h
@@ -301,7 +301,7 @@ public:
     void writeTo(SmallVectorBase<char>& buffer, LiteralBase base, bool includeBase,
                  bitwidth_t abbreviateThresholdBits = MAX_BITS) const;
     std::string toString(bitwidth_t abbreviateThresholdBits =
-            DefaultStringAbbreviationThresholdBits) const;
+            DefaultStringAbbreviationThresholdBits, bool exactUnknowns = false) const;
     std::string toString(LiteralBase base, bitwidth_t abbreviateThresholdBits =
             DefaultStringAbbreviationThresholdBits) const;
     std::string toString(LiteralBase base, bool includeBase,

--- a/include/slang/numeric/SVInt.h
+++ b/include/slang/numeric/SVInt.h
@@ -296,11 +296,14 @@ public:
     static SVInt createFillZ(bitwidth_t bitWidth, bool isSigned);
 
     [[nodiscard]] size_t hash() const;
-    void writeTo(SmallVectorBase<char>& buffer, LiteralBase base) const;
+    void writeTo(SmallVectorBase<char>& buffer, LiteralBase base, bitwidth_t
+        abbreviateThresholdBits = DefaultStringAbbreviationThresholdBits) const;
     void writeTo(SmallVectorBase<char>& buffer, LiteralBase base, bool includeBase,
                  bitwidth_t abbreviateThresholdBits = MAX_BITS) const;
-    std::string toString() const;
-    std::string toString(LiteralBase base) const;
+    std::string toString(bitwidth_t abbreviateThresholdBits =
+            DefaultStringAbbreviationThresholdBits) const;
+    std::string toString(LiteralBase base, bitwidth_t abbreviateThresholdBits =
+            DefaultStringAbbreviationThresholdBits) const;
     std::string toString(LiteralBase base, bool includeBase,
                          bitwidth_t abbreviateThresholdBits = MAX_BITS) const;
 
@@ -550,7 +553,7 @@ public:
     static const SVInt One;
 
     /// The default threshold, in bits, to use for abbreviating toString results
-    /// when calling one of the simple toString() methods that doesn't take a user
+    /// when calling one of the simple toString() methods without passing a user
     /// provided threshold.
     static constexpr bitwidth_t DefaultStringAbbreviationThresholdBits = 128;
 

--- a/include/slang/numeric/SVInt.h
+++ b/include/slang/numeric/SVInt.h
@@ -296,14 +296,15 @@ public:
     static SVInt createFillZ(bitwidth_t bitWidth, bool isSigned);
 
     [[nodiscard]] size_t hash() const;
-    void writeTo(SmallVectorBase<char>& buffer, LiteralBase base, bitwidth_t
-        abbreviateThresholdBits = DefaultStringAbbreviationThresholdBits) const;
+    void writeTo(SmallVectorBase<char>& buffer, LiteralBase base,
+                 bitwidth_t abbreviateThresholdBits = DefaultStringAbbreviationThresholdBits) const;
     void writeTo(SmallVectorBase<char>& buffer, LiteralBase base, bool includeBase,
                  bitwidth_t abbreviateThresholdBits = MAX_BITS) const;
-    std::string toString(bitwidth_t abbreviateThresholdBits =
-            DefaultStringAbbreviationThresholdBits, bool exactUnknowns = false) const;
+    std::string toString(
+        bitwidth_t abbreviateThresholdBits = DefaultStringAbbreviationThresholdBits,
+        bool exactUnknowns = false) const;
     std::string toString(LiteralBase base, bitwidth_t abbreviateThresholdBits =
-            DefaultStringAbbreviationThresholdBits) const;
+                                               DefaultStringAbbreviationThresholdBits) const;
     std::string toString(LiteralBase base, bool includeBase,
                          bitwidth_t abbreviateThresholdBits = MAX_BITS) const;
 

--- a/source/ast/types/TypePrinter.cpp
+++ b/source/ast/types/TypePrinter.cpp
@@ -101,7 +101,8 @@ void TypePrinter::visit(const EnumType& type, string_view overrideName) {
         }
         buffer->append("}");
 
-        if (!overrideName.empty())
+        if (options.skipScopedTypeNames);
+        else if (!overrideName.empty())
             buffer->append(overrideName);
         else {
             printScope(type.getParentScope());
@@ -142,7 +143,8 @@ void TypePrinter::visit(const PackedStructType& type, string_view overrideName) 
 
         appendMembers(type);
 
-        if (!overrideName.empty())
+        if (options.skipScopedTypeNames);
+        else if (!overrideName.empty())
             buffer->append(overrideName);
         else {
             printScope(type.getParentScope());
@@ -167,7 +169,8 @@ void TypePrinter::visit(const PackedUnionType& type, string_view overrideName) {
 
         appendMembers(type);
 
-        if (!overrideName.empty())
+        if (options.skipScopedTypeNames);
+        else if (!overrideName.empty())
             buffer->append(overrideName);
         else {
             printScope(type.getParentScope());
@@ -241,7 +244,8 @@ void TypePrinter::visit(const UnpackedStructType& type, string_view overrideName
         buffer->append("struct");
         appendMembers(type);
 
-        if (!overrideName.empty())
+        if (options.skipScopedTypeNames);
+        else if (!overrideName.empty())
             buffer->append(overrideName);
         else {
             printScope(type.getParentScope());
@@ -263,7 +267,8 @@ void TypePrinter::visit(const UnpackedUnionType& type, string_view overrideName)
         buffer->append("union");
         appendMembers(type);
 
-        if (!overrideName.empty())
+        if (options.skipScopedTypeNames);
+        else if (!overrideName.empty())
             buffer->append(overrideName);
         else {
             printScope(type.getParentScope());

--- a/source/ast/types/TypePrinter.cpp
+++ b/source/ast/types/TypePrinter.cpp
@@ -87,7 +87,11 @@ void TypePrinter::visit(const EnumType& type, string_view overrideName) {
             buffer->append(overrideName);
     }
     else {
-        buffer->append("enum{");
+        buffer->append("enum");
+        if (options.fullEnumType) {
+            buffer->append(" " + type.baseType.toString());
+        }
+        buffer->append("{");
 
         bool first = true;
         for (const auto& member : type.values()) {

--- a/source/ast/types/TypePrinter.cpp
+++ b/source/ast/types/TypePrinter.cpp
@@ -105,7 +105,8 @@ void TypePrinter::visit(const EnumType& type, string_view overrideName) {
         }
         buffer->append("}");
 
-        if (options.skipScopedTypeNames);
+        if (options.skipScopedTypeNames)
+            ;
         else if (!overrideName.empty())
             buffer->append(overrideName);
         else {
@@ -147,7 +148,8 @@ void TypePrinter::visit(const PackedStructType& type, string_view overrideName) 
 
         appendMembers(type);
 
-        if (options.skipScopedTypeNames);
+        if (options.skipScopedTypeNames)
+            ;
         else if (!overrideName.empty())
             buffer->append(overrideName);
         else {
@@ -173,7 +175,8 @@ void TypePrinter::visit(const PackedUnionType& type, string_view overrideName) {
 
         appendMembers(type);
 
-        if (options.skipScopedTypeNames);
+        if (options.skipScopedTypeNames)
+            ;
         else if (!overrideName.empty())
             buffer->append(overrideName);
         else {
@@ -248,7 +251,8 @@ void TypePrinter::visit(const UnpackedStructType& type, string_view overrideName
         buffer->append("struct");
         appendMembers(type);
 
-        if (options.skipScopedTypeNames);
+        if (options.skipScopedTypeNames)
+            ;
         else if (!overrideName.empty())
             buffer->append(overrideName);
         else {
@@ -271,7 +275,8 @@ void TypePrinter::visit(const UnpackedUnionType& type, string_view overrideName)
         buffer->append("union");
         appendMembers(type);
 
-        if (options.skipScopedTypeNames);
+        if (options.skipScopedTypeNames)
+            ;
         else if (!overrideName.empty())
             buffer->append(overrideName);
         else {

--- a/source/numeric/ConstantValue.cpp
+++ b/source/numeric/ConstantValue.cpp
@@ -19,14 +19,14 @@ struct always_false : std::false_type {};
 
 const ConstantValue ConstantValue::Invalid;
 
-std::string ConstantValue::toString(bitwidth_t abbreviateThresholdBits) const {
+std::string ConstantValue::toString(bitwidth_t abbreviateThresholdBits, bool exactUnknowns) const {
     return std::visit(
-        [abbreviateThresholdBits](auto&& arg) {
+        [abbreviateThresholdBits, exactUnknowns](auto&& arg) {
             using T = std::decay_t<decltype(arg)>;
             if constexpr (std::is_same_v<T, std::monostate>)
                 return "<unset>"s;
             else if constexpr (std::is_same_v<T, SVInt>)
-                return arg.toString(abbreviateThresholdBits);
+                return arg.toString(abbreviateThresholdBits, exactUnknowns);
             else if constexpr (std::is_same_v<T, real_t>)
                 return fmt::format("{}", double(arg));
             else if constexpr (std::is_same_v<T, shortreal_t>)

--- a/source/numeric/ConstantValue.cpp
+++ b/source/numeric/ConstantValue.cpp
@@ -37,7 +37,7 @@ std::string ConstantValue::toString() const {
                 return "$"s;
             else if constexpr (std::is_same_v<T, Elements>) {
                 FormatBuffer buffer;
-                buffer.append("[");
+                buffer.append("'{");
                 for (auto& element : arg) {
                     buffer.append(element.toString());
                     buffer.append(",");
@@ -45,14 +45,14 @@ std::string ConstantValue::toString() const {
 
                 if (!arg.empty())
                     buffer.pop_back();
-                buffer.append("]");
+                buffer.append("}");
                 return buffer.str();
             }
             else if constexpr (std::is_same_v<T, std::string>)
                 return fmt::format("\"{}\"", arg);
             else if constexpr (std::is_same_v<T, Map>) {
                 FormatBuffer buffer;
-                buffer.append("[");
+                buffer.append("'{");
                 for (auto& [key, val] : *arg)
                     buffer.format("{}:{},", key.toString(), val.toString());
 
@@ -61,12 +61,12 @@ std::string ConstantValue::toString() const {
                 else if (!arg->empty())
                     buffer.pop_back();
 
-                buffer.append("]");
+                buffer.append("}");
                 return buffer.str();
             }
             else if constexpr (std::is_same_v<T, Queue>) {
                 FormatBuffer buffer;
-                buffer.append("[");
+                buffer.append("'{");
                 for (auto& element : *arg) {
                     buffer.append(element.toString());
                     buffer.append(",");
@@ -74,7 +74,7 @@ std::string ConstantValue::toString() const {
 
                 if (!arg->empty())
                     buffer.pop_back();
-                buffer.append("]");
+                buffer.append("}");
                 return buffer.str();
             }
             else if constexpr (std::is_same_v<T, Union>) {

--- a/source/numeric/ConstantValue.cpp
+++ b/source/numeric/ConstantValue.cpp
@@ -40,7 +40,8 @@ std::string ConstantValue::toString(bitwidth_t abbreviateThresholdBits, bool exa
                 FormatBuffer buffer;
                 buffer.append(useAssignmentPatterns ? "'{"sv : "["sv);
                 for (auto& element : arg) {
-                    buffer.append(element.toString(abbreviateThresholdBits, exactUnknowns, useAssignmentPatterns));
+                    buffer.append(element.toString(abbreviateThresholdBits, exactUnknowns,
+                                                   useAssignmentPatterns));
                     buffer.append(",");
                 }
 
@@ -55,12 +56,16 @@ std::string ConstantValue::toString(bitwidth_t abbreviateThresholdBits, bool exa
                 FormatBuffer buffer;
                 buffer.append(useAssignmentPatterns ? "'{"sv : "["sv);
                 for (auto& [key, val] : *arg)
-                    buffer.format("{}:{},", key.toString(abbreviateThresholdBits, exactUnknowns, useAssignmentPatterns),
-                                  val.toString(abbreviateThresholdBits, exactUnknowns, useAssignmentPatterns));
+                    buffer.format("{}:{},",
+                                  key.toString(abbreviateThresholdBits, exactUnknowns,
+                                               useAssignmentPatterns),
+                                  val.toString(abbreviateThresholdBits, exactUnknowns,
+                                               useAssignmentPatterns));
 
                 if (arg->defaultValue)
-                    buffer.format("default:{}", arg->defaultValue.toString(abbreviateThresholdBits,
-                                                                           exactUnknowns, useAssignmentPatterns));
+                    buffer.format("default:{}",
+                                  arg->defaultValue.toString(abbreviateThresholdBits, exactUnknowns,
+                                                             useAssignmentPatterns));
                 else if (!arg->empty())
                     buffer.pop_back();
 
@@ -71,7 +76,8 @@ std::string ConstantValue::toString(bitwidth_t abbreviateThresholdBits, bool exa
                 FormatBuffer buffer;
                 buffer.append(useAssignmentPatterns ? "'{"sv : "["sv);
                 for (auto& element : *arg) {
-                    buffer.append(element.toString(abbreviateThresholdBits, exactUnknowns, useAssignmentPatterns));
+                    buffer.append(element.toString(abbreviateThresholdBits, exactUnknowns,
+                                                   useAssignmentPatterns));
                     buffer.append(",");
                 }
 
@@ -85,7 +91,8 @@ std::string ConstantValue::toString(bitwidth_t abbreviateThresholdBits, bool exa
                     return "(unset)"s;
 
                 return fmt::format("({}) {}", *arg->activeMember,
-                                   arg->value.toString(abbreviateThresholdBits, exactUnknowns, useAssignmentPatterns));
+                                   arg->value.toString(abbreviateThresholdBits, exactUnknowns,
+                                                       useAssignmentPatterns));
             }
             else {
                 static_assert(always_false<T>::value, "Missing case");

--- a/source/numeric/ConstantValue.cpp
+++ b/source/numeric/ConstantValue.cpp
@@ -40,7 +40,7 @@ std::string ConstantValue::toString(bitwidth_t abbreviateThresholdBits, bool exa
                 FormatBuffer buffer;
                 buffer.append(useAssignmentPatterns ? "'{"sv : "["sv);
                 for (auto& element : arg) {
-                    buffer.append(element.toString(abbreviateThresholdBits));
+                    buffer.append(element.toString(abbreviateThresholdBits, exactUnknowns, useAssignmentPatterns));
                     buffer.append(",");
                 }
 
@@ -55,12 +55,12 @@ std::string ConstantValue::toString(bitwidth_t abbreviateThresholdBits, bool exa
                 FormatBuffer buffer;
                 buffer.append(useAssignmentPatterns ? "'{"sv : "["sv);
                 for (auto& [key, val] : *arg)
-                    buffer.format("{}:{},", key.toString(abbreviateThresholdBits),
-                                  val.toString(abbreviateThresholdBits));
+                    buffer.format("{}:{},", key.toString(abbreviateThresholdBits, exactUnknowns, useAssignmentPatterns),
+                                  val.toString(abbreviateThresholdBits, exactUnknowns, useAssignmentPatterns));
 
                 if (arg->defaultValue)
-                    buffer.format("default:{}",
-                                  arg->defaultValue.toString(abbreviateThresholdBits));
+                    buffer.format("default:{}", arg->defaultValue.toString(abbreviateThresholdBits,
+                                                                           exactUnknowns, useAssignmentPatterns));
                 else if (!arg->empty())
                     buffer.pop_back();
 
@@ -71,7 +71,7 @@ std::string ConstantValue::toString(bitwidth_t abbreviateThresholdBits, bool exa
                 FormatBuffer buffer;
                 buffer.append(useAssignmentPatterns ? "'{"sv : "["sv);
                 for (auto& element : *arg) {
-                    buffer.append(element.toString(abbreviateThresholdBits));
+                    buffer.append(element.toString(abbreviateThresholdBits, exactUnknowns, useAssignmentPatterns));
                     buffer.append(",");
                 }
 
@@ -84,7 +84,8 @@ std::string ConstantValue::toString(bitwidth_t abbreviateThresholdBits, bool exa
                 if (!arg->activeMember)
                     return "(unset)"s;
 
-                return fmt::format("({}) {}", *arg->activeMember, arg->value.toString(abbreviateThresholdBits));
+                return fmt::format("({}) {}", *arg->activeMember,
+                                   arg->value.toString(abbreviateThresholdBits, exactUnknowns, useAssignmentPatterns));
             }
             else {
                 static_assert(always_false<T>::value, "Missing case");

--- a/source/numeric/ConstantValue.cpp
+++ b/source/numeric/ConstantValue.cpp
@@ -19,9 +19,10 @@ struct always_false : std::false_type {};
 
 const ConstantValue ConstantValue::Invalid;
 
-std::string ConstantValue::toString(bitwidth_t abbreviateThresholdBits, bool exactUnknowns) const {
+std::string ConstantValue::toString(bitwidth_t abbreviateThresholdBits, bool exactUnknowns,
+                                    bool useAssignmentPatterns) const {
     return std::visit(
-        [abbreviateThresholdBits, exactUnknowns](auto&& arg) {
+        [abbreviateThresholdBits, exactUnknowns, useAssignmentPatterns](auto&& arg) {
             using T = std::decay_t<decltype(arg)>;
             if constexpr (std::is_same_v<T, std::monostate>)
                 return "<unset>"s;
@@ -37,7 +38,7 @@ std::string ConstantValue::toString(bitwidth_t abbreviateThresholdBits, bool exa
                 return "$"s;
             else if constexpr (std::is_same_v<T, Elements>) {
                 FormatBuffer buffer;
-                buffer.append("'{");
+                buffer.append(useAssignmentPatterns ? "'{"sv : "["sv);
                 for (auto& element : arg) {
                     buffer.append(element.toString(abbreviateThresholdBits));
                     buffer.append(",");
@@ -45,14 +46,14 @@ std::string ConstantValue::toString(bitwidth_t abbreviateThresholdBits, bool exa
 
                 if (!arg.empty())
                     buffer.pop_back();
-                buffer.append("}");
+                buffer.append(useAssignmentPatterns ? "}"sv : "]"sv);
                 return buffer.str();
             }
             else if constexpr (std::is_same_v<T, std::string>)
                 return fmt::format("\"{}\"", arg);
             else if constexpr (std::is_same_v<T, Map>) {
                 FormatBuffer buffer;
-                buffer.append("'{");
+                buffer.append(useAssignmentPatterns ? "'{"sv : "["sv);
                 for (auto& [key, val] : *arg)
                     buffer.format("{}:{},", key.toString(abbreviateThresholdBits),
                                   val.toString(abbreviateThresholdBits));
@@ -63,12 +64,12 @@ std::string ConstantValue::toString(bitwidth_t abbreviateThresholdBits, bool exa
                 else if (!arg->empty())
                     buffer.pop_back();
 
-                buffer.append("}");
+                buffer.append(useAssignmentPatterns ? "}"sv : "]"sv);
                 return buffer.str();
             }
             else if constexpr (std::is_same_v<T, Queue>) {
                 FormatBuffer buffer;
-                buffer.append("'{");
+                buffer.append(useAssignmentPatterns ? "'{"sv : "["sv);
                 for (auto& element : *arg) {
                     buffer.append(element.toString(abbreviateThresholdBits));
                     buffer.append(",");
@@ -76,7 +77,7 @@ std::string ConstantValue::toString(bitwidth_t abbreviateThresholdBits, bool exa
 
                 if (!arg->empty())
                     buffer.pop_back();
-                buffer.append("}");
+                buffer.append(useAssignmentPatterns ? "}"sv : "]"sv);
                 return buffer.str();
             }
             else if constexpr (std::is_same_v<T, Union>) {

--- a/source/numeric/SVInt.cpp
+++ b/source/numeric/SVInt.cpp
@@ -637,10 +637,12 @@ std::ostream& operator<<(std::ostream& os, const SVInt& rhs) {
     return os;
 }
 
-std::string SVInt::toString(bitwidth_t abbreviateThresholdBits) const {
+std::string SVInt::toString(bitwidth_t abbreviateThresholdBits, bool exactUnknowns) const {
     // guess the base to use
     LiteralBase base;
-    if (bitWidth < 8 || (unknownFlag && bitWidth <= 64))
+    // unless the int is wholly or digit/hexit-wise X or Z (TODO: worth checking?),
+    // unknown bits require binary base for lossless representation.
+    if (bitWidth < 8 || (unknownFlag && exactUnknowns) || (unknownFlag && bitWidth <= 64))
         base = LiteralBase::Binary;
     else if (bitWidth <= 32 || signFlag)
         base = LiteralBase::Decimal;

--- a/source/numeric/SVInt.cpp
+++ b/source/numeric/SVInt.cpp
@@ -640,8 +640,7 @@ std::ostream& operator<<(std::ostream& os, const SVInt& rhs) {
 std::string SVInt::toString(bitwidth_t abbreviateThresholdBits, bool exactUnknowns) const {
     // guess the base to use
     LiteralBase base;
-    // unless the int is wholly or digit/hexit-wise X or Z (TODO: worth checking?),
-    // unknown bits require binary base for lossless representation.
+    // unknown bits require binary base for lossless representation
     if (bitWidth < 8 || (unknownFlag && exactUnknowns) || (unknownFlag && bitWidth <= 64))
         base = LiteralBase::Binary;
     else if (bitWidth <= 32 || signFlag)

--- a/source/numeric/SVInt.cpp
+++ b/source/numeric/SVInt.cpp
@@ -637,7 +637,7 @@ std::ostream& operator<<(std::ostream& os, const SVInt& rhs) {
     return os;
 }
 
-std::string SVInt::toString() const {
+std::string SVInt::toString(bitwidth_t abbreviateThresholdBits) const {
     // guess the base to use
     LiteralBase base;
     if (bitWidth < 8 || (unknownFlag && bitWidth <= 64))
@@ -647,15 +647,15 @@ std::string SVInt::toString() const {
     else
         base = LiteralBase::Hex;
 
-    return toString(base);
+    return toString(base, abbreviateThresholdBits);
 }
 
-std::string SVInt::toString(LiteralBase base) const {
+std::string SVInt::toString(LiteralBase base, bitwidth_t abbreviateThresholdBits) const {
     // Append the base unless we're a signed 32-bit base 10 integer.
     bool includeBase = base != LiteralBase::Decimal || bitWidth != 32 || !signFlag || unknownFlag;
 
     SmallVector<char> buffer;
-    writeTo(buffer, base, includeBase, DefaultStringAbbreviationThresholdBits);
+    writeTo(buffer, base, includeBase, abbreviateThresholdBits);
     return std::string(buffer.begin(), buffer.end());
 }
 
@@ -666,10 +666,11 @@ std::string SVInt::toString(LiteralBase base, bool includeBase,
     return std::string(buffer.begin(), buffer.end());
 }
 
-void SVInt::writeTo(SmallVectorBase<char>& buffer, LiteralBase base) const {
+void SVInt::writeTo(SmallVectorBase<char>& buffer, LiteralBase base,
+                    bitwidth_t abbreviateThresholdBits) const {
     // Append the base unless we're a signed 32-bit base 10 integer.
     bool includeBase = base != LiteralBase::Decimal || bitWidth != 32 || !signFlag || unknownFlag;
-    writeTo(buffer, base, includeBase);
+    writeTo(buffer, base, includeBase, abbreviateThresholdBits);
 }
 
 void SVInt::writeTo(SmallVectorBase<char>& buffer, LiteralBase base, bool includeBase,


### PR DESCRIPTION
## Overview
Enable `TypePrinter` and various `toString()`s to produce more parseable output by optionally emitting well-formed SystemVerilog expressions in more situations.

All changes below except 3. keep existing stringifications unchanged by default. All existing code remains compatible through optional fields and parameters.

These changes do not guarantee type or constant parseability, but cover some simple-to-fix gaps in Slang's already quite parseable stringifications.

## Changes

### `TypePrinter`
1. Add the `skipScopedTypeNames` option to `TypePrinter` to omit suffixed type names from container types.
2. Add the `fullEnumType`option to `TypePrinter` to include enum base types.

### `ConstantValue` and `SVInt`
3. Use assignment patterns (`'{...}` ) instead of simple brackets (`[...]`) for container constants.
4. Expose `abbreviateThresholdBits` to the end user of `ConstantValue.toString()` and callees to control or suppress integer vector abbreviation as needed.
5. Add the optional `exactUnknowns` parameter to `ConstantValue.toString()` and callees to ensure a reversible representation of integer vectors with unknown bits.
