### PR TITLE
Fix errors on non blocking assignments with RHS delays inside always_ff

### DIFF
--- a/source/ast/Statements.cpp
+++ b/source/ast/Statements.cpp
@@ -2281,12 +2281,14 @@ Statement& ExpressionStatement::fromSyntax(Compilation& compilation,
             ok = true;
             break;
         }
-        case ExpressionKind::Assignment:
-            if (auto timing = expr.as<AssignmentExpression>().timingControl)
-                stmtCtx.observeTiming(*timing);
+        case ExpressionKind::Assignment: {
+            const AssignmentExpression& ae = expr.as<AssignmentExpression>();
+            if (ae.isBlocking() && ae.timingControl)
+                stmtCtx.observeTiming(*ae.timingControl);
 
             ok = true;
             break;
+        }
         case ExpressionKind::NewClass:
             ok = true;
             break;


### PR DESCRIPTION
This is my attempt to fix #932 .
It works, the new unit tests pass, but I'm really lacking confidence in my patch (at least it is very short and can be easily reviewed).
