### PR TITLE
Backport slang to clang9

### DIFF
--- a/include/slang/util/Enum.h
+++ b/include/slang/util/Enum.h
@@ -29,9 +29,8 @@
         static constexpr auto vals = {elements(UTIL_ENUM_ELEMENT)};                             \
         static constexpr auto getValues() {                                                     \
             std::array<name, vals.size()> result{};                                             \
-            size_t i = 0;                                                                       \
-            for (auto val : vals)                                                               \
-                result[i++] = name(val);                                                        \
+            for (size_t i = 0; i < vals.size(); i++)                                            \
+                result[i] = name(i);                                                            \
             return result;                                                                      \
         }                                                                                       \
                                                                                                 \


### PR DESCRIPTION
Since the minimum gcc version is 9, its release date is May 3, 2019
I hope clang 9 should support either. (19 September 2019)
