### PR TITLE
[slang-netlist] Exclude unused modules from netlist

### DIFF
--- a/tools/netlist/include/NetlistVisitor.h
+++ b/tools/netlist/include/NetlistVisitor.h
@@ -361,6 +361,13 @@ public:
 
     /// Instance.
     void handle(const ast::InstanceSymbol& symbol) {
+        DEBUG_PRINT(fmt::format("Instance {}\n", symbol.name));
+        if (symbol.name.empty()) {
+            // An instance without a name has been excluded from the design.
+            // This can happen when the --top option is used and there is an
+            // uninstanced module.
+            return;
+        }
         // Body members.
         // Variables first.
         for (auto& member : symbol.body.members()) {

--- a/tools/netlist/tests/NetlistTests.cpp
+++ b/tools/netlist/tests/NetlistTests.cpp
@@ -510,4 +510,5 @@ endmodule
     compilation.addSyntaxTree(tree);
     NO_COMPILATION_ERRORS;
     auto netlist = createNetlist(compilation);
+    CHECK(netlist.numNodes() > 0);
 }

--- a/tools/netlist/tests/NetlistTests.cpp
+++ b/tools/netlist/tests/NetlistTests.cpp
@@ -464,3 +464,50 @@ endmodule
     CHECK(!pathFinder.find(*netlist.lookupPort("mux.sel_a"), *netlist.lookupPort("mux.f")).empty());
     CHECK(!pathFinder.find(*netlist.lookupPort("mux.sel_b"), *netlist.lookupPort("mux.f")).empty());
 }
+
+//===---------------------------------------------------------------------===//
+// Tests for name resolution
+//===---------------------------------------------------------------------===//
+
+TEST_CASE("Unused modules") {
+    // Test that unused modules are not visited by the netlist builder.
+    // See Issue #793.
+    auto tree = SyntaxTree::fromText(R"(
+module test (input i1,
+             input i2,
+             output o1
+             );
+   cell_a i_cell_a(.d1(i1),
+                   .d2(i2),
+                   .c(o1));
+endmodule
+
+module cell_a(input  d1,
+              input  d2,
+              output c);
+   assign c = d1 + d2;
+endmodule
+
+// unused
+module cell_b(input  a,
+              input  b,
+              output z);
+   assign z = a || b;
+endmodule
+
+// unused
+module cell_c(input  a,
+              input  b,
+              output z);
+   assign z = (!a) && b;
+endmodule
+)");
+    CompilationOptions coptions;
+    coptions.topModules.emplace("test"sv);
+    Bag options;
+    options.set(coptions);
+    Compilation compilation(options);
+    compilation.addSyntaxTree(tree);
+    NO_COMPILATION_ERRORS;
+    auto netlist = createNetlist(compilation);
+}


### PR DESCRIPTION
Fix #793

Using `--top` causes unused (ie uninstanced) modules to lose their symbol names.

Since it is not necessary to include unused modules in a netlist, this patch skips them during the AST traversal.