### PR TITLE
Add --obfuscate-ids option to driver

### DIFF
--- a/include/slang/driver/Driver.h
+++ b/include/slang/driver/Driver.h
@@ -261,10 +261,12 @@ public:
 
     /// Runs the preprocessor on all loaded buffers and outputs the result to stdout.
     /// Any errors encountered will be printed to stderr.
-    /// @param includeComments If true, comments will be included in the output
+    /// @param includeComments If true, comments will be included in the output.
     /// @param includeDirectives If true, preprocessor directives will be included in the output.
+    /// @param fuzzIds If true, identifiers will be randomized.
     /// @returns true on success and false if errors were encountered.
-    [[nodiscard]] bool runPreprocessor(bool includeComments, bool includeDirectives);
+    [[nodiscard]] bool runPreprocessor(bool includeComments, bool includeDirectives,
+                                       bool fuzzIds);
 
     /// Prints all macros from all loaded buffers to stdout.
     void reportMacros();

--- a/include/slang/driver/Driver.h
+++ b/include/slang/driver/Driver.h
@@ -265,8 +265,7 @@ public:
     /// @param includeDirectives If true, preprocessor directives will be included in the output.
     /// @param fuzzIds If true, identifiers will be randomized.
     /// @returns true on success and false if errors were encountered.
-    [[nodiscard]] bool runPreprocessor(bool includeComments, bool includeDirectives,
-                                       bool fuzzIds);
+    [[nodiscard]] bool runPreprocessor(bool includeComments, bool includeDirectives, bool fuzzIds);
 
     /// Prints all macros from all loaded buffers to stdout.
     void reportMacros();

--- a/include/slang/driver/Driver.h
+++ b/include/slang/driver/Driver.h
@@ -263,9 +263,9 @@ public:
     /// Any errors encountered will be printed to stderr.
     /// @param includeComments If true, comments will be included in the output.
     /// @param includeDirectives If true, preprocessor directives will be included in the output.
-    /// @param fuzzIds If true, identifiers will be randomized.
+    /// @param obfuscateIds If true, identifiers will be randomized.
     /// @returns true on success and false if errors were encountered.
-    [[nodiscard]] bool runPreprocessor(bool includeComments, bool includeDirectives, bool fuzzIds);
+    [[nodiscard]] bool runPreprocessor(bool includeComments, bool includeDirectives, bool obfuscateIds);
 
     /// Prints all macros from all loaded buffers to stdout.
     void reportMacros();

--- a/include/slang/driver/Driver.h
+++ b/include/slang/driver/Driver.h
@@ -265,7 +265,8 @@ public:
     /// @param includeDirectives If true, preprocessor directives will be included in the output.
     /// @param obfuscateIds If true, identifiers will be randomized.
     /// @returns true on success and false if errors were encountered.
-    [[nodiscard]] bool runPreprocessor(bool includeComments, bool includeDirectives, bool obfuscateIds);
+    [[nodiscard]] bool runPreprocessor(bool includeComments, bool includeDirectives,
+                                       bool obfuscateIds);
 
     /// Prints all macros from all loaded buffers to stdout.
     void reportMacros();

--- a/tests/unittests/DriverTests.cpp
+++ b/tests/unittests/DriverTests.cpp
@@ -109,7 +109,7 @@ TEST_CASE("Driver file preprocess") {
     const char* argv[] = {"testfoo", filePath.c_str()};
     CHECK(driver.parseCommandLine(2, argv));
     CHECK(driver.processOptions());
-    CHECK(driver.runPreprocessor(true, false));
+    CHECK(driver.runPreprocessor(true, false, false));
 
     auto output = OS::capturedStdout;
     output = std::regex_replace(output, std::regex("\r\n"), "\n");
@@ -134,7 +134,7 @@ TEST_CASE("Driver file preprocess with error") {
     const char* argv[] = {"testfoo", filePath.c_str()};
     CHECK(driver.parseCommandLine(2, argv));
     CHECK(driver.processOptions());
-    CHECK(!driver.runPreprocessor(true, false));
+    CHECK(!driver.runPreprocessor(true, false, false));
     CHECK(stderrContains("unknown macro"));
 }
 

--- a/tools/driver/driver.cpp
+++ b/tools/driver/driver.cpp
@@ -71,13 +71,13 @@ int driverMain(int argc, TArgs argv) try {
 
     std::optional<bool> includeComments;
     std::optional<bool> includeDirectives;
-    std::optional<bool> fuzzIds;
+    std::optional<bool> obfuscateIds;
     driver.cmdLine.add("--comments", includeComments,
                        "Include comments in preprocessed output (with -E)");
     driver.cmdLine.add("--directives", includeDirectives,
                        "Include compiler directives in preprocessed output (with -E)");
-    driver.cmdLine.add("--fuzz-ids", fuzzIds,
-                       "Randomize all identifiers in  preprocessed output (with -E)");
+    driver.cmdLine.add("--obfuscate-ids", obfuscateIds,
+                       "Randomize all identifiers in preprocessed output (with -E)");
 
     std::optional<std::string> astJsonFile;
     driver.cmdLine.add(
@@ -131,7 +131,7 @@ int driverMain(int argc, TArgs argv) try {
     try {
         if (onlyPreprocess == true) {
             ok = driver.runPreprocessor(includeComments == true, includeDirectives == true,
-                                        fuzzIds == true);
+                                        obfuscateIds == true);
         }
         else if (onlyMacros == true) {
             driver.reportMacros();

--- a/tools/driver/driver.cpp
+++ b/tools/driver/driver.cpp
@@ -71,10 +71,13 @@ int driverMain(int argc, TArgs argv) try {
 
     std::optional<bool> includeComments;
     std::optional<bool> includeDirectives;
+    std::optional<bool> fuzzIds;
     driver.cmdLine.add("--comments", includeComments,
                        "Include comments in preprocessed output (with -E)");
     driver.cmdLine.add("--directives", includeDirectives,
                        "Include compiler directives in preprocessed output (with -E)");
+    driver.cmdLine.add("--fuzz-ids", fuzzIds,
+                       "Randomize all identifiers in  preprocessed output (with -E)");
 
     std::optional<std::string> astJsonFile;
     driver.cmdLine.add(
@@ -127,7 +130,8 @@ int driverMain(int argc, TArgs argv) try {
     bool ok = true;
     try {
         if (onlyPreprocess == true) {
-            ok = driver.runPreprocessor(includeComments == true, includeDirectives == true);
+            ok = driver.runPreprocessor(includeComments == true, includeDirectives == true,
+                                        fuzzIds == true);
         }
         else if (onlyMacros == true) {
             driver.reportMacros();


### PR DESCRIPTION
With this option the preprocessed output will have all of its identifiers randomized.

It might come useful in order to share SV code without having to use a commercial encryption tool.