### PR TITLE
non-boost build fixes

### DIFF
--- a/bindings/python/pyslang.h
+++ b/bindings/python/pyslang.h
@@ -167,6 +167,7 @@ private:
     std::span<T> value;
 };
 
+#ifdef SLANG_USE_BOOST
 // Convert between flat_hash_map and python dict.
 template<typename Key, typename Value, typename Hash, typename Equal, typename Alloc>
 struct type_caster<flat_hash_map<Key, Value, Hash, Equal, Alloc>>
@@ -176,6 +177,7 @@ struct type_caster<flat_hash_map<Key, Value, Hash, Equal, Alloc>>
 template<typename Key, typename Hash, typename Equal, typename Alloc>
 struct type_caster<flat_hash_set<Key, Hash, Equal, Alloc>>
     : set_caster<flat_hash_set<Key, Hash, Equal, Alloc>, Key> {};
+#endif
 
 template<typename type>
 class type_caster<not_null<type>> {

--- a/source/numeric/Time.cpp
+++ b/source/numeric/Time.cpp
@@ -7,6 +7,7 @@
 //------------------------------------------------------------------------------
 #include "slang/numeric/Time.h"
 
+#include <cmath>
 #include <fmt/core.h>
 #include <ostream>
 


### PR DESCRIPTION
Two commits to fix non-boost build failures. Commit messages are reproduced below.

651ccfa19df210b0b843a488ea958e82fd0eeb9c

> Time.cpp: include \<cmath\>
> 
 > Time.cpp uses `std::round` from \<cmath\>. When `SLANG_USE_BOOST` is on,
    cmath is pulled in somehow from a transitive include. When
    `SLANG_USE_BOOST` is off, at least on some systems, this include
    is not pulled in.
> 
>    Include \<cmath\> explicitly in Time.cpp to ensure `std::round` is
    available, including for certain non-boost-using builds.

46163c31027e954a34658f6149180449a988c1b3

>    pyslang.h: guard type_casters for flat_hash_map based on `SLANG_USE_BOOST`
>
>    include/slang/util/Hash.h defines the alias templates `flat_hash_map`
    and `flat_hash_set` based on the macro `SLANG_USE_BOOST`. If the macro
    is defined, these aliases refer to boost class templates. If the macro
    is not defined, they reference standard class templates.
>
>    Pybind11 v2.10.4 defines type_casters for `std::unordered_map` and
    `std::unordered_set` in include/pybind11/stl.h on lines
    302-304 and 294-296, respectively.
>
>    As pyslang.h includes \<pybind11/stl.h\>, avoid multiple definitions
    of these type casters by guarding their definitions in pyslang.h
    based on the `SLANG_USE_BOOST` macro.