### PR TITLE
If a backslash is found at the end of the line, ignore it

### DIFF
--- a/source/util/CommandLine.cpp
+++ b/source/util/CommandLine.cpp
@@ -248,15 +248,18 @@ void CommandLine::parseStr(std::string_view argList, ParseOptions options, bool&
             continue;
         }
 
-        // Any non-whitespace character here means we are building an argument.
-        hasArg = true;
-
         // Escape character preserves the value of the next character.
         if (c == '\\') {
-            if (ptr != end)
-                current += *ptr++;
+            if (ptr == end || (*ptr == '\n'))
+                continue;
+            current += *ptr++;
+            // Any non-whitespace character here means we are building an argument.
+            hasArg = true;
             continue;
         }
+
+        // Any non-whitespace character here means we are building an argument.
+        hasArg = true;
 
         // Single quotes consume all characters until the next single quote.
         if (c == '\'') {

--- a/tests/unittests/util/CommandLineTests.cpp
+++ b/tests/unittests/util/CommandLineTests.cpp
@@ -118,6 +118,24 @@ OPTIONS:
 )");
 }
 
+TEST_CASE("Test CommandLine -- backslash at EOL") {
+    std::optional<bool> a, b, c;
+    CommandLine cmdLine;
+    cmdLine.add("-a", a, "SDF");
+    cmdLine.add("-b", b, "SDF");
+    cmdLine.add("-c", c, "SDF");
+
+    // Check for backslash at EOL
+    // Check for backslash plus whitespace(s) at EOL
+    // Check for backslash at end of command line args
+    CHECK(cmdLine.parse(
+        "prog -a\\\n -b -c\\"sv));
+    CHECK(cmdLine.getProgramName() == "prog");
+    CHECK(a);
+    CHECK(b);
+    CHECK(c);
+}
+
 TEST_CASE("Test CommandLine -- nonspan") {
     std::optional<bool> a;
     CommandLine cmdLine;

--- a/tests/unittests/util/CommandLineTests.cpp
+++ b/tests/unittests/util/CommandLineTests.cpp
@@ -128,8 +128,7 @@ TEST_CASE("Test CommandLine -- backslash at EOL") {
     // Check for backslash at EOL
     // Check for backslash plus whitespace(s) at EOL
     // Check for backslash at end of command line args
-    CHECK(cmdLine.parse(
-        "prog -a\\\n -b -c\\"sv));
+    CHECK(cmdLine.parse("prog -a\\\n -b -c\\"sv));
     CHECK(cmdLine.getProgramName() == "prog");
     CHECK(a);
     CHECK(b);


### PR DESCRIPTION
This brings behavior in-line with other tools as well as shell-like behavior, as discussed in #964.
In the rare case someone really wants to escape \n, he can always use single quotes.
