### PR TITLE
[slang] Fix virtual interface comparison

### DIFF
--- a/tests/unittests/ast/MemberTests.cpp
+++ b/tests/unittests/ast/MemberTests.cpp
@@ -2660,7 +2660,6 @@ endmodule
     NO_COMPILATION_ERRORS;
 }
 
-
 TEST_CASE("Instance comparison") {
     auto tree = SyntaxTree::fromText(R"(
 interface PBus1 #(parameter WIDTH=8);
@@ -2684,7 +2683,6 @@ endmodule
     CHECK(diags[0].code == diag::NotAValue);
     CHECK(diags[1].code == diag::NotAValue);
 }
-
 
 TEST_CASE("Virtual interfaces of different types comparison") {
     auto tree = SyntaxTree::fromText(R"(

--- a/tests/unittests/ast/MemberTests.cpp
+++ b/tests/unittests/ast/MemberTests.cpp
@@ -2634,3 +2634,87 @@ endmodule
     compilation.addSyntaxTree(tree);
     NO_COMPILATION_ERRORS;
 }
+
+TEST_CASE("Virtual interface comparison") {
+    auto tree = SyntaxTree::fromText(R"(
+interface PBus1 #(parameter WIDTH=8);
+        logic req, grant;
+        logic [WIDTH-1:0] addr, data;
+        modport phy(input addr, ref data);
+endinterface
+
+module top;
+        PBus1 #(16) p16();
+        virtual PBus1 #(16) v16;
+
+        initial begin
+                if (p16 == v16) begin end
+                if (v16 == p16) begin end
+                if (v16 == v16) begin end
+        end
+endmodule
+)");
+
+    Compilation compilation;
+    compilation.addSyntaxTree(tree);
+    NO_COMPILATION_ERRORS;
+}
+
+
+TEST_CASE("Instance comparison") {
+    auto tree = SyntaxTree::fromText(R"(
+interface PBus1 #(parameter WIDTH=8);
+        logic req, grant;
+        logic [WIDTH-1:0] addr, data;
+        modport phy(input addr, ref data);
+endinterface
+
+module top;
+        PBus1 #(16) p16();
+        initial begin
+                if (p16 == p16) begin end
+        end
+endmodule
+)");
+
+    Compilation compilation;
+    compilation.addSyntaxTree(tree);
+    auto& diags = compilation.getAllDiagnostics();
+    REQUIRE(diags.size() == 2);
+    CHECK(diags[0].code == diag::NotAValue);
+    CHECK(diags[1].code == diag::NotAValue);
+}
+
+
+TEST_CASE("Virtual interfaces of different types comparison") {
+    auto tree = SyntaxTree::fromText(R"(
+interface PBus1 #(parameter WIDTH=8);
+        logic req, grant;
+        logic [WIDTH-1:0] addr, data;
+        modport phy(input addr, ref data);
+endinterface
+
+interface PBus2 #(parameter WIDTH=8);
+        logic req, grant;
+        logic [WIDTH-1:0] addr, data;
+        modport phy(input addr, ref data);
+endinterface
+
+module top;
+        virtual PBus1 #(16) v16;
+        virtual PBus2 #(16) v26;
+        PBus1 #(16) p16();
+        initial begin
+                if (p16 == v26) begin end
+                if (v16 == v26) begin end
+        end
+endmodule
+)");
+
+    Compilation compilation;
+    compilation.addSyntaxTree(tree);
+    auto& diags = compilation.getAllDiagnostics();
+    REQUIRE(diags.size() == 2);
+    CHECK(diags[0].code == diag::BadBinaryExpression);
+    CHECK(diags[1].code == diag::BadBinaryExpression);
+}


### PR DESCRIPTION
`systemverilog` LRM (for example IEEE 1800-2017 or IEEE 1800-2023) 25.9 clause says:

> — Equality ( == ) and inequality ( != ) with the following:
• Another virtual interface of the same type
• An interface instance of the same type
• The special constant null

It follows that virtual interfaces can be compared with instances of the same type which is not supported by `slang` for now. 

I fixed this at that PR. 