### PR TITLE
Add new check slang-tidy check: OnlyANSIPortDecl

### DIFF
--- a/tools/tidy/CMakeLists.txt
+++ b/tools/tidy/CMakeLists.txt
@@ -16,8 +16,7 @@ add_library(
   src/style/AlwaysCombNonBlocking.cpp
   src/style/AlwaysFFBlocking.cpp
   src/style/EnforceModuleInstantiationPrefix.cpp
-  src/style/OnlyANSIPortDecl.cpp
-)
+  src/style/OnlyANSIPortDecl.cpp)
 
 target_include_directories(slang_tidy_obj_lib PUBLIC include ../../include)
 target_link_libraries(slang_tidy_obj_lib PUBLIC slang::slang)

--- a/tools/tidy/CMakeLists.txt
+++ b/tools/tidy/CMakeLists.txt
@@ -15,7 +15,9 @@ add_library(
   src/style/NoOldAlwaysSyntax.cpp
   src/style/AlwaysCombNonBlocking.cpp
   src/style/AlwaysFFBlocking.cpp
-  src/style/EnforceModuleInstantiationPrefix.cpp)
+  src/style/EnforceModuleInstantiationPrefix.cpp
+  src/style/OnlyANSIPortDecl.cpp
+)
 
 target_include_directories(slang_tidy_obj_lib PUBLIC include ../../include)
 target_link_libraries(slang_tidy_obj_lib PUBLIC slang::slang)

--- a/tools/tidy/include/TidyDiags.h
+++ b/tools/tidy/include/TidyDiags.h
@@ -19,5 +19,6 @@ inline constexpr DiagCode NoOldAlwaysSyntax(DiagSubsystem::Tidy, 4);
 inline constexpr DiagCode AlwaysCombNonBlocking(DiagSubsystem::Tidy, 5);
 inline constexpr DiagCode AlwaysFFBlocking(DiagSubsystem::Tidy, 6);
 inline constexpr DiagCode EnforceModuleInstantiationPrefix(DiagSubsystem::Tidy, 7);
+inline constexpr DiagCode OnlyANSIPortDecl(DiagSubsystem::Tidy, 8);
 
 } // namespace slang::diag

--- a/tools/tidy/src/TidyConfig.cpp
+++ b/tools/tidy/src/TidyConfig.cpp
@@ -22,6 +22,7 @@ TidyConfig::TidyConfig() {
     styleChecks.emplace("EnforcePortSuffix", CheckStatus::ENABLED);
     styleChecks.emplace("NoOldAlwaysSyntax", CheckStatus::ENABLED);
     styleChecks.emplace("EnforceModuleInstantiationPrefix", CheckStatus::ENABLED);
+    styleChecks.emplace("OnlyANSIPortDecl", CheckStatus::ENABLED);
     checkKinds.insert({slang::TidyKind::Style, styleChecks});
 
     auto synthesisChecks = std::unordered_map<std::string, CheckStatus>();

--- a/tools/tidy/src/style/OnlyANSIPortDecl.cpp
+++ b/tools/tidy/src/style/OnlyANSIPortDecl.cpp
@@ -16,7 +16,7 @@ struct MainVisitor : public TidyVisitor, ASTVisitor<MainVisitor, true, false> {
     void handle(const PortSymbol& port) {
         NEEDS_SKIP_SYMBOL(port)
         
-        if (port.isAnsiPort) {
+        if (!port.isAnsiPort) {
             diags.add(diag::OnlyANSIPortDecl, port.location) << port.internalSymbol->name;
         }
     }

--- a/tools/tidy/src/style/OnlyANSIPortDecl.cpp
+++ b/tools/tidy/src/style/OnlyANSIPortDecl.cpp
@@ -1,0 +1,54 @@
+// SPDX-FileCopyrightText: Michael Popoloski
+// SPDX-License-Identifier: MIT
+
+#include "ASTHelperVisitors.h"
+#include "TidyDiags.h"
+
+#include "slang/syntax/AllSyntax.h"
+
+using namespace slang;
+using namespace slang::ast;
+
+namespace no_ansi_port_decl {
+struct MainVisitor : public TidyVisitor, ASTVisitor<MainVisitor, true, false> {
+    explicit MainVisitor(Diagnostics& diagnostics) : TidyVisitor(diagnostics) {}
+
+    void handle(const PortSymbol& port) {
+        NEEDS_SKIP_SYMBOL(port)
+        
+        if (port.isAnsiPort) {
+            diags.add(diag::OnlyANSIPortDecl, port.location) << port.internalSymbol->name;
+        }
+    }
+};
+} // namespace enforce_port_suffix
+
+using namespace no_ansi_port_decl;
+class OnlyANSIPortDecl : public TidyCheck {
+public:
+    [[maybe_unused]] explicit OnlyANSIPortDecl(TidyKind kind) : TidyCheck(kind) {}
+
+    bool check(const ast::RootSymbol& root) override {
+        MainVisitor visitor(diagnostics);
+        root.visit(visitor);
+        if (!diagnostics.empty())
+            return false;
+        return true;
+    }
+
+    DiagCode diagCode() const override { return diag::OnlyANSIPortDecl; }
+    DiagnosticSeverity diagSeverity() const override { return DiagnosticSeverity::Warning; }
+    std::string diagString() const override {
+        return "port '{}' is declared using non-ANSI port declaration style";
+    }
+    std::string name() const override { return "OnlyANSIPortDecl"; }
+    std::string description() const override {
+        return "Enforces that all ports in the design are declared using the ANSI port "
+               "declaration style";
+    }
+    std::string shortDescription() const override {
+        return "Enforces ANSI port declaration style";
+    }
+};
+
+REGISTER(OnlyANSIPortDecl, OnlyANSIPortDecl, TidyKind::Style)

--- a/tools/tidy/src/style/OnlyANSIPortDecl.cpp
+++ b/tools/tidy/src/style/OnlyANSIPortDecl.cpp
@@ -15,13 +15,13 @@ struct MainVisitor : public TidyVisitor, ASTVisitor<MainVisitor, true, false> {
 
     void handle(const PortSymbol& port) {
         NEEDS_SKIP_SYMBOL(port)
-        
+
         if (!port.isAnsiPort) {
             diags.add(diag::OnlyANSIPortDecl, port.location) << port.internalSymbol->name;
         }
     }
 };
-} // namespace enforce_port_suffix
+} // namespace no_ansi_port_decl
 
 using namespace no_ansi_port_decl;
 class OnlyANSIPortDecl : public TidyCheck {
@@ -46,9 +46,7 @@ public:
         return "Enforces that all ports in the design are declared using the ANSI port "
                "declaration style";
     }
-    std::string shortDescription() const override {
-        return "Enforces ANSI port declaration style";
-    }
+    std::string shortDescription() const override { return "Enforces ANSI port declaration style"; }
 };
 
 REGISTER(OnlyANSIPortDecl, OnlyANSIPortDecl, TidyKind::Style)

--- a/tools/tidy/tests/CMakeLists.txt
+++ b/tools/tidy/tests/CMakeLists.txt
@@ -15,7 +15,8 @@ add_executable(
   NoOldAlwaysSyntaxTest.cpp
   AlwaysCombNonBlockingTest.cpp
   AlwaysFFBlockingTest.cpp
-  EnforceModuleInstantiationTest.cpp)
+  EnforceModuleInstantiationTest.cpp
+  OnlyANSIPortDecl.cpp)
 
 target_link_libraries(tidy_unittests PRIVATE Catch2::Catch2 slang_tidy_obj_lib)
 target_compile_definitions(tidy_unittests PRIVATE UNITTESTS)

--- a/tools/tidy/tests/OnlyANSIPortDecl.cpp
+++ b/tools/tidy/tests/OnlyANSIPortDecl.cpp
@@ -1,0 +1,71 @@
+// SPDX-FileCopyrightText: Michael Popoloski
+// SPDX-License-Identifier: MIT
+
+#include "Test.h"
+#include "TidyFactory.h"
+
+TEST_CASE("OnlyANSIPortDecl: Use of non-ANSI port declaration style") {
+    auto tree = SyntaxTree::fromText(R"(
+module top(a,b,c);
+    input logic a;
+    inout logic b;
+    output logic c;
+
+endmodule
+)");
+
+    Compilation compilation;
+    compilation.addSyntaxTree(tree);
+    compilation.getAllDiagnostics();
+    auto& root = compilation.getRoot();
+
+    TidyConfig config;
+    Registry::setConfig(config);
+    Registry::setSourceManager(compilation.getSourceManager());
+    auto visitor = Registry::create("OnlyANSIPortDecl");
+    bool result = visitor->check(root);
+    CHECK_FALSE(result);
+}
+
+TEST_CASE("OnlyANSIPortDecl: Use of ANSI port declaration style") {
+    auto tree = SyntaxTree::fromText(R"(
+module top(
+    input logic a,
+    inout logic b,
+    output logic c
+);
+
+endmodule
+)");
+
+    Compilation compilation;
+    compilation.addSyntaxTree(tree);
+    compilation.getAllDiagnostics();
+    auto& root = compilation.getRoot();
+
+    TidyConfig config;
+    Registry::setConfig(config);
+    Registry::setSourceManager(compilation.getSourceManager());
+    auto visitor = Registry::create("OnlyANSIPortDecl");
+    bool result = visitor->check(root);
+    CHECK(result);
+}
+
+TEST_CASE("OnlyANSIPortDecl: No port declaration") {
+    auto tree = SyntaxTree::fromText(R"(
+module top;
+endmodule
+)");
+
+    Compilation compilation;
+    compilation.addSyntaxTree(tree);
+    compilation.getAllDiagnostics();
+    auto& root = compilation.getRoot();
+
+    TidyConfig config;
+    Registry::setConfig(config);
+    Registry::setSourceManager(compilation.getSourceManager());
+    auto visitor = Registry::create("OnlyANSIPortDecl");
+    bool result = visitor->check(root);
+    CHECK(result);
+}


### PR DESCRIPTION
Hi folks,
this PR adds a new slang-tidy check to ensure that only ANSI port declaration style is used.