### PR TITLE
GenericClassDefSymbol::serializeTo: write specializations

### DIFF
--- a/source/ast/symbols/ClassSymbols.cpp
+++ b/source/ast/symbols/ClassSymbols.cpp
@@ -1013,6 +1013,10 @@ void GenericClassDefSymbol::addParameterDecl(const DefinitionSymbol::ParameterDe
 void GenericClassDefSymbol::serializeTo(ASTSerializer& serializer) const {
     if (firstForward)
         serializer.write("forward", *firstForward);
+    serializer.startArray("specializations");
+    for (auto&& spec : specializations())
+        serializer.serialize(spec, /* inMembersArray */ true);
+    serializer.endArray();
 }
 
 GenericClassDefSymbol::SpecializationKey::SpecializationKey(


### PR DESCRIPTION
Include the specializations of a generic class definition symbol during serialization, so that consumers, such as slang-explorer, can see them.