### PR TITLE
Adds a possibility to access the first Token of a SyntaxNode.

### DIFF
--- a/include/slang/syntax/SyntaxNode.h
+++ b/include/slang/syntax/SyntaxNode.h
@@ -107,6 +107,12 @@ public:
     /// Get the last leaf token in this subtree.
     Token getLastToken() const;
 
+    /// Get the first leaf token as a mutable pointer in this subtree.
+    Token* getFirstTokenPtr(); 
+
+    /// Get the last leaf token a mutable pointer in this subtree.
+    Token* getLastTokenPtr();
+
     /// Get the source range of the node.
     SourceRange sourceRange() const;
 
@@ -185,6 +191,7 @@ protected:
 private:
     ConstTokenOrSyntax getChild(size_t index) const;
     TokenOrSyntax getChild(size_t index);
+    PtrTokenOrSyntax getChildPtr(size_t index);
 };
 
 /// @brief Performs a shallow clone of the given syntax node.
@@ -260,6 +267,9 @@ public:
     /// Gets the child (token or node) at the given index.
     virtual ConstTokenOrSyntax getChild(size_t index) const = 0;
 
+    // Gets the child pointer (token or node) at given index.
+    virtual PtrTokenOrSyntax getChildPtr(size_t index) = 0;
+
     /// Sets the child (token or node) at the given index.
     virtual void setChild(size_t index, TokenOrSyntax child) = 0;
 
@@ -289,6 +299,7 @@ public:
 private:
     TokenOrSyntax getChild(size_t index) final { return (*this)[index]; }
     ConstTokenOrSyntax getChild(size_t index) const final { return (*this)[index]; }
+    PtrTokenOrSyntax getChildPtr(size_t index) final {return (*this)[index];};
 
     void setChild(size_t index, TokenOrSyntax child) final {
         (*this)[index] = &child.node()->as<T>();
@@ -327,6 +338,7 @@ public:
 private:
     TokenOrSyntax getChild(size_t index) final { return (*this)[index]; }
     ConstTokenOrSyntax getChild(size_t index) const final { return (*this)[index]; }
+    PtrTokenOrSyntax getChildPtr(size_t index) final {return &(*this)[index];};
     void setChild(size_t index, TokenOrSyntax child) final { (*this)[index] = child.token(); }
 
     SyntaxListBase* clone(BumpAllocator& alloc) const final {
@@ -418,6 +430,12 @@ public:
 private:
     TokenOrSyntax getChild(size_t index) final { return elements[index]; }
     ConstTokenOrSyntax getChild(size_t index) const final { return elements[index]; }
+    PtrTokenOrSyntax getChildPtr(size_t index) final {
+        if(elements[index].isNode())
+            return elements[index].node();
+        else
+            return &(std::get<parsing::Token>(elements[index]));
+        }
     void setChild(size_t index, TokenOrSyntax child) final { elements[index] = child; }
 
     SyntaxListBase* clone(BumpAllocator& alloc) const final {

--- a/include/slang/syntax/SyntaxNode.h
+++ b/include/slang/syntax/SyntaxNode.h
@@ -20,6 +20,32 @@ namespace slang::syntax {
 
 class SyntaxNode;
 
+/// A token pointer or a syntax node.
+struct SLANG_EXPORT PtrTokenOrSyntax : public std::variant<parsing::Token*, SyntaxNode*> {
+    using Base = std::variant<parsing::Token*, SyntaxNode*>;
+    PtrTokenOrSyntax(parsing::Token* token) : Base(token) {}
+    PtrTokenOrSyntax(SyntaxNode* node) : Base(node) {}
+    PtrTokenOrSyntax(nullptr_t) : Base((parsing::Token*)nullptr) {}
+
+    /// @return true if the object is a token.
+    bool isToken() const { return this->index() == 0; }
+
+    /// @return true if the object is a syntax node.
+    bool isNode() const { return this->index() == 1; }
+
+    /// Gets access to the object as a token (throwing an exception
+    /// if it's not actually a token).
+    parsing::Token* token() const { return std::get<0>(*this); }
+
+    /// Gets access to the object as a syntax node (throwing an exception
+    /// if it's not actually a syntax node).
+    SyntaxNode* node() const { return std::get<1>(*this); }
+
+    /// Gets the source range for the token or syntax node or NoLocation if it
+    /// points to nullptr.
+    SourceRange range() const;
+};
+
 /// A token or a constant syntax node.
 struct SLANG_EXPORT ConstTokenOrSyntax : public std::variant<parsing::Token, const SyntaxNode*> {
     using Base = std::variant<parsing::Token, const SyntaxNode*>;

--- a/include/slang/syntax/SyntaxNode.h
+++ b/include/slang/syntax/SyntaxNode.h
@@ -108,7 +108,7 @@ public:
     Token getLastToken() const;
 
     /// Get the first leaf token as a mutable pointer in this subtree.
-    Token* getFirstTokenPtr(); 
+    Token* getFirstTokenPtr();
 
     /// Get the last leaf token a mutable pointer in this subtree.
     Token* getLastTokenPtr();
@@ -130,7 +130,7 @@ public:
     Token childToken(size_t index) const;
 
     /// Gets a pointer to the child token at the specified index. If the
-    /// child at the given index is not a token (probably a node) then 
+    /// child at the given index is not a token (probably a node) then
     /// this returns null.
     Token* childTokenPtr(size_t index);
 
@@ -304,7 +304,7 @@ public:
 private:
     TokenOrSyntax getChild(size_t index) final { return (*this)[index]; }
     ConstTokenOrSyntax getChild(size_t index) const final { return (*this)[index]; }
-    PtrTokenOrSyntax getChildPtr(size_t index) final {return (*this)[index];};
+    PtrTokenOrSyntax getChildPtr(size_t index) final { return (*this)[index]; };
 
     void setChild(size_t index, TokenOrSyntax child) final {
         (*this)[index] = &child.node()->as<T>();
@@ -343,7 +343,7 @@ public:
 private:
     TokenOrSyntax getChild(size_t index) final { return (*this)[index]; }
     ConstTokenOrSyntax getChild(size_t index) const final { return (*this)[index]; }
-    PtrTokenOrSyntax getChildPtr(size_t index) final {return &(*this)[index];};
+    PtrTokenOrSyntax getChildPtr(size_t index) final { return &(*this)[index]; };
     void setChild(size_t index, TokenOrSyntax child) final { (*this)[index] = child.token(); }
 
     SyntaxListBase* clone(BumpAllocator& alloc) const final {
@@ -436,11 +436,11 @@ private:
     TokenOrSyntax getChild(size_t index) final { return elements[index]; }
     ConstTokenOrSyntax getChild(size_t index) const final { return elements[index]; }
     PtrTokenOrSyntax getChildPtr(size_t index) final {
-        if(elements[index].isNode())
+        if (elements[index].isNode())
             return elements[index].node();
         else
             return &(std::get<parsing::Token>(elements[index]));
-        }
+    }
     void setChild(size_t index, TokenOrSyntax child) final { elements[index] = child; }
 
     SyntaxListBase* clone(BumpAllocator& alloc) const final {

--- a/include/slang/syntax/SyntaxNode.h
+++ b/include/slang/syntax/SyntaxNode.h
@@ -129,6 +129,11 @@ public:
     /// an empty Token.
     Token childToken(size_t index) const;
 
+    /// Gets a pointer to the child token at the specified index. If the
+    /// child at the given index is not a token (probably a node) then 
+    /// this returns null.
+    Token* childTokenPtr(size_t index);
+
     /// Gets the number of (direct) children underneath this node in the tree.
     size_t getChildCount() const; // Note: implemented in AllSyntax.cpp
 

--- a/scripts/syntax_gen.py
+++ b/scripts/syntax_gen.py
@@ -506,8 +506,8 @@ size_t SyntaxNode::getChildCount() const {
                         # addr = "&" if  != (returnPointer and not (m[1] in v.notNullMembers)) else ""
                         get = ".get()" if m[1] in v.notNullMembers else ""
                         cppf.write(
-                            "        case {}: return {}{}{}; //{}\n".format(
-                                index, addr, m[1], get, f"ptr = {m[1] in v.pointerMembers}, nn={m[1] in v.notNullMembers}"
+                            "        case {}: return {}{}{};\n".format(
+                                index, addr, m[1], get
                             )
                         )
                         index += 1

--- a/scripts/syntax_gen.py
+++ b/scripts/syntax_gen.py
@@ -482,10 +482,17 @@ size_t SyntaxNode::getChildCount() const {
         cppf.write("}\n\n")
 
         if v.members or v.final != "":
-            for returnType in ("TokenOrSyntax", "ConstTokenOrSyntax", "PtrTokenOrSyntax"):
+            for returnType in (
+                "TokenOrSyntax",
+                "ConstTokenOrSyntax",
+                "PtrTokenOrSyntax",
+            ):
                 cppf.write(
                     "{} {}::getChild{}(size_t index){} {{\n".format(
-                        returnType, k, ("Ptr" if returnType.startswith("Ptr") else ""), "" if not returnType.startswith("Const") else " const"
+                        returnType,
+                        k,
+                        ("Ptr" if returnType.startswith("Ptr") else ""),
+                        "" if not returnType.startswith("Const") else " const",
                     )
                 )
 
@@ -497,12 +504,12 @@ size_t SyntaxNode::getChildCount() const {
                     index = 0
                     for m in v.combinedMembers:
                         addr = ""
-                        if returnPointer :
+                        if returnPointer:
                             if m[0] == "Token" or (m[1] in v.pointerMembers):
                                 addr = "&"
-                        elif m[1] in v.pointerMembers :
+                        elif m[1] in v.pointerMembers:
                             addr = "&"
-                            
+
                         # addr = "&" if  != (returnPointer and not (m[1] in v.notNullMembers)) else ""
                         get = ".get()" if m[1] in v.notNullMembers else ""
                         cppf.write(

--- a/source/syntax/SyntaxNode.cpp
+++ b/source/syntax/SyntaxNode.cpp
@@ -33,6 +33,17 @@ struct GetChildVisitor {
 
 namespace slang::syntax {
 
+SourceRange PtrTokenOrSyntax::range() const {
+    if(isNode())
+        return node()->sourceRange();
+    else {
+        if(token() == nullptr)
+            return SourceRange::NoLocation;
+        else 
+            return token()->range();
+    }
+}
+
 SourceRange ConstTokenOrSyntax::range() const {
     return isNode() ? node()->sourceRange() : token().range();
 }

--- a/source/syntax/SyntaxNode.cpp
+++ b/source/syntax/SyntaxNode.cpp
@@ -41,12 +41,12 @@ struct GetChildVisitor {
 namespace slang::syntax {
 
 SourceRange PtrTokenOrSyntax::range() const {
-    if(isNode())
+    if (isNode())
         return node()->sourceRange();
     else {
-        if(token() == nullptr)
+        if (token() == nullptr)
             return SourceRange::NoLocation;
-        else 
+        else
             return token()->range();
     }
 }

--- a/source/syntax/SyntaxNode.cpp
+++ b/source/syntax/SyntaxNode.cpp
@@ -169,6 +169,13 @@ parsing::Token SyntaxNode::childToken(size_t index) const {
     return child.token();
 }
 
+parsing::Token* SyntaxNode::childTokenPtr(size_t index) {
+    auto child = getChildPtr(index);
+    if (!child.isToken())
+        return nullptr;
+    return child.token();
+}
+
 bool SyntaxNode::isEquivalentTo(const SyntaxNode& other) const {
     size_t childCount = getChildCount();
     if (kind != other.kind || childCount != other.getChildCount())


### PR DESCRIPTION
Addressing #900 (and, by extension #898 )

This PR adds the `getChildPtr`, `getTokenPtr`, `getFirstTokenPtr` and `getLastTokenPtr` functions as well as required backend.

Please let me know how to ensure the tests are still relevant and everything is covered if required.
 