### PR TITLE
NewClassExpression::serializeTo: write isSuperClass property

### DIFF
--- a/source/ast/expressions/AssignmentExpressions.cpp
+++ b/source/ast/expressions/AssignmentExpressions.cpp
@@ -1282,6 +1282,7 @@ ConstantValue NewClassExpression::evalImpl(EvalContext& context) const {
 void NewClassExpression::serializeTo(ASTSerializer& serializer) const {
     if (constructorCall())
         serializer.write("constructorCall", *constructorCall());
+    serializer.write("isSuperClass", isSuperClass);
 }
 
 Expression& NewCovergroupExpression::fromSyntax(Compilation& compilation,

--- a/tests/unittests/ast/MemberTests.cpp
+++ b/tests/unittests/ast/MemberTests.cpp
@@ -433,7 +433,8 @@ endmodule
             "type": "C",
             "initializer": {
               "kind": "NewClass",
-              "type": "C"
+              "type": "C",
+              "isSuperClass": false
             },
             "lifetime": "Static"
           }


### PR DESCRIPTION
This is a useful property not currently visible in serialized ASTs, for example in the JSON format, viewable from sv-lang.com/explore.