### PR TITLE
[slang-tidy] Fix segmentation fault during mapping checker name on the group

### DIFF
--- a/tools/tidy/src/TidyConfig.cpp
+++ b/tools/tidy/src/TidyConfig.cpp
@@ -74,8 +74,15 @@ bool TidyConfig::toggleCheck(slang::TidyKind kind, const std::string& checkName,
         registeredChecks.end()) {
         return false;
     }
-    checkKinds.at(kind).at(checkName) = status;
-    return true;
+
+    auto& checkNames = checkKinds.at(kind);
+    // Check that checker name is presence at target group
+    if (checkNames.count(checkName)) {
+        checkNames.at(checkName) = status;
+        return true;
+    }
+
+    return false;
 }
 
 bool TidyConfig::isCheckEnabled(slang::TidyKind kind, const std::string& checkName) const {

--- a/tools/tidy/tests/TidyConfigParserTest.cpp
+++ b/tools/tidy/tests/TidyConfigParserTest.cpp
@@ -197,3 +197,13 @@ TEST_CASE("TidyParser: Support for moduleInstantiationPrefix") {
     auto config = parser.getConfig();
     CHECK(config.getCheckConfigs().moduleInstantiationPrefix == "asdf");
 }
+
+TEST_CASE("TidyParser: existing checker in the wrong group") {
+    auto config_str = std::string(R"(Checks:
+    -style-enforce-port-suffix)");
+    TidyConfigParser parser(config_str);
+
+    auto config = parser.getConfig();
+
+    CHECK_FALSE(config.isCheckEnabled(slang::TidyKind::Style, "EnforcePortSuffix"));
+}


### PR DESCRIPTION
There is a `segfault` when existing checker is mapped to else's group

For example (`segfault` - `no-old-always-syntax` is from `style` group but not `synthesis`):

```shell
./build/gcc-11-release/bin/slang-tidy --config-file="Checks:-*,synthesis-no-old-always-syntax" test.sv
```
