### PR TITLE
Fix library name in sv-lang.pc.in

### DIFF
--- a/scripts/sv-lang.pc.in
+++ b/scripts/sv-lang.pc.in
@@ -7,4 +7,4 @@ Description: @PROJECT_DESCRIPTION@
 URL: @PROJECT_HOMEPAGE_URL@
 Version: @PROJECT_VERSION@
 Cflags: -I"${includedir}"
-Libs: -L"${libdir}" -lslang
+Libs: -L"${libdir}" -lsvlang


### PR DESCRIPTION
Not sure if the .pc file should also be named `svlang.pc.in` to match the library rename.