### PR TITLE
[slang-reflect] Fix more namespace issues and header prints

### DIFF
--- a/tools/reflect/include/CppEmitter.h
+++ b/tools/reflect/include/CppEmitter.h
@@ -55,7 +55,7 @@ public:
         auto headersTransform = std::views::transform(headers, [](const auto& h) {
             return fmt::format("#include \"{}.h\"", h);
         });
-        return fmt::format("// {}\n#pragma once\n\n{}{}\n\n{}", fileName,
+        return fmt::format("// {}\n#pragma once\n\n{}\n{}\n\n{}", fileName,
                            fmt::join(includesTransform, "\n"), fmt::join(headersTransform, "\n"),
                            hpp.str());
     }

--- a/tools/reflect/src/SvStruct.cpp
+++ b/tools/reflect/src/SvStruct.cpp
@@ -104,8 +104,13 @@ void SvStruct::toCpp(HppFile& hppFile, std::string_view _namespace, const SvAlia
             const auto& value = values[i];
 
             if (member.second.isStructOrEnum())
-                hppFile.addWithIndent(
-                    fmt::format("{} = {}({});\n", member.first, member.second.toString(), value));
+                if (_namespace != member.second._namespace)
+                    hppFile.addWithIndent(fmt::format("{} = {}::{}({});\n", member.first,
+                                                      member.second._namespace,
+                                                      member.second.toString(), value));
+                else
+                    hppFile.addWithIndent(fmt::format("{} = {}({});\n", member.first,
+                                                      member.second.toString(), value));
             else
                 hppFile.addWithIndent(fmt::format("{} = {};\n", member.first, value));
         }
@@ -132,8 +137,13 @@ void SvStruct::toCpp(HppFile& hppFile, std::string_view _namespace, const SvAlia
                                     member.first);
 
             if (member.second.isStructOrEnum())
-                hppFile.addWithIndent(
-                    fmt::format("{} = {}({});\n", member.first, member.second.toString(), value));
+                if (_namespace != member.second._namespace)
+                    hppFile.addWithIndent(fmt::format("{} = {}::{}({});\n", member.first,
+                                                      member.second._namespace,
+                                                      member.second.toString(), value));
+                else
+                    hppFile.addWithIndent(fmt::format("{} = {}({});\n", member.first,
+                                                      member.second.toString(), value));
             else
                 hppFile.addWithIndent(fmt::format("{} = {};\n", member.first, value));
         }
@@ -257,7 +267,12 @@ void SvStruct::toCpp(HppFile& hppFile, std::string_view _namespace, const SvAlia
         }
 
         if (member.second.isStructOrEnum())
-            hppFile.addWithIndent(fmt::format("return {}({});\n", member.second.toString(), value));
+            if (_namespace != member.second._namespace)
+                hppFile.addWithIndent(fmt::format("return {}::{}({});\n", member.second._namespace,
+                                                  member.second.toString(), value));
+            else
+                hppFile.addWithIndent(
+                    fmt::format("return {}({});\n", member.second.toString(), value));
         else
             hppFile.addWithIndent(fmt::format("return {};\n", value));
 


### PR DESCRIPTION
We were still missing some namespace annotations in some parts of the generated code, and we were also missing a newline when printing the headers of the generated .h file