### PR TITLE
[slang-tidy] Fix UB with unmodified stringstream input argument

### DIFF
--- a/tools/tidy/src/TidyConfigParser.cpp
+++ b/tools/tidy/src/TidyConfigParser.cpp
@@ -39,9 +39,9 @@ char TidyConfigParser::nextChar() {
     char c;
     do {
         fileStream >> std::noskipws >> c;
+        if (fileStream.eof())
+            return 0;
     } while (c == ' ' || c == '\t');
-    if (fileStream.eof())
-        return 0;
     col++;
 #if defined(_WIN32)
     if (c == '\r' && fileStream.peek() == '\n') {


### PR DESCRIPTION
There is undefined behavior related to [reading](https://github.com/MikePopoloski/slang/blob/47a4dc927b82502cdd0be063b8aa5a889e8aa017/tools/tidy/src/TidyConfigParser.cpp#L42) uninitialized value [c](https://github.com/MikePopoloski/slang/blob/47a4dc927b82502cdd0be063b8aa5a889e8aa017/tools/tidy/src/TidyConfigParser.cpp#L39) (which is UB due to C++ standard) in `TidyConfigParser::nextChar` because there is no guaranteed that `fileStream >> std::noskipws >> c;` call will set the value of `c` due to [basic_istream](https://en.cppreference.com/w/cpp/io/basic_stringstream) [operator>>](https://en.cppreference.com/w/cpp/io/basic_istream/operator_gtgt) description in case of empty or bad stream.

`nextChar` can be called from many different places and there is non-zero chance to enter that call with empty `fileStream`.

Assume that we are unlucky and got `c` which was initialized with `\t` garbage value from stack on some build. So the target loop would be endless. This patch can prove it:

```diff
diff --git a/tools/tidy/src/TidyConfigParser.cpp b/tools/tidy/src/TidyConfigParser.cpp
index c6946283..6fe0fdb5 100644
--- a/tools/tidy/src/TidyConfigParser.cpp
+++ b/tools/tidy/src/TidyConfigParser.cpp
@@ -36,7 +36,7 @@ TidyConfigParser::TidyConfigParser(const std::string& config) {
 }

 char TidyConfigParser::nextChar() {
-    char c;
+    char c = '\t';
     do {
         fileStream >> std::noskipws >> c;
     } while (c == ' ' || c == '\t');
```