### PR TITLE
[slang-netlist] Fix writing to file from FormatBuffer

### DIFF
--- a/tools/netlist/netlist.cpp
+++ b/tools/netlist/netlist.cpp
@@ -102,7 +102,7 @@ void printDOT(const Netlist& netlist, const std::string& fileName) {
         }
     }
     buffer.append("}\n");
-    OS::writeFile(fileName, buffer.data());
+    OS::writeFile(fileName, buffer.str());
 }
 
 void reportPath(Compilation& compilation, const NetlistPath& path) {


### PR DESCRIPTION
Use `FormatBuffer::str()` to avoid returning garbage.

Fix #955.