### PR TITLE
SmallVector.h: avoid casting away constness

### DIFF
--- a/include/slang/util/SmallVector.h
+++ b/include/slang/util/SmallVector.h
@@ -453,7 +453,7 @@ public:
 
     /// Indicates whether we are still "small", which means we are still on the stack.
     [[nodiscard]] constexpr bool isSmall() const noexcept {
-        return (void*)data_ == (void*)firstElement;
+        return (const void*)data_ == (const void*)firstElement;
     }
 
 protected:


### PR DESCRIPTION
Casting to `void*` removes constness if `T` is a `const` type. Even though the casting here is safe (i.e., no modifications are made), some compilers warn about the cast anyway. Avoid casting away constness to remove some picky compiler warnings.