### PR TITLE
SVInt operator< fix.

### DIFF
--- a/include/slang/numeric/SVInt.h
+++ b/include/slang/numeric/SVInt.h
@@ -684,6 +684,14 @@ inline SLANG_EXPORT uint32_t clog2(const SVInt& v) {
     return v.getBitWidth() - (v - SVInt::One).countLeadingZeros();
 }
 
+// Returns maximum value of signed or unsugned int
+SVInt getMinValue(const SVInt& Int);
+SVInt getMinValue(bitwidth_t bitwidth, bool isSigned);
+
+// Returns minimum value of signed or unsugned int
+SVInt getMaxValue(const SVInt& Int);
+SVInt getMaxValue(bitwidth_t bitwidth, bool isSigned);
+
 inline namespace literals {
 
 inline SVInt operator""_si(const char* str, size_t size) {

--- a/source/numeric/SVInt.cpp
+++ b/source/numeric/SVInt.cpp
@@ -1399,7 +1399,7 @@ logic_t SVInt::operator<(const SVInt& rhs) const {
         // handle negatives
         if (isNegative()) {
             if (rhs.isNegative())
-                return -(*this) > -rhs;
+                return ~(*this) > ~rhs;
             else
                 return logic_t(true);
         }
@@ -2431,6 +2431,34 @@ bool caseZWildcardEqual(const SVInt& lhs, const SVInt& rhs) {
     }
 
     return true;
+}
+
+SVInt getMinValue(const SVInt& Int) {
+    return getMinValue(Int.getBitWidth(), Int.isSigned());
+}
+
+SVInt getMinValue(bitwidth_t bitwidth, bool isSigned) {
+    if (!isSigned)
+        return SVInt(bitwidth, 0, isSigned);
+
+    SVInt out(bitwidth, 0, isSigned);
+    out.setAllOnes();
+    out = out.lshr(1);
+    out = ~out;
+    return out;
+}
+
+SVInt getMaxValue(const SVInt& Int) {
+    return getMaxValue(Int.getBitWidth(), Int.isSigned());
+}
+
+SVInt getMaxValue(bitwidth_t bitwidth, bool isSigned) {
+    SVInt out(bitwidth, 0, isSigned);
+    out.setAllOnes();
+    if (isSigned)
+        out = out.lshr(1);
+
+    return out;
 }
 
 } // namespace slang

--- a/tests/unittests/util/NumericTests.cpp
+++ b/tests/unittests/util/NumericTests.cpp
@@ -260,6 +260,8 @@ TEST_CASE("Comparison") {
     CHECK("100'sd99999999999999999999999999"_si >= "-120'sd999999999999977789999"_si);
     CHECK("100'd99999999999999999999999999"_si < "-120'sd999999999999977789999"_si);
     CHECK("100'd99999999999999999999999999"_si >= -50);
+    CHECK(SVInt(32, -2147483648, 1) < SVInt(32, -1, 1));
+    CHECK(SVInt(32, -1, 1) > SVInt(32, -2147483648, 1));
 
     CHECK(bool("100'd1234"_si && "100'd09809345"_si));
     CHECK(bool("100'd1234"_si || "100'd0"_si));
@@ -827,4 +829,11 @@ value = value >> 1
     Compilation compilation;
     compilation.addSyntaxTree(tree);
     compilation.getAllDiagnostics();
+}
+TEST_CASE("Get minimum and maximum value") {
+    CHECK(slang::getMaxValue(32, 0) == 4294967295);
+    CHECK(slang::getMinValue(32, 0) == 0);
+
+    CHECK(slang::getMaxValue(32, 1) == 2147483647);
+    CHECK(slang::getMinValue(32, 1) == -2147483648);
 }


### PR DESCRIPTION
Hello, SVInt compares incorrectly with minimum signed int value. These test cases are failed on current main branch
```
CHECK(SVInt(32, -2147483648, 1) < SVInt(32, -1, 1));
CHECK(SVInt(32, -1, 1) > SVInt(32, -2147483648, 1));
```

It is because of negation of minimum signed int value is impossible (INT_MIN = -INT_MAX-1). This fact is used [here](https://github.com/MikePopoloski/slang/blob/3c5e5e0106f53a505c8b23d0db4e23a2ffa58a6b/source/numeric/SVInt.cpp#L1402). It is better to compare bit inversions of negative values as 
```
-var = ~var + 1
``` 
so every value can be represented.

This patch also includes function for representing minimum and maximum integer values.