### PR TITLE
Add helper function to determine if a location is in a range

### DIFF
--- a/include/slang/text/SourceLocation.h
+++ b/include/slang/text/SourceLocation.h
@@ -162,6 +162,11 @@ public:
     /// @return the end of the range.
     SourceLocation end() const { return endLoc; }
 
+    /// @return true if @a location is within the range, boundaries included.
+    bool contains(const SourceLocation& loc) const { 
+        return loc >= startLoc && loc <= endLoc; 
+    }
+
     bool operator==(const SourceRange& rhs) const = default;
 
     /// A range that is reserved to represent "no location" at all.

--- a/include/slang/text/SourceLocation.h
+++ b/include/slang/text/SourceLocation.h
@@ -163,9 +163,7 @@ public:
     SourceLocation end() const { return endLoc; }
 
     /// @return true if @a location is within the range, boundaries included.
-    bool contains(const SourceLocation& loc) const { 
-        return loc >= startLoc && loc <= endLoc; 
-    }
+    bool contains(const SourceLocation& loc) const { return loc >= startLoc && loc <= endLoc; }
 
     bool operator==(const SourceRange& rhs) const = default;
 


### PR DESCRIPTION
Adds `SourceRange::contains(SourceLocation)` allowing to know if a source location is within the boundaries of the source range.

----
The objective is to know if a location is included in a range.
I assumed that the boundaries of the range are both included (hence the usage of `<=` and `>=` operators)

Please let me know if any update are required (or do not hesitate to make the changes yourself). 