### PR TITLE
Expose symbol on ParameterSymbolBase in Python bindings

### DIFF
--- a/bindings/python/SymbolBindings.cpp
+++ b/bindings/python/SymbolBindings.cpp
@@ -211,7 +211,8 @@ void registerSymbols(py::module_& m) {
                                [](const EnumValueSymbol& self) { return self.getValue(); });
 
     py::class_<ParameterSymbolBase>(m, "ParameterSymbolBase")
-        .def_property_readonly("symbol", [](const ParameterSymbolBase& self) { return &self.symbol; } )
+        .def_property_readonly("symbol",
+                               [](const ParameterSymbolBase& self) { return &self.symbol; })
         .def_property_readonly("isLocalParam", &ParameterSymbolBase::isLocalParam)
         .def_property_readonly("isPortParam", &ParameterSymbolBase::isPortParam)
         .def_property_readonly("isBodyParam", &ParameterSymbolBase::isBodyParam)

--- a/bindings/python/SymbolBindings.cpp
+++ b/bindings/python/SymbolBindings.cpp
@@ -211,6 +211,7 @@ void registerSymbols(py::module_& m) {
                                [](const EnumValueSymbol& self) { return self.getValue(); });
 
     py::class_<ParameterSymbolBase>(m, "ParameterSymbolBase")
+        .def_property_readonly("symbol", [](const ParameterSymbolBase& self) { return &self.symbol; } )
         .def_property_readonly("isLocalParam", &ParameterSymbolBase::isLocalParam)
         .def_property_readonly("isPortParam", &ParameterSymbolBase::isPortParam)
         .def_property_readonly("isBodyParam", &ParameterSymbolBase::isBodyParam)


### PR DESCRIPTION
As discussed in MikePopoloski/pyslang#172, I was looking for a way to get to the parameter symbol from the ParameterSymbolBase class, and I just exposed the `symbol`.

I know you proposed a different solution, but I compiled and tested this and am using this now myself in the meantime so I figured I would just open a pull request.