### PR TITLE
Enhance ReplicatedAssignmentPatternExpression

### DIFF
--- a/include/slang/ast/expressions/AssignmentExpressions.h
+++ b/include/slang/ast/expressions/AssignmentExpressions.h
@@ -335,11 +335,13 @@ class SLANG_EXPORT ReplicatedAssignmentPatternExpression : public AssignmentPatt
 public:
     ReplicatedAssignmentPatternExpression(const Type& type, const Expression& count,
                                           span<const Expression* const> elements,
+                                          span<const Expression* const> oriElements,
                                           SourceRange sourceRange) :
         AssignmentPatternExpressionBase(ExpressionKind::ReplicatedAssignmentPattern, type, elements,
                                         sourceRange),
-        count_(&count) {}
+        count_(&count), oriElements_(oriElements) {}
 
+    span<const Expression* const> oriElements() const { return oriElements_; }
     const Expression& count() const { return *count_; }
 
     void serializeTo(ASTSerializer& serializer) const;
@@ -376,6 +378,7 @@ private:
                                            const ASTContext& context, size_t& count);
 
     const Expression* count_;
+    span<const Expression* const> oriElements_;
 };
 
 } // namespace slang::ast

--- a/source/ast/expressions/AssignmentExpressions.cpp
+++ b/source/ast/expressions/AssignmentExpressions.cpp
@@ -1882,9 +1882,10 @@ Expression& ReplicatedAssignmentPatternExpression::forStruct(
         }
     }
 
-    auto result = comp.emplace<ReplicatedAssignmentPatternExpression>(type, countExpr,
-                                                                      elems.copy(comp),
-                                                                      sourceRange);
+    auto elemsCopy = elems.copy(comp);
+    auto originElems = elemsCopy.first(syntax.items.size());
+    auto result = comp.emplace<ReplicatedAssignmentPatternExpression>(type, countExpr, elemsCopy,
+                                                                      originElems, sourceRange);
     if (bad)
         return badExpr(comp, result);
 
@@ -1904,8 +1905,9 @@ Expression& ReplicatedAssignmentPatternExpression::forFixedArray(
     auto elems = bindExpressionList(type, elementType, count, numElements, syntax.items, context,
                                     sourceRange, bad);
 
+    auto originElems = elems.first(syntax.items.size());
     auto result = comp.emplace<ReplicatedAssignmentPatternExpression>(type, countExpr, elems,
-                                                                      sourceRange);
+                                                                      originElems, sourceRange);
     if (bad)
         return badExpr(comp, result);
 
@@ -1925,8 +1927,9 @@ Expression& ReplicatedAssignmentPatternExpression::forDynamicArray(
     auto elems = bindExpressionList(type, elementType, count, 0, syntax.items, context, sourceRange,
                                     bad);
 
+    auto originElems = elems.first(syntax.items.size());
     auto result = comp.emplace<ReplicatedAssignmentPatternExpression>(type, countExpr, elems,
-                                                                      sourceRange);
+                                                                      originElems, sourceRange);
     if (bad)
         return badExpr(comp, result);
 


### PR DESCRIPTION
I need the following semantics
```
byte data[4] = '{4{1}}; 
```
ReplicatedAssignmentPatternExpression would expanded into
```
{1, 1, 1, 1} 
```
but I want to keep the original semantics.