### PR TITLE
New slang-tidy checks

### DIFF
--- a/tools/tidy/CMakeLists.txt
+++ b/tools/tidy/CMakeLists.txt
@@ -17,7 +17,8 @@ add_library(
   src/style/AlwaysFFBlocking.cpp
   src/style/EnforceModuleInstantiationPrefix.cpp
   src/style/OnlyANSIPortDecl.cpp
-  src/synthesis/XilinxDoNotCareValues.cpp)
+  src/synthesis/XilinxDoNotCareValues.cpp
+  src/synthesis/CastSignedIndex.cpp)
 
 target_include_directories(slang_tidy_obj_lib PUBLIC include ../../include)
 target_link_libraries(slang_tidy_obj_lib PUBLIC slang::slang)

--- a/tools/tidy/CMakeLists.txt
+++ b/tools/tidy/CMakeLists.txt
@@ -16,7 +16,8 @@ add_library(
   src/style/AlwaysCombNonBlocking.cpp
   src/style/AlwaysFFBlocking.cpp
   src/style/EnforceModuleInstantiationPrefix.cpp
-  src/style/OnlyANSIPortDecl.cpp)
+  src/style/OnlyANSIPortDecl.cpp
+  src/synthesis/XilinxDoNotCareValues.cpp)
 
 target_include_directories(slang_tidy_obj_lib PUBLIC include ../../include)
 target_link_libraries(slang_tidy_obj_lib PUBLIC slang::slang)

--- a/tools/tidy/include/TidyDiags.h
+++ b/tools/tidy/include/TidyDiags.h
@@ -20,5 +20,6 @@ inline constexpr DiagCode AlwaysCombNonBlocking(DiagSubsystem::Tidy, 5);
 inline constexpr DiagCode AlwaysFFBlocking(DiagSubsystem::Tidy, 6);
 inline constexpr DiagCode EnforceModuleInstantiationPrefix(DiagSubsystem::Tidy, 7);
 inline constexpr DiagCode OnlyANSIPortDecl(DiagSubsystem::Tidy, 8);
+inline constexpr DiagCode XilinxDoNotCareValues(DiagSubsystem::Tidy, 9);
 
 } // namespace slang::diag

--- a/tools/tidy/include/TidyDiags.h
+++ b/tools/tidy/include/TidyDiags.h
@@ -21,5 +21,6 @@ inline constexpr DiagCode AlwaysFFBlocking(DiagSubsystem::Tidy, 6);
 inline constexpr DiagCode EnforceModuleInstantiationPrefix(DiagSubsystem::Tidy, 7);
 inline constexpr DiagCode OnlyANSIPortDecl(DiagSubsystem::Tidy, 8);
 inline constexpr DiagCode XilinxDoNotCareValues(DiagSubsystem::Tidy, 9);
+inline constexpr DiagCode CastSignedIndex(DiagSubsystem::Tidy, 10);
 
 } // namespace slang::diag

--- a/tools/tidy/src/TidyConfig.cpp
+++ b/tools/tidy/src/TidyConfig.cpp
@@ -30,6 +30,8 @@ TidyConfig::TidyConfig() {
     synthesisChecks.emplace("NoLatchesOnDesign", CheckStatus::ENABLED);
     synthesisChecks.emplace("OnlyAssignedOnReset", CheckStatus::ENABLED);
     synthesisChecks.emplace("RegisterHasNoReset", CheckStatus::ENABLED);
+    synthesisChecks.emplace("XilinxDoNotCareValues", CheckStatus::ENABLED);
+    synthesisChecks.emplace("CastSignedIndex", CheckStatus::ENABLED);
     checkKinds.insert({slang::TidyKind::Synthesis, synthesisChecks});
 }
 

--- a/tools/tidy/src/synthesis/CastSignedIndex.cpp
+++ b/tools/tidy/src/synthesis/CastSignedIndex.cpp
@@ -43,7 +43,7 @@ public:
 
     DiagnosticSeverity diagSeverity() const override { return DiagnosticSeverity::Warning; }
 
-    std::string name() const override { return "NoLatchesOnDesign"; }
+    std::string name() const override { return "CastSignedIndex"; }
 
     std::string description() const override { return shortDescription(); }
 

--- a/tools/tidy/src/synthesis/CastSignedIndex.cpp
+++ b/tools/tidy/src/synthesis/CastSignedIndex.cpp
@@ -1,0 +1,56 @@
+// SPDX-FileCopyrightText: Michael Popoloski
+// SPDX-License-Identifier: MIT
+
+#include "ASTHelperVisitors.h"
+#include "TidyDiags.h"
+#include "fmt/color.h"
+
+#include "slang/syntax/AllSyntax.h"
+
+using namespace slang;
+using namespace slang::ast;
+
+namespace cast_signed_index {
+struct MainVisitor : public TidyVisitor, ASTVisitor<MainVisitor, true, true> {
+    explicit MainVisitor(Diagnostics& diagnostics) : TidyVisitor(diagnostics) {}
+
+    void handle(const ElementSelectExpression& expr) {
+        if (auto& selector = expr.selector();
+            selector.kind == slang::ast::ExpressionKind::Conversion && selector.type->isSigned())
+            diags.add(diag::CastSignedIndex, selector.sourceRange);
+    }
+};
+} // namespace cast_signed_index
+
+using namespace cast_signed_index;
+
+class CastSignedIndex : public TidyCheck {
+public:
+    [[maybe_unused]] explicit CastSignedIndex(TidyKind kind) : TidyCheck(kind) {}
+
+    bool check(const RootSymbol& root) override {
+        MainVisitor visitor(diagnostics);
+        root.visit(visitor);
+        return diagnostics.empty();
+    }
+
+    DiagCode diagCode() const override { return diag::CastSignedIndex; }
+
+    std::string diagString() const override {
+        return "casting signed indexes can potentially produce negative indexes. Please remove the "
+               "cast or make the index unsigned";
+    }
+
+    DiagnosticSeverity diagSeverity() const override { return DiagnosticSeverity::Warning; }
+
+    std::string name() const override { return "NoLatchesOnDesign"; }
+
+    std::string description() const override { return shortDescription(); }
+
+    std::string shortDescription() const override {
+        return "The cast of a signed index can potentially produce negative indexes making some "
+               "positions unreachable.";
+    }
+};
+
+REGISTER(CastSignedIndex, CastSignedIndex, TidyKind::Synthesis)

--- a/tools/tidy/src/synthesis/XilinxDoNotCareValues.cpp
+++ b/tools/tidy/src/synthesis/XilinxDoNotCareValues.cpp
@@ -1,0 +1,64 @@
+// SPDX-FileCopyrightText: Michael Popoloski
+// SPDX-License-Identifier: MIT
+
+#include "ASTHelperVisitors.h"
+#include "TidyDiags.h"
+#include "TidyFactory.h"
+#include "fmt/color.h"
+
+#include "slang/syntax/AllSyntax.h"
+
+using namespace slang;
+using namespace slang::ast;
+
+namespace xilinx_do_not_care_values {
+struct MainVisitor : public TidyVisitor, ASTVisitor<MainVisitor, true, true> {
+    explicit MainVisitor(Diagnostics& diagnostics) : TidyVisitor(diagnostics) {}
+
+    void handle(const IntegerLiteral& expr) {
+        if (auto syntax = expr.syntax; syntax) {
+            bool hasDoNotCare = syntax->toString().find('?') != std::string::npos;
+            bool hasDecimal = syntax->toString().find('d') != std::string::npos;
+
+            if (hasDoNotCare && hasDecimal)
+                diags.add(diag::XilinxDoNotCareValues, syntax->sourceRange());
+        }
+    }
+};
+} // namespace xilinx_do_not_care_values
+
+using namespace xilinx_do_not_care_values;
+
+class XilinxDoNotCareValues : public TidyCheck {
+public:
+    explicit XilinxDoNotCareValues(TidyKind kind) : TidyCheck(kind) {}
+
+    bool check(const RootSymbol& root) override {
+        MainVisitor visitor(diagnostics);
+        root.visit(visitor);
+        return diagnostics.empty();
+    }
+
+    DiagCode diagCode() const override { return diag::XilinxDoNotCareValues; }
+
+    std::string diagString() const override {
+        return "use of x'd? for do-not-care values is not recommended use x'b? instead";
+    }
+
+    DiagnosticSeverity diagSeverity() const override { return DiagnosticSeverity::Warning; }
+
+    std::string name() const override { return "RegisterHasNoReset"; }
+
+    std::string description() const override {
+        return "The use of x'd? notation for do-not-care values is not recommended since it has "
+               "been observed to produce unexpected results for Xilinx synthesis engines. In "
+               "particular for Xilinx synthesis tools, 4'd? is not interpreted as 4'd???? or 4'b?.";
+    }
+
+    std::string shortDescription() const override {
+        return "The use of x'd? notation for do-not-care values is not recommended since it has "
+               "been observed to produce unexpected results for Xilinx synthesis engines.";
+    }
+};
+
+REGISTER(XilinxDoNotCareValues, XilinxDoNotCareValues, TidyKind::Synthesis)

--- a/tools/tidy/src/synthesis/XilinxDoNotCareValues.cpp
+++ b/tools/tidy/src/synthesis/XilinxDoNotCareValues.cpp
@@ -47,7 +47,7 @@ public:
 
     DiagnosticSeverity diagSeverity() const override { return DiagnosticSeverity::Warning; }
 
-    std::string name() const override { return "RegisterHasNoReset"; }
+    std::string name() const override { return "XilinxDoNotCareValues"; }
 
     std::string description() const override {
         return "The use of x'd? notation for do-not-care values is not recommended since it has "

--- a/tools/tidy/tests/CMakeLists.txt
+++ b/tools/tidy/tests/CMakeLists.txt
@@ -17,7 +17,8 @@ add_executable(
   AlwaysFFBlockingTest.cpp
   EnforceModuleInstantiationTest.cpp
   OnlyANSIPortDecl.cpp
-  XilinxDoNotCareValuesTest.cpp)
+  XilinxDoNotCareValuesTest.cpp
+  CastSignedIndexTest.cpp)
 
 target_link_libraries(tidy_unittests PRIVATE Catch2::Catch2 slang_tidy_obj_lib)
 target_compile_definitions(tidy_unittests PRIVATE UNITTESTS)

--- a/tools/tidy/tests/CMakeLists.txt
+++ b/tools/tidy/tests/CMakeLists.txt
@@ -16,7 +16,8 @@ add_executable(
   AlwaysCombNonBlockingTest.cpp
   AlwaysFFBlockingTest.cpp
   EnforceModuleInstantiationTest.cpp
-  OnlyANSIPortDecl.cpp)
+  OnlyANSIPortDecl.cpp
+  XilinxDoNotCareValuesTest.cpp)
 
 target_link_libraries(tidy_unittests PRIVATE Catch2::Catch2 slang_tidy_obj_lib)
 target_compile_definitions(tidy_unittests PRIVATE UNITTESTS)

--- a/tools/tidy/tests/CastSignedIndexTest.cpp
+++ b/tools/tidy/tests/CastSignedIndexTest.cpp
@@ -1,0 +1,57 @@
+// SPDX-FileCopyrightText: Michael Popoloski
+// SPDX-License-Identifier: MIT
+
+#include "Test.h"
+#include "TidyFactory.h"
+
+TEST_CASE("CastSignedIndex: Negative index") {
+    auto tree = SyntaxTree::fromText(R"(
+module top;
+    logic a [4];
+
+    always_comb begin
+        for (int i = 0; i < 4; i++) begin
+            a[2'(i)] = i;
+        end
+    end
+endmodule
+)");
+
+    Compilation compilation;
+    compilation.addSyntaxTree(tree);
+    compilation.getAllDiagnostics();
+    auto& root = compilation.getRoot();
+
+    TidyConfig config;
+    Registry::setConfig(config);
+    Registry::setSourceManager(compilation.getSourceManager());
+    auto visitor = Registry::create("CastSignedIndex");
+    bool result = visitor->check(root);
+    CHECK_FALSE(result);
+}
+
+TEST_CASE("CastSignedIndex: Signed index") {
+    auto tree = SyntaxTree::fromText(R"(
+module top;
+    logic a [4];
+
+    always_comb begin
+        for (int i = 0; i < 4; i++) begin
+            a[i] = i;
+        end
+    end
+endmodule
+)");
+
+    Compilation compilation;
+    compilation.addSyntaxTree(tree);
+    compilation.getAllDiagnostics();
+    auto& root = compilation.getRoot();
+
+    TidyConfig config;
+    Registry::setConfig(config);
+    Registry::setSourceManager(compilation.getSourceManager());
+    auto visitor = Registry::create("CastSignedIndex");
+    bool result = visitor->check(root);
+    CHECK(result);
+}

--- a/tools/tidy/tests/XilinxDoNotCareValuesTest.cpp
+++ b/tools/tidy/tests/XilinxDoNotCareValuesTest.cpp
@@ -1,0 +1,65 @@
+// SPDX-FileCopyrightText: Michael Popoloski
+// SPDX-License-Identifier: MIT
+
+#include "Test.h"
+#include "TidyFactory.h"
+
+TEST_CASE("XilinxDoNotCareValues: Use of 'd") {
+    auto tree = SyntaxTree::fromText(R"(
+module top;
+    logic [3:0] a = 4'd?;
+endmodule
+)");
+
+    Compilation compilation;
+    compilation.addSyntaxTree(tree);
+    compilation.getAllDiagnostics();
+    auto& root = compilation.getRoot();
+
+    TidyConfig config;
+    Registry::setConfig(config);
+    Registry::setSourceManager(compilation.getSourceManager());
+    auto visitor = Registry::create("XilinxDoNotCareValues");
+    bool result = visitor->check(root);
+    CHECK_FALSE(result);
+}
+
+TEST_CASE("XilinxDoNotCareValues: Use of 'b") {
+    auto tree = SyntaxTree::fromText(R"(
+module top;
+    logic [3:0] a = 4'b?;
+endmodule
+)");
+
+    Compilation compilation;
+    compilation.addSyntaxTree(tree);
+    compilation.getAllDiagnostics();
+    auto& root = compilation.getRoot();
+
+    TidyConfig config;
+    Registry::setConfig(config);
+    Registry::setSourceManager(compilation.getSourceManager());
+    auto visitor = Registry::create("XilinxDoNotCareValues");
+    bool result = visitor->check(root);
+    CHECK(result);
+}
+
+TEST_CASE("XilinxDoNotCareValues: No do-not-care values") {
+    auto tree = SyntaxTree::fromText(R"(
+module top;
+    logic [3:0] a = 4'd10;
+endmodule
+)");
+
+    Compilation compilation;
+    compilation.addSyntaxTree(tree);
+    compilation.getAllDiagnostics();
+    auto& root = compilation.getRoot();
+
+    TidyConfig config;
+    Registry::setConfig(config);
+    Registry::setSourceManager(compilation.getSourceManager());
+    auto visitor = Registry::create("XilinxDoNotCareValues");
+    bool result = visitor->check(root);
+    CHECK(result);
+}


### PR DESCRIPTION
Added two new checks:

- **CastSignedIndex**: The cast of a signed index can potentially produce negative indexes making some positions unreachable.
- **XilinxDoNotCareValues**: The use of x'd? notation for do-not-care values is not recommended since it has been observed to produce unexpected results for Xilinx synthesis engines. In particular for Xilinx synthesis tools, 4'd? is not interpreted as 4'd???? or 4'b?.