### PR TITLE
Add skip path option to slang-tidy

### DIFF
--- a/tools/tidy/include/ASTHelperVisitors.h
+++ b/tools/tidy/include/ASTHelperVisitors.h
@@ -28,11 +28,13 @@ protected:
 
     [[nodiscard]] bool skip(std::string_view path) const {
         auto file = std::filesystem::path(path).filename().string();
-        auto parentPath = std::filesystem::path(path).parent_path().string();
+        auto parentPath = weakly_canonical(std::filesystem::path(path));
         const auto& skipFiles = config.getSkipFiles();
         const auto& skipPaths = config.getSkipPaths();
         return std::find(skipFiles.begin(), skipFiles.end(), file) != skipFiles.end() ||
-               std::find(skipPaths.begin(), skipPaths.end(), parentPath) != skipPaths.end();
+               std::find_if(skipPaths.begin(), skipPaths.end(), [&](auto& path) {
+                   return parentPath.string().find(path) != std::string::npos;
+               }) != skipPaths.end();
     }
 
     slang::not_null<const slang::SourceManager*> sourceManager;

--- a/tools/tidy/include/ASTHelperVisitors.h
+++ b/tools/tidy/include/ASTHelperVisitors.h
@@ -27,9 +27,12 @@ protected:
         config(Registry::getConfig()) {}
 
     [[nodiscard]] bool skip(std::string_view path) const {
-        auto file = std::filesystem::path(path).filename();
+        auto file = std::filesystem::path(path).filename().string();
+        auto parentPath = std::filesystem::path(path).parent_path().string();
         const auto& skipFiles = config.getSkipFiles();
-        return std::find(skipFiles.begin(), skipFiles.end(), file) != skipFiles.end();
+        const auto& skipPaths = config.getSkipPaths();
+        return std::find(skipFiles.begin(), skipFiles.end(), file) != skipFiles.end() ||
+               std::find(skipPaths.begin(), skipPaths.end(), parentPath) != skipPaths.end();
     }
 
     slang::not_null<const slang::SourceManager*> sourceManager;

--- a/tools/tidy/include/TidyConfig.h
+++ b/tools/tidy/include/TidyConfig.h
@@ -46,9 +46,16 @@ public:
     // Returns a vector containing the file names that won't be checked by slang-tidy
     inline const std::vector<std::string>& getSkipFiles() const { return skipFiles; }
 
+    // Returns a vector containing the paths names that won't be checked by slang-tidy
+    inline const std::vector<std::string>& getSkipPaths() const { return skipPaths; }
+
     // Adds a new file into the list of skipped files
     void addSkipFile(const std::string& path);
-    void addSkipFile(std::vector<std::string> paths);
+    void addSkipFile(const std::vector<std::string>& paths);
+
+    // Adds a new path into the list of skipped paths
+    void addSkipPath(const std::string& path);
+    void addSkipPath(const std::vector<std::string>& paths);
 
 private:
     CheckConfigs checkConfigs;
@@ -60,6 +67,9 @@ private:
 
     // List of files that won't be checked by slang-tidy
     std::vector<std::string> skipFiles;
+
+    // List of paths that won't be checked by slang-tidy
+    std::vector<std::string> skipPaths;
 
     /// Enables or disables all the implemented checks based on status
     void toggleAl(CheckStatus status);

--- a/tools/tidy/src/TidyConfig.cpp
+++ b/tools/tidy/src/TidyConfig.cpp
@@ -5,7 +5,8 @@
 
 #include "TidyFactory.h"
 #include <filesystem>
-#include <utility>
+
+namespace fs = std::filesystem;
 
 TidyConfig::TidyConfig() {
     checkConfigs.clkName = "clk_i";
@@ -33,11 +34,21 @@ TidyConfig::TidyConfig() {
 }
 
 void TidyConfig::addSkipFile(const std::string& path) {
-    skipFiles.push_back(std::filesystem::path(path).filename().string());
+    skipFiles.push_back(fs::path(path).filename().string());
 }
 
-void TidyConfig::addSkipFile(std::vector<std::string> paths) {
-    skipFiles = std::move(paths);
+void TidyConfig::addSkipFile(const std::vector<std::string>& paths) {
+    for (const auto& path : paths)
+        skipFiles.push_back(fs::path(path).filename().string());
+}
+
+void TidyConfig::addSkipPath(const std::string& path) {
+    skipPaths.push_back(fs::path(path).parent_path().string());
+}
+
+void TidyConfig::addSkipPath(const std::vector<std::string>& paths) {
+    for (const auto& path : paths)
+        skipPaths.push_back(fs::path(path).parent_path().string());
 }
 
 void TidyConfig::toggleAl(CheckStatus status) {

--- a/tools/tidy/src/tidy.cpp
+++ b/tools/tidy/src/tidy.cpp
@@ -44,7 +44,10 @@ int main(int argc, char** argv) {
                        "Path to where the tidy config file is located");
 
     std::vector<std::string> skippedFiles;
-    driver.cmdLine.add("--skip-file", skippedFiles, "Paths to be skipped by slang-tidy");
+    driver.cmdLine.add("--skip-file", skippedFiles, "Files to be skipped by slang-tidy");
+
+    std::vector<std::string> skippedPaths;
+    driver.cmdLine.add("--skip-path", skippedPaths, "Paths to be skipped by slang-tidy");
 
     if (!driver.parseCommandLine(argc, argv))
         return 1;
@@ -75,7 +78,10 @@ int main(int argc, char** argv) {
     }
 
     // Add skipped files provided by the cmd args
-    tidyConfig.addSkipFile(std::move(skippedFiles));
+    tidyConfig.addSkipFile(skippedFiles);
+
+    // Add skipped paths provided by the cmd args
+    tidyConfig.addSkipPath(skippedPaths);
 
     // Print (short)descriptions of the checks
     if (printDescriptions || printShortDescriptions) {


### PR DESCRIPTION
This MR adds a new command option to the slang tidy that allows to skip checks on files under the paths provided by `--skip-path`