### PR TITLE
doc/parsing.dox: update file reference

### DIFF
--- a/docs/parsing.dox
+++ b/docs/parsing.dox
@@ -162,7 +162,7 @@ text via the @ref slang::syntax::SyntaxPrinter class. This class has a variety o
 for how you'd like the text printed, and then will print any tokens, trivia,
 or syntax nodes you give it.
 
-See the tests/unittests/RewriterTests.cpp file for an example of using all of
+See the tests/unittests/VisitorTests.cpp file for an example of using all of
 these mechanisms together.
 
 */


### PR DESCRIPTION
tests/unittests/RewriterTests.cpp was renamed to
tests/unittests/VisitorTests.cpp in 3957da7
(Many improvements to ASTVisitor and supporting types, Sat Mar 14 12:38:53 2020 -0400).