### PR TITLE
Update Parser_expressions.cpp

### DIFF
--- a/source/parsing/Parser_expressions.cpp
+++ b/source/parsing/Parser_expressions.cpp
@@ -1135,6 +1135,13 @@ TimingControlSyntax* Parser::parseTimingControl() {
                                                              expect(TokenKind::CloseParenthesis));
                     }
 
+                    // Special case since @(*) will be lexed as '@' '(' '*)'
+                    if (peek(TokenKind::StarCloseParenthesis)) {
+                        auto startclosePara = consume();
+                        return &factory.implicitEventControl(at, openParen, startclosePara,
+                                                             Token());
+                    }
+
                     auto& eventExpr = parseEventExpression();
                     auto closeParen = expect(TokenKind::CloseParenthesis);
                     return &factory.eventControlWithExpression(

--- a/source/parsing/Parser_expressions.cpp
+++ b/source/parsing/Parser_expressions.cpp
@@ -1137,8 +1137,8 @@ TimingControlSyntax* Parser::parseTimingControl() {
 
                     // Special case since @(*) will be lexed as '@' '(' '*)'
                     if (peek(TokenKind::StarCloseParenthesis)) {
-                        auto startclosePara = consume();
-                        return &factory.implicitEventControl(at, openParen, startclosePara,
+                        auto starCloseParen = consume();
+                        return &factory.implicitEventControl(at, openParen, starCloseParen,
                                                              Token());
                     }
 

--- a/tests/unittests/ExpressionParsingTests.cpp
+++ b/tests/unittests/ExpressionParsingTests.cpp
@@ -887,8 +887,8 @@ TEST_CASE("Event control parsing @( *)") {
     auto& text = R"(
 module t(a,b,ou);
 	input a,b;
-	output ou;     
-	reg a,b,ou;        
+	output ou;
+	reg a,b,ou;
 	always @( *) begin
         ou <= a ^ b;
 	end

--- a/tests/unittests/ExpressionParsingTests.cpp
+++ b/tests/unittests/ExpressionParsingTests.cpp
@@ -882,3 +882,18 @@ source:6:24: error: expected ','
                        ^
 )");
 }
+
+TEST_CASE("Event control parsing @( *)") {
+    auto& text = R"(
+module t(a,b,ou);
+	input a,b;
+	output ou;     
+	reg a,b,ou;        
+	always @( *) begin
+        ou <= a ^ b;
+	end
+endmodule
+)";
+    parseCompilationUnit(text);
+    CHECK_DIAGNOSTICS_EMPTY;
+}


### PR DESCRIPTION
For 'always@( *)' lexed as '@' '(' '*,' , there will be a error for the parser. The commit can correct the error.