### PR TITLE
ASTVisitor.h: allow optionally visiting bad nodes

### DIFF
--- a/include/slang/ast/ASTVisitor.h
+++ b/include/slang/ast/ASTVisitor.h
@@ -52,14 +52,14 @@ concept HasVisitExprs = requires(const T& t, TVisitor&& visitor) { t.visitExprs(
 /// visited -- you can include that behavior by invoking @a visitDefault
 /// in your handler.
 ///
-template<typename TDerived, bool VisitStatements, bool VisitExpressions>
+template<typename TDerived, bool VisitStatements, bool VisitExpressions, bool VisitBad = false>
 class ASTVisitor {
 #define DERIVED *static_cast<TDerived*>(this)
 public:
     /// The visit() entry point for visiting AST nodes.
     template<typename T>
     void visit(const T& t) {
-        if constexpr (requires { t.bad(); }) {
+        if constexpr (!VisitBad && requires { t.bad(); }) {
             if (t.bad())
                 return;
         }


### PR DESCRIPTION
Occasionally it is useful to visit bad nodes during an AST traversal. For example, in slang_main.cpp::printJson, the ASTSerializer is used to dump the JSON representation of a slang AST whether or not that AST has bad nodes or not. That serializer does not use the generic ASTVisitor infrastructure, instead rewriting similar traversal logic in the member function template ASTSerializer.cpp::ASTSerializer::visit. It may be the case that this traversal could be rewritten to use ASTVisitor now that it supports bad nodes (but the author is not sure).

Since this functionality is introduced by a trailing default template parameter (with default false), this commit changes no functionality, and can only be turned on by explicitly asking for it by specifying true as the value of VisitBad.