### PR TITLE
[slang-tidy] fix slang-tidy's config-file option

### DIFF
--- a/tools/tidy/src/tidy.cpp
+++ b/tools/tidy/src/tidy.cpp
@@ -70,10 +70,15 @@ int main(int argc, char** argv) {
     // Create the config class and populate it with the config file if provided
     TidyConfig tidyConfig;
     if (tidyConfigFile) {
-        if (!exists(std::filesystem::path(tidyConfigFile.value())))
+        if (!exists(std::filesystem::path(tidyConfigFile.value()))) {
             slang::OS::printE(fmt::format("the path provided for the config file does not exist {}",
                                           tidyConfigFile.value()));
-        tidyConfig = TidyConfigParser(tidyConfigFile.value()).getConfig();
+            tidyConfig = TidyConfigParser(tidyConfigFile.value()).getConfig();
+        }
+        else {
+            tidyConfig =
+                TidyConfigParser(std::filesystem::path(tidyConfigFile.value())).getConfig();
+        }
     }
     else if (auto path = project_slang_tidy_config()) {
         tidyConfig = TidyConfigParser(path.value()).getConfig();


### PR DESCRIPTION
The problem deal with "--config-file" slang-tidy option (file: tools/tidy/src/tidy.cpp line: 76)
The  TidyConfigParser constructor have either "std::filesystem::path"(to open file) or "std::string" (for getting config from the string).
The " TidyConfigParser(const std::string& config)" version is selected here in any case instead of "TidyConfigParser(const std::filesystem::path& path)" in case of file exist.
I propose call "TidyConfigParser(std::filesystem::path(tidyConfigFile.value()))" in the file exist case and leave as is other-wise.