### PR TITLE
More distro friendly cmake fixes.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -69,6 +69,10 @@ option(SLANG_FUZZ_TARGET "Enables changes to make binaries easier to fuzz test"
        OFF)
 option(BUILD_SHARED_LIBS "Generate shared libraries instead of static" OFF)
 
+set(SLANG_LIB_NAME
+    "slang"
+    CACHE STRING "Default output library name")
+
 set(SLANG_CLANG_TIDY
     ""
     CACHE STRING "Run clang-tidy during the build with the given binary")
@@ -152,6 +156,59 @@ if(NOT CMAKE_INSTALL_RPATH AND BUILD_SHARED_LIBS)
   file(RELATIVE_PATH relDir ${CMAKE_CURRENT_BINARY_DIR}/${CMAKE_INSTALL_BINDIR}
        ${CMAKE_CURRENT_BINARY_DIR}/${CMAKE_INSTALL_LIBDIR})
   set(CMAKE_INSTALL_RPATH ${base} ${base}/${relDir})
+endif()
+
+set(STD_FS_LIB "")
+# ==== The test below is based on:
+# https://github.com/pybind/pybind11/blob/master/tests/CMakeLists.txt
+#
+# It is under a BSD-style license, see:
+# https://github.com/pybind/pybind11/blob/master/LICENSE
+#
+# Check if we need to add -lstdc++fs or -lc++fs or nothing
+if(DEFINED CMAKE_CXX_STANDARD AND CMAKE_CXX_STANDARD LESS 17)
+  set(STD_FS_NO_LIB_NEEDED TRUE)
+elseif(MSVC)
+  set(STD_FS_NO_LIB_NEEDED TRUE)
+else()
+  file(
+    WRITE ${CMAKE_CURRENT_BINARY_DIR}/main.cpp
+    "#include <filesystem>\nint main(int argc, char ** argv) {\n  std::filesystem::path p(argv[0]);\n  return p.string().length();\n}"
+  )
+  try_compile(
+    STD_FS_NO_LIB_NEEDED ${CMAKE_CURRENT_BINARY_DIR}
+    SOURCES ${CMAKE_CURRENT_BINARY_DIR}/main.cpp
+    COMPILE_DEFINITIONS -std=c++17)
+  try_compile(
+    STD_FS_NEEDS_STDCXXFS ${CMAKE_CURRENT_BINARY_DIR}
+    SOURCES ${CMAKE_CURRENT_BINARY_DIR}/main.cpp
+    COMPILE_DEFINITIONS -std=c++17
+    LINK_LIBRARIES stdc++fs)
+  try_compile(
+    STD_FS_NEEDS_CXXFS ${CMAKE_CURRENT_BINARY_DIR}
+    SOURCES ${CMAKE_CURRENT_BINARY_DIR}/main.cpp
+    COMPILE_DEFINITIONS -std=c++17
+    LINK_LIBRARIES c++fs)
+endif()
+
+if(STD_FS_NEEDS_STDCXXFS)
+  set(STD_FS_LIB stdc++fs)
+elseif(STD_FS_NEEDS_CXXFS)
+  set(STD_FS_LIB c++fs)
+elseif(STD_FS_NO_LIB_NEEDED)
+  message(WARNING "Unknown C++17 compiler - not passing -lstdc++fs")
+endif()
+# ==== (end of test for stdc++fs)
+
+if(NOT "${STD_FS_LIB}")
+  message(STATUS "Linking with: ${STD_FS_LIB}")
+  list(APPEND SLANG_LIBRARIES ${STD_FS_LIB})
+endif()
+
+if(BUILD_SHARED_LIBS)
+  message(STATUS "Build SHARED library as: ${SLANG_LIB_NAME}")
+else()
+  message(STATUS "Build STATIC library as: ${SLANG_LIB_NAME}")
 endif()
 
 include(external/CMakeLists.txt)

--- a/bindings/CMakeLists.txt
+++ b/bindings/CMakeLists.txt
@@ -37,7 +37,7 @@ pybind11_add_module(
   python/types.cpp
   python/util.cpp
   ${CMAKE_CURRENT_BINARY_DIR}/PySyntaxBindings.cpp)
-target_link_libraries(pyslang PUBLIC slang::slang fmt::fmt)
+target_link_libraries(pyslang PUBLIC slang::slang fmt::fmt ${SLANG_LIBRARIES})
 target_include_directories(pyslang PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/python)
 target_compile_definitions(pyslang PRIVATE VERSION_INFO=${PROJECT_VERSION})
 

--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -86,7 +86,6 @@ add_library(
 
 add_subdirectory(ast)
 
-set(SLANG_SHARED_LIB_NAME slang)
 add_library(slang::slang ALIAS slang_slang)
 set_target_properties(
   slang_slang
@@ -94,8 +93,8 @@ set_target_properties(
              VISIBILITY_INLINES_HIDDEN YES
              VERSION ${PROJECT_VERSION}
              SOVERSION ${PROJECT_VERSION_MAJOR}
-             EXPORT_NAME ${SLANG_SHARED_LIB_NAME}
-             OUTPUT_NAME ${SLANG_SHARED_LIB_NAME})
+             EXPORT_NAME ${SLANG_LIB_NAME}
+             OUTPUT_NAME ${SLANG_LIB_NAME})
 
 # Compile options
 target_compile_options(slang_slang PRIVATE ${SLANG_WARN_FLAGS})
@@ -113,9 +112,10 @@ target_include_directories(
 
 # Link libraries
 find_package(Threads)
-target_link_libraries(slang_slang PRIVATE ${CMAKE_THREAD_LIBS_INIT})
-target_link_libraries(slang_slang PRIVATE fmt::fmt)
-target_link_libraries(slang_slang PUBLIC unordered_dense::unordered_dense)
+target_link_libraries(
+  slang_slang
+  PRIVATE fmt::fmt ${CMAKE_THREAD_LIBS_INIT} ${SLANG_LIBRARIES}
+  PUBLIC unordered_dense::unordered_dense)
 
 # If building the Python library we'll end up with a shared lib no matter what,
 # so make sure we always build with PIC.

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -45,7 +45,10 @@ add_executable(
   unittests/TypeTests.cpp
   unittests/VisitorTests.cpp)
 
-target_link_libraries(unittests PRIVATE slang::slang Catch2::Catch2 fmt::fmt)
+target_link_libraries(
+  unittests
+  PRIVATE slang::slang Catch2::Catch2 fmt::fmt
+  PUBLIC ${SLANG_LIBRARIES})
 target_compile_definitions(unittests PRIVATE UNITTESTS)
 
 if(SLANG_CI_BUILD)

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -6,18 +6,27 @@
 add_executable(slang_driver driver/driver.cpp)
 add_executable(slang::driver ALIAS slang_driver)
 
-target_link_libraries(slang_driver PRIVATE slang::slang fmt::fmt)
+target_link_libraries(
+  slang_driver
+  PRIVATE slang::slang fmt::fmt
+  PUBLIC ${SLANG_LIBRARIES})
 set_target_properties(slang_driver PROPERTIES OUTPUT_NAME "slang")
 
 add_executable(rewriter rewriter/rewriter.cpp)
-target_link_libraries(rewriter PRIVATE slang::slang)
+target_link_libraries(
+  rewriter
+  PRIVATE slang::slang
+  PUBLIC ${SLANG_LIBRARIES})
 
 if(SLANG_FUZZ_TARGET)
   message("Tweaking driver for fuzz testing")
   target_compile_definitions(slang_driver PRIVATE FUZZ_TARGET)
 
   target_compile_options(slang_driver PRIVATE "-fsanitize=fuzzer")
-  target_link_libraries(slang_driver PRIVATE "-fsanitize=fuzzer")
+  target_link_libraries(
+    slang_driver
+    PRIVATE "-fsanitize=fuzzer"
+    PUBLIC ${SLANG_LIBRARIES})
 endif()
 
 if(SLANG_INCLUDE_INSTALL)


### PR DESCRIPTION
(x ) This PR address few issues:

1. Fix and advertise the optional ```SLANG_LIB_NAME``` for either STATIC or SHARED (see [#650](https://github.com/MikePopoloski/slang/pull/650)).
3. ~~Fix ```SHARED``` mode, add PIC related flags and condition library visibility settings.~~
4. Automate adding of needed ```stdc++fs``` / ```c++fs``` variants for various compiler needs.

(x) This PR preserves and **does not affect current** build behaviour.

Cc: @jrudess 

---

(x) See the introduced advertisements:
```
%cmake .. -Wno-dev \
       -DCMAKE_SKIP_RPATH=ON \
       -DCMAKE_VERBOSE_MAKEFILE=OFF \
       -DCMAKE_BUILD_TYPE=RelWithDebInfo \
       -DBUILD_SHARED_LIB=ON \
       -DSLANG_LIB_NAME="svlang" \
       -DSLANG_INCLUDE_LLVM=OFF \
       -DSLANG_INCLUDE_DOCS=OFF \
       -DSLANG_INCLUDE_TESTS=ON \
       -DSLANG_INCLUDE_PYLIB=ON \
       -DSLANG_INCLUDE_TOOLS=ON \
       -DSLANG_INCLUDE_INSTALL=ON
-- CMake version: 3.20.2
-- slang version: 2.0.0+211ccf5
-- The CXX compiler identification is GNU 8.5.0
{...}
-- Linking with: stdc++fs
-- Build SHARED library as: svlang
{..}
```

(x) Builds pass on *{x86_64, ppc64le, aarch64} x {rhel8, rhel9, fc35, fc36, fc37, fc38}*, see:
https://copr.fedorainfracloud.org/coprs/rezso/HDL/build/5034654/

---

@MikePopoloski,

Thank you for having this excellent tool !
~Cristian.
