### PR TITLE
PR: Make command-line defines stronger than `define's inside Verilog files

### DIFF
--- a/include/slang/parsing/Preprocessor.h
+++ b/include/slang/parsing/Preprocessor.h
@@ -250,6 +250,7 @@ private:
         const syntax::DefineDirectiveSyntax* syntax = nullptr;
         MacroIntrinsic intrinsic = MacroIntrinsic::None;
         bool builtIn = false;
+        bool commandLine = false;
 
         MacroDef() = default;
         MacroDef(const syntax::DefineDirectiveSyntax* syntax) : syntax(syntax) {}

--- a/source/parsing/Preprocessor.cpp
+++ b/source/parsing/Preprocessor.cpp
@@ -643,7 +643,7 @@ Trivia Preprocessor::handleDefineDirective(Token directive) {
             bad = true;
         }
         else if (it->second.commandLine)
-            bad = true;
+            bad = true; // not really bad, but commandLine args has precedence so we skip this
         else if (!bad && it->second.valid() && !isSameMacro(*result, *it->second.syntax)) {
             auto& diag = addDiag(diag::RedefiningMacro, name.range());
             diag << name.valueText();

--- a/source/parsing/Preprocessor.cpp
+++ b/source/parsing/Preprocessor.cpp
@@ -119,9 +119,11 @@ void Preprocessor::predefine(const std::string& definition, std::string_view nam
     // Look for the macro in the temporary preprocessor's macro map.
     // Any macros found that are not the built-in intrinsic macros should
     // be copied over to our own map.
-    for (const auto& pair : pp.macros) {
-        if (!pair.second.isIntrinsic())
+    for (auto& pair : pp.macros) {
+        if (!pair.second.isIntrinsic()) {
+            pair.second.commandLine = true;
             macros.insert(pair);
+        }
     }
 }
 
@@ -640,6 +642,8 @@ Trivia Preprocessor::handleDefineDirective(Token directive) {
             addDiag(diag::InvalidMacroName, name.range());
             bad = true;
         }
+        else if (it->second.commandLine)
+            bad = true;
         else if (!bad && it->second.valid() && !isSameMacro(*result, *it->second.syntax)) {
             auto& diag = addDiag(diag::RedefiningMacro, name.range());
             diag << name.valueText();

--- a/tests/unittests/parsing/PreprocessorTests.cpp
+++ b/tests/unittests/parsing/PreprocessorTests.cpp
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: MIT
 
 #include "Test.h"
-#include <algorithm>
 
 #include "slang/parsing/Preprocessor.h"
 #include "slang/syntax/AllSyntax.h"

--- a/tests/unittests/parsing/PreprocessorTests.cpp
+++ b/tests/unittests/parsing/PreprocessorTests.cpp
@@ -1,9 +1,8 @@
 // SPDX-FileCopyrightText: Michael Popoloski
 // SPDX-License-Identifier: MIT
 
-#include <algorithm>
-
 #include "Test.h"
+#include <algorithm>
 
 #include "slang/parsing/Preprocessor.h"
 #include "slang/syntax/AllSyntax.h"

--- a/tests/unittests/parsing/PreprocessorTests.cpp
+++ b/tests/unittests/parsing/PreprocessorTests.cpp
@@ -1,6 +1,8 @@
 // SPDX-FileCopyrightText: Michael Popoloski
 // SPDX-License-Identifier: MIT
 
+#include <algorithm>
+
 #include "Test.h"
 
 #include "slang/parsing/Preprocessor.h"
@@ -1380,6 +1382,41 @@ TEST_CASE("Preprocessor API") {
 
     pp.setKeywordVersion(KeywordVersion::v1364_2001);
     CHECK(pp.getDefinedMacros().size() == 19);
+}
+
+TEST_CASE("Command-line defines priority over `define") {
+    PreprocessorOptions ppOptions;
+    ppOptions.predefines.emplace_back("A=2");
+    ppOptions.predefines.emplace_back("B=2");
+    ppOptions.predefines.emplace_back("C=2");
+
+    Bag options;
+    options.set(ppOptions);
+
+    auto& text = R"(
+`define A 1
+`undef B
+`undef C
+`define C 1
+)";
+    Preprocessor preprocessor(getSourceManager(), alloc, diagnostics, options);
+    preprocessor.pushSource(text);
+
+    while (true) {
+        Token token = preprocessor.next();
+        if (token.kind == TokenKind::EndOfFile)
+            break;
+    }
+
+    CHECK(!preprocessor.isDefined("B"));
+    CHECK(preprocessor.isDefined("A"));
+    CHECK(preprocessor.isDefined("C"));
+    for (auto macro : preprocessor.getDefinedMacros()) {
+        if (macro->name.toString() == "A")
+            CHECK(macro->body[0].toString() == "2");
+        if (macro->name.toString() == "C")
+            CHECK(macro->body[0].toString() == "1");
+    }
 }
 
 TEST_CASE("Undef builtin") {


### PR DESCRIPTION
Here is a simple PR that solves #927 , although it doesn't add a command line flag to keep the older behavior optionally.
I haven't added more unit tests yet, but the existing unittests all pass.
Here are 3 manual cases I've tried, all ran with `slang +define+N=2 t.v` :

``` Verilog
`define N 1
module t;
generate
  $info("%d", `N);
endgenerate
endmodule
```
This one yields 2, as the command line flag overrides the `define` inside the file.

```Verilog
`define N 1
`undef N
module t;
generate
  $info("%d", `N);
endgenerate
endmodule
```
This one yields an undefined macro error, since the `undef` inside the file removed the command-line `define`.

```Verilog
`define N 1
`undef N
`define N 1
module t;
generate
  $info("%d", `N);
endgenerate
endmodule
```
This one yields 1 because once `N` is undefined, it can be redefined inside the file.
