### PR TITLE
MethodPrototypeSymbol::serialize: write subroutine, if it exists

### DIFF
--- a/source/ast/symbols/SubroutineSymbols.cpp
+++ b/source/ast/symbols/SubroutineSymbols.cpp
@@ -1254,6 +1254,9 @@ void MethodPrototypeSymbol::serializeTo(ASTSerializer& serializer) const {
 
     if (flags)
         serializer.write("flags", flagsToStr(flags));
+
+    if (auto* sub = getSubroutine())
+        serializer.write("subroutine", *sub);
 }
 
 } // namespace slang::ast


### PR DESCRIPTION
As in 47010bdd (NewClassExpression::serializeTo: write isSuperClass property, Wed Apr 24 15:17:01 2024 -0400), the subroutine member of a MethodPrototypeSymbol is a crucial property for understanding the prototype. Write it in the serializer (when it exists), so that consumers, such as slang-explorer, can see it.