### PR TITLE
Pr hier filenames

### DIFF
--- a/tools/hier/hier.cpp
+++ b/tools/hier/hier.cpp
@@ -34,7 +34,7 @@ int main(int argc, char** argv) {
     driver.cmdLine.add("--inst-regex", instRegex,
                        "Show only instances matched by regex (scans whole tree)", "<inst-regex>");
     driver.cmdLine.add("--custom-format", customFormat,
-                       "Use libfmt style strings to format output. argument names are inst, module, file", "<fmt::format string>");
+                       "Use libfmt-style strings to format output with {inst}, {module}, {file} as argument names", "<fmt::format string>");
 
     if (!driver.parseCommandLine(argc, argv))
         return 1;

--- a/tools/hier/hier.cpp
+++ b/tools/hier/hier.cpp
@@ -53,6 +53,7 @@ int main(int argc, char** argv) {
     bool ok = driver.parseAllSources();
 
     auto compilation = driver.createCompilation();
+    auto sourceManager = compilation->getSourceManager();
 
     if (instRegex.has_value())
         regex = instRegex.value();
@@ -82,8 +83,8 @@ int main(int argc, char** argv) {
                 }
                 type.getHierarchicalPath(tmp_path);
                 if (!instRegex.has_value() || std::regex_search(tmp_path, match, regex)) {
-                    OS::print(fmt::format("Module=\"{}\" Instance=\"{}\" ",
-                                          type.getDefinition().name, tmp_path));
+                    OS::print(fmt::format("Module=\"{}\" Instance=\"{}\" File=\"{}\" ",
+                                          type.getDefinition().name, tmp_path, sourceManager->getFileName(type.location)));
                     int size = type.body.getParameters().size();
                     if (size && params.value_or(false)) {
                         OS::print(fmt::format("Parameters: "));

--- a/tools/hier/hier.cpp
+++ b/tools/hier/hier.cpp
@@ -33,8 +33,10 @@ int main(int argc, char** argv) {
                        "<inst-prefix>");
     driver.cmdLine.add("--inst-regex", instRegex,
                        "Show only instances matched by regex (scans whole tree)", "<inst-regex>");
-    driver.cmdLine.add("--custom-format", customFormat,
-                       "Use libfmt-style strings to format output with {inst}, {module}, {file} as argument names", "<fmt::format string>");
+    driver.cmdLine.add(
+        "--custom-format", customFormat,
+        "Use libfmt-style strings to format output with {inst}, {module}, {file} as argument names",
+        "<fmt::format string>");
 
     if (!driver.parseCommandLine(argc, argv))
         return 1;
@@ -89,9 +91,12 @@ int main(int argc, char** argv) {
                     auto s_module = type.getDefinition().name;
                     auto s_file = sourceManager->getFileName(type.getDefinition().location);
                     if (customFormat.has_value())
-                        OS::print(fmt::format(fmt::runtime(customFormat.value()), fmt::arg("module", s_module), fmt::arg("inst", s_inst), fmt::arg("file", s_file)));
+                        OS::print(fmt::format(fmt::runtime(customFormat.value()),
+                                              fmt::arg("module", s_module),
+                                              fmt::arg("inst", s_inst), fmt::arg("file", s_file)));
                     else
-                        OS::print(fmt::format("Module=\"{}\" Instance=\"{}\" File=\"{}\" ", s_module, s_inst, s_file));
+                        OS::print(fmt::format("Module=\"{}\" Instance=\"{}\" File=\"{}\" ",
+                                              s_module, s_inst, s_file));
                     int size = type.body.getParameters().size();
                     if (size && params.value_or(false)) {
                         OS::print(fmt::format("Parameters: "));


### PR DESCRIPTION
This PR allows controlling `slang-hier` output by supplying a libfmt-style format string with the `--custom-format` argument.
There are 3 named arguments supported:
`{module}` - The current module's name
`{inst}` - The full instance name under which the module is instanciated
`{file}` - The file from which the module was read.

We also augment the default output format with the module's filename, which was not available before in the output.