### PR TITLE
Provide cmake override for shared-lib name

### DIFF
--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -86,6 +86,7 @@ add_library(
 
 add_subdirectory(ast)
 
+set(SLANG_SHARED_LIB_NAME slang)
 add_library(slang::slang ALIAS slang_slang)
 set_target_properties(
   slang_slang
@@ -93,8 +94,8 @@ set_target_properties(
              VISIBILITY_INLINES_HIDDEN YES
              VERSION ${PROJECT_VERSION}
              SOVERSION ${PROJECT_VERSION_MAJOR}
-             EXPORT_NAME slang
-             OUTPUT_NAME slang)
+             EXPORT_NAME ${SLANG_SHARED_LIB_NAME}
+             OUTPUT_NAME ${SLANG_SHARED_LIB_NAME})
 
 # Compile options
 target_compile_options(slang_slang PRIVATE ${SLANG_WARN_FLAGS})


### PR DESCRIPTION
As discussed in #646, this PR  provides a solution to the packaging issue, by adding a new variable SLANG_SHARED_LIB_NAME allowing a command line method for renaming the shared-lib during distribution packaging.

Since "s-lang" is in the dependency tree for NetworkManager most distros will have libslang.so installed already.   I'll be using "libsvlang.so" for Arch Linux packaging.