### PR TITLE
[slang-tidy] Fix NoOldAlwaysSyntax checker segmentation fault

### DIFF
--- a/tools/tidy/include/ASTHelperVisitors.h
+++ b/tools/tidy/include/ASTHelperVisitors.h
@@ -55,7 +55,8 @@ struct CollectIdentifiers : public slang::ast::ASTVisitor<CollectIdentifiers, fa
 /// ASTVisitor that will collect all LHS assignment symbols under a node
 struct CollectLHSSymbols : public slang::ast::ASTVisitor<CollectLHSSymbols, true, true> {
     void handle(const slang::ast::AssignmentExpression& expression) {
-        symbols.push_back(expression.left().getSymbolReference());
+        if (const auto symbol = expression.left().getSymbolReference(); symbol)
+            symbols.push_back(symbol);
     }
 
     std::vector<const slang::ast::Symbol*> symbols;

--- a/tools/tidy/tests/NoOldAlwaysSyntaxTest.cpp
+++ b/tools/tidy/tests/NoOldAlwaysSyntaxTest.cpp
@@ -199,3 +199,27 @@ endmodule
     bool result = visitor->check(root);
     CHECK(result);
 }
+
+TEST_CASE("NoOldAlwaysSyntax: composite lhs") {
+    auto tree = SyntaxTree::fromText(R"(
+module top();
+    logic n;
+
+    always @(*) begin
+        {n} = 1;
+    end
+endmodule
+)");
+
+    Compilation compilation;
+    compilation.addSyntaxTree(tree);
+    compilation.getAllDiagnostics();
+    auto& root = compilation.getRoot();
+
+    TidyConfig config;
+    Registry::setConfig(config);
+    Registry::setSourceManager(compilation.getSourceManager());
+    auto visitor = Registry::create("NoOldAlwaysSyntax");
+    bool result = visitor->check(root);
+    CHECK(result);
+}


### PR DESCRIPTION
By default `LHSSymbol` collector from [ASTHelpers](https://github.com/MikePopoloski/slang/blob/de0398780b7d1a42cc84676487e93c67b32d84c2/tools/tidy/include/ASTHelperVisitors.h#L58) may store `nullptr` value when - assignment lhs is not `lvalue` [directy](https://github.com/MikePopoloski/slang/blob/de0398780b7d1a42cc84676487e93c67b32d84c2/source/ast/Expression.cpp#L615) (for example - `{x} = 1;`) and at another cases. Then it leads to segmentation fault at `NoOldAlwaysSyntax` checker when stored lhs value is [dereferenced](https://github.com/MikePopoloski/slang/blob/de0398780b7d1a42cc84676487e93c67b32d84c2/tools/tidy/src/style/NoOldAlwaysSyntax.cpp#L35).

How to reproduce:

1. Create an `bug.sv` file:

```verilog
module top();
    logic n;
    always @(*) begin
        {n} = 1;
    end
endmodule
```

2. Run `NoOldAlwaysSyntax` checker on it at any build. For example:

```shell
./build/gcc-11-release/bin/slang-tidy --config-file="Checks:-*, style-no-old-always-syntax"  bug.sv
```