### PR TITLE
Don't error if multiple UDP row inputs match, unless their output differ

### DIFF
--- a/source/ast/symbols/MemberSymbols.cpp
+++ b/source/ast/symbols/MemberSymbols.cpp
@@ -1015,9 +1015,12 @@ static void createTableRow(const Scope& scope, const UdpEntrySyntax& syntax,
         return 0;
     };
 
-    auto stateChar = getStateChar(syntax.current);
-    if (!stateChar)
-        return;
+    char stateChar = 0;
+    if (syntax.current) {
+        stateChar = getStateChar(syntax.current);
+        if (!stateChar)
+            return;
+    }
 
     auto getOutputChar = [](const UdpFieldBaseSyntax* base) -> char {
         if (base && base->kind == SyntaxKind::UdpSimpleField) {

--- a/source/ast/symbols/MemberSymbols.cpp
+++ b/source/ast/symbols/MemberSymbols.cpp
@@ -995,7 +995,7 @@ static void createTableRow(const Scope& scope, const UdpEntrySyntax& syntax,
         return;
     }
 
-    auto getstateChar = [](const UdpFieldBaseSyntax* base) -> char {
+    auto getStateChar = [](const UdpFieldBaseSyntax* base) -> char {
         if (base && base->kind == SyntaxKind::UdpSimpleField) {
             auto raw = base->as<UdpSimpleFieldSyntax>().field.rawText();
             if (raw.size() == 1) {
@@ -1015,7 +1015,7 @@ static void createTableRow(const Scope& scope, const UdpEntrySyntax& syntax,
         return 0;
     };
 
-    auto stateChar = getstateChar(syntax.current);
+    auto stateChar = getStateChar(syntax.current);
     if (!stateChar)
         return;
 
@@ -1064,7 +1064,7 @@ static void createTableRow(const Scope& scope, const UdpEntrySyntax& syntax,
         // This is an error if the existing row has a different output,
         // otherwise it's just silently ignored.
         auto existingOutput = getOutputChar(existing->next);
-        auto existingState = getstateChar(existing->current);
+        auto existingState = getStateChar(existing->current);
         if (!((existingOutput == outputChar) ||
               matchOutput(existingState, existingOutput, outputChar) ||
               matchOutput(stateChar, outputChar, existingOutput))) {

--- a/source/ast/symbols/MemberSymbols.cpp
+++ b/source/ast/symbols/MemberSymbols.cpp
@@ -1049,8 +1049,8 @@ static void createTableRow(const Scope& scope, const UdpEntrySyntax& syntax,
         auto existingOutput = getOutputChar(existing->next);
         auto existingState = getstateChar(existing->current);
         if (!((existingOutput == outputChar) ||
-              (existingOutput == '-') && (existingState == outputChar) ||
-              (outputChar == '-') && (stateChar == existingOutput))) {
+              ((existingOutput == '-') && (existingState == outputChar)) ||
+              ((outputChar == '-') && (stateChar == existingOutput)))) {
             auto& diag = scope.addDiag(diag::UdpDupDiffOutput, syntax.sourceRange());
             diag.addNote(diag::NotePreviousDefinition, existing->sourceRange());
             return;

--- a/source/ast/symbols/MemberSymbols.cpp
+++ b/source/ast/symbols/MemberSymbols.cpp
@@ -1014,10 +1014,10 @@ static void createTableRow(const Scope& scope, const UdpEntrySyntax& syntax,
         }
         return 0;
     };
-    
+
     auto stateChar = getstateChar(syntax.current);
     if (!stateChar)
-            return;
+        return;
 
     auto getOutputChar = [](const UdpFieldBaseSyntax* base) -> char {
         if (base && base->kind == SyntaxKind::UdpSimpleField) {
@@ -1049,7 +1049,7 @@ static void createTableRow(const Scope& scope, const UdpEntrySyntax& syntax,
         auto existingOutput = getOutputChar(existing->next);
         auto existingState = getstateChar(existing->current);
         if (!((existingOutput == outputChar) ||
-              (existingOutput == '-') && (existingState == outputChar) || 
+              (existingOutput == '-') && (existingState == outputChar) ||
               (outputChar == '-') && (stateChar == existingOutput))) {
             auto& diag = scope.addDiag(diag::UdpDupDiffOutput, syntax.sourceRange());
             diag.addNote(diag::NotePreviousDefinition, existing->sourceRange());

--- a/tests/unittests/ast/PrimitiveTests.cpp
+++ b/tests/unittests/ast/PrimitiveTests.cpp
@@ -444,7 +444,7 @@ TEST_CASE("UDP overlapping inputs with compatible outputs") {
           output reg q;
           input clk, d, _c, _s;
           table
-          // clk in  _c  _s  : Qt  : Qt+1                             
+          // clk in  _c  _s  : Qt  : Qt+1
             r    0    1   1  : ?   :  0;
             *    0    ?   1  : 0   :  -;
           endtable
@@ -453,7 +453,7 @@ TEST_CASE("UDP overlapping inputs with compatible outputs") {
           output reg q;
           input clk, d, _c, _s;
           table
-          // clk in  _c  _s  : Qt  : Qt+1                             
+          // clk in  _c  _s  : Qt  : Qt+1
             r    0    1   1  : 1   :  -;
             *    0    ?   1  : ?   :  1;
           endtable

--- a/tests/unittests/ast/PrimitiveTests.cpp
+++ b/tests/unittests/ast/PrimitiveTests.cpp
@@ -176,13 +176,22 @@ primitive p14 (a, b, c);
         xx:0:0;
     endtable
 endprimitive
+
+primitive p15 (a, b);
+    output a;
+    input b;
+    table
+        0:0;
+        0:1;
+    endtable
+endprimitive
 )");
 
     Compilation compilation;
     compilation.addSyntaxTree(tree);
 
     auto& diags = compilation.getAllDiagnostics();
-    REQUIRE(diags.size() == 24);
+    REQUIRE(diags.size() == 25);
     CHECK(diags[0].code == diag::PrimitiveOutputFirst);
     CHECK(diags[1].code == diag::PrimitiveAnsiMix);
     CHECK(diags[2].code == diag::DuplicateDefinition);
@@ -207,6 +216,7 @@ endprimitive
     CHECK(diags[21].code == diag::UdpWrongInputCount);
     CHECK(diags[22].code == diag::UdpDupDiffOutput);
     CHECK(diags[23].code == diag::UdpAllX);
+    CHECK(diags[24].code == diag::UdpDupDiffOutput);
 }
 
 TEST_CASE("UDP instances error checking") {

--- a/tests/unittests/ast/PrimitiveTests.cpp
+++ b/tests/unittests/ast/PrimitiveTests.cpp
@@ -440,23 +440,78 @@ endmodule
 
 TEST_CASE("UDP overlapping inputs with compatible outputs") {
     auto tree = SyntaxTree::fromText(R"(
- primitive D1 (q, clk, d, _c, _s);
-          output reg q;
-          input clk, d, _c, _s;
-          table
-          // clk in  _c  _s  : Qt  : Qt+1
-            r    0    1   1  : ?   :  0;
-            *    0    ?   1  : 0   :  -;
-          endtable
+ primitive X1 (q, clk, d);
+    output reg q;
+    input clk, d;
+    table
+    // clk in  : Qt  : Qt+1
+    r    0   : ?   :  0;
+    *    0   : 0   :  -;
+    endtable
  endprimitive
- primitive D2 (q, clk, d, _c, _s);
-          output reg q;
-          input clk, d, _c, _s;
-          table
-          // clk in  _c  _s  : Qt  : Qt+1
-            r    0    1   1  : 1   :  -;
-            *    0    ?   1  : ?   :  1;
-          endtable
+ primitive X2 (q, clk, d);
+    output reg q;
+    input clk, d;
+    table
+    // clk in  : Qt  : Qt+1
+    r    0   : 1   :  -;
+    *    0   : ?   :  1;
+    endtable
+ endprimitive
+ primitive X3 (q, clk, d);
+    output reg q;
+    input clk, d;
+    table
+    // clk in  : Qt  : Qt+1
+    r    0   : ?   :  -;
+    *    0   : ?   :  0;
+    *    1   : ?   :  0;
+    r    1   : ?   :  -;
+    endtable
+ endprimitive
+ primitive X4 (q, clk, d);
+    output reg q;
+    input clk, d;
+    table
+    // clk in  : Qt  : Qt+1
+    r    0   : ?   :  -;
+    *    0   : ?   :  1;
+    *    1   : ?   :  1;
+    r    1   : ?   :  -;
+    endtable
+ endprimitive
+ primitive X5 (q, clk, d);
+    output reg q;
+    input clk, d;
+    table
+    // clk in  : Qt  : Qt+1
+    r    0   : ?   :  -;
+    *    0   : ?   :  x;
+    *    1   : ?   :  x;
+    r    1   : ?   :  -;
+    endtable
+ endprimitive
+ primitive X6 (q, clk, d);
+    output reg q;
+    input clk, d;
+    table
+    // clk in  : Qt  : Qt+1
+    r    0   : b   :  -;
+    *    0   : ?   :  0;
+    *    1   : ?   :  0;
+    r    1   : b   :  -;
+    endtable
+ endprimitive
+primitive X7 (q, clk, d);
+    output reg q;
+    input clk, d;
+    table
+    // clk in  : Qt  : Qt+1
+    r    0   : b   :  -;
+    *    0   : ?   :  1;
+    *    1   : ?   :  1;
+    r    1   : b   :  -;
+    endtable
  endprimitive
 )");
 

--- a/tests/unittests/ast/PrimitiveTests.cpp
+++ b/tests/unittests/ast/PrimitiveTests.cpp
@@ -438,6 +438,35 @@ endmodule
     CHECK(diags[2].code == diag::UdpDupDiffOutput);
 }
 
+TEST_CASE("UDP overlapping inputs with compatible outputs") {
+    auto tree = SyntaxTree::fromText(R"(
+ primitive D1 (q, clk, d, _c, _s);
+          output reg q;
+          input clk, d, _c, _s;
+          table
+          // clk in  _c  _s  : Qt  : Qt+1                             
+            r    0    1   1  : ?   :  0;
+            *    0    ?   1  : 0   :  -;
+          endtable
+ endprimitive
+ primitive D2 (q, clk, d, _c, _s);
+          output reg q;
+          input clk, d, _c, _s;
+          table
+          // clk in  _c  _s  : Qt  : Qt+1                             
+            r    0    1   1  : 1   :  -;
+            *    0    ?   1  : ?   :  1;
+          endtable
+ endprimitive
+)");
+
+    Compilation compilation;
+    compilation.addSyntaxTree(tree);
+
+    auto& diags = compilation.getAllDiagnostics();
+    REQUIRE(diags.size() == 0);
+}
+
 TEST_CASE("More UDP error cases") {
     auto tree = SyntaxTree::fromText(R"(
 primitive p1(output reg o, input a);


### PR DESCRIPTION
This fixes #926 .
It takes into account the 'keep previous state' output value when comparing UDP table rows.
Also includes a new unit test.
