### PR TITLE
[slang][lang-compliance] Introduce nondegeneracy check

### DIFF
--- a/bindings/python/ASTBindings.cpp
+++ b/bindings/python/ASTBindings.cpp
@@ -333,7 +333,7 @@ void registerAST(py::module_& m) {
         .def_readonly("kind", &AssertionExpr::kind)
         .def_readonly("syntax", &AssertionExpr::syntax)
         .def_property_readonly("bad", &AssertionExpr::bad)
-        .def_property_readonly("admitsEmpty", &AssertionExpr::admitsEmpty)
+        .def_property_readonly("checkNondegeneracy", &AssertionExpr::checkNondegeneracy)
         .def("__repr__", [](const AssertionExpr& self) {
             return fmt::format("AssertionExpr(AssertionExprKind.{})", toString(self.kind));
         });

--- a/include/slang/ast/expressions/AssertionExpr.h
+++ b/include/slang/ast/expressions/AssertionExpr.h
@@ -7,10 +7,6 @@
 //------------------------------------------------------------------------------
 #pragma once
 
-#include <optional>
-#include <set>
-#include <utility>
-
 #include "slang/ast/ASTSerializer.h"
 #include "slang/ast/Expression.h"
 #include "slang/ast/TimingControl.h"
@@ -131,9 +127,9 @@ public:
     static const AssertionExpr& bind(const syntax::SequenceExprSyntax& syntax,
                                      const ASTContext& context, bool allowDisable = false);
 
-    static const AssertionExpr& bind(
-        const syntax::PropertyExprSyntax& syntax, const ASTContext& context,
-        bool allowDisable = false, const NondegeneracyFlags nondegFlags = NondegeneracyFlags::None);
+    static const AssertionExpr& bind(const syntax::PropertyExprSyntax& syntax,
+                                     const ASTContext& context, bool allowDisable = false,
+                                     NondegeneracyFlags nondegFlags = NondegeneracyFlags::None);
 
     static const AssertionExpr& bind(const syntax::PropertySpecSyntax& syntax,
                                      const ASTContext& context);
@@ -295,7 +291,7 @@ public:
     /// An optional repetition of the sequence.
     std::optional<SequenceRepetition> repetition;
 
-    /// Store `true` if sequence exression is can be evaluated as constant `false` (`0`).
+    /// Store `true` if sequence exression can be evaluated as constant `false` (`0`).
     bool isNullExpr;
 
     SimpleAssertionExpr(const Expression& expr, std::optional<SequenceRepetition> repetition,

--- a/include/slang/ast/expressions/AssertionExpr.h
+++ b/include/slang/ast/expressions/AssertionExpr.h
@@ -131,9 +131,9 @@ public:
     static const AssertionExpr& bind(const syntax::SequenceExprSyntax& syntax,
                                      const ASTContext& context, bool allowDisable = false);
 
-    static const AssertionExpr& bind(const syntax::PropertyExprSyntax& syntax,
-                                     const ASTContext& context, bool allowDisable = false,
-                                     const NondegeneracyFlags nondegFlags = NondegeneracyFlags::None);
+    static const AssertionExpr& bind(
+        const syntax::PropertyExprSyntax& syntax, const ASTContext& context,
+        bool allowDisable = false, const NondegeneracyFlags nondegFlags = NondegeneracyFlags::None);
 
     static const AssertionExpr& bind(const syntax::PropertySpecSyntax& syntax,
                                      const ASTContext& context);
@@ -206,7 +206,9 @@ public:
     explicit InvalidAssertionExpr(const AssertionExpr* child) :
         AssertionExpr(AssertionExprKind::Invalid), child(child) {}
 
-    bitmask<NondegeneracyStatus> checkNondegeneracyImpl() const { return NondegeneracyStatus::None; }
+    bitmask<NondegeneracyStatus> checkNondegeneracyImpl() const {
+        return NondegeneracyStatus::None;
+    }
 
     std::optional<SequenceRange> computeSequenceLengthImpl() const;
 
@@ -298,8 +300,8 @@ public:
 
     SimpleAssertionExpr(const Expression& expr, std::optional<SequenceRepetition> repetition,
                         bool isNullExpr = false) :
-        AssertionExpr(AssertionExprKind::Simple),
-        expr(expr), repetition(repetition), isNullExpr(isNullExpr) {}
+        AssertionExpr(AssertionExprKind::Simple), expr(expr), repetition(repetition),
+        isNullExpr(isNullExpr) {}
 
     void requireSequence(const ASTContext& context, DiagCode code) const;
 
@@ -413,7 +415,9 @@ public:
                        std::optional<SequenceRange> range) :
         AssertionExpr(AssertionExprKind::Unary), op(op), expr(expr), range(range) {}
 
-    bitmask<NondegeneracyStatus> checkNondegeneracyImpl() const { return expr.checkNondegeneracy(); }
+    bitmask<NondegeneracyStatus> checkNondegeneracyImpl() const {
+        return expr.checkNondegeneracy();
+    }
 
     std::optional<SequenceRange> computeSequenceLengthImpl() const {
         return expr.computeSequenceLength();
@@ -567,7 +571,9 @@ public:
     StrongWeakAssertionExpr(const AssertionExpr& expr, Strength strength) :
         AssertionExpr(AssertionExprKind::StrongWeak), expr(expr), strength(strength) {}
 
-    bitmask<NondegeneracyStatus> checkNondegeneracyImpl() const { return expr.checkNondegeneracy(); }
+    bitmask<NondegeneracyStatus> checkNondegeneracyImpl() const {
+        return expr.checkNondegeneracy();
+    }
 
     std::optional<SequenceRange> computeSequenceLengthImpl() const {
         return expr.computeSequenceLength();
@@ -603,8 +609,8 @@ public:
 
     AbortAssertionExpr(const Expression& condition, const AssertionExpr& expr, Action action,
                        bool isSync) :
-        AssertionExpr(AssertionExprKind::Abort),
-        condition(condition), expr(expr), action(action), isSync(isSync) {}
+        AssertionExpr(AssertionExprKind::Abort), condition(condition), expr(expr), action(action),
+        isSync(isSync) {}
 
     bitmask<NondegeneracyStatus> checkNondegeneracyImpl() const {
         return expr.checkNondegeneracy();
@@ -645,7 +651,9 @@ public:
         AssertionExpr(AssertionExprKind::Conditional), condition(condition), ifExpr(ifExpr),
         elseExpr(elseExpr) {}
 
-    bitmask<NondegeneracyStatus> checkNondegeneracyImpl() const { return NondegeneracyStatus::None; }
+    bitmask<NondegeneracyStatus> checkNondegeneracyImpl() const {
+        return NondegeneracyStatus::None;
+    }
 
     /// Returns maximum possible sequence length beetween `if` and `else` sequence expressions.
     std::optional<SequenceRange> computeSequenceLengthImpl() const;
@@ -689,10 +697,12 @@ public:
 
     CaseAssertionExpr(const Expression& expr, std::span<const ItemGroup> items,
                       const AssertionExpr* defaultCase) :
-        AssertionExpr(AssertionExprKind::Case),
-        expr(expr), items(items), defaultCase(defaultCase) {}
+        AssertionExpr(AssertionExprKind::Case), expr(expr), items(items), defaultCase(defaultCase) {
+    }
 
-    bitmask<NondegeneracyStatus> checkNondegeneracyImpl() const { return NondegeneracyStatus::None; }
+    bitmask<NondegeneracyStatus> checkNondegeneracyImpl() const {
+        return NondegeneracyStatus::None;
+    }
 
     /// Returns maximum possible sequence length beetween all case labels sequence expressions
     /// include `default` label
@@ -731,7 +741,9 @@ public:
     DisableIffAssertionExpr(const Expression& condition, const AssertionExpr& expr) :
         AssertionExpr(AssertionExprKind::DisableIff), condition(condition), expr(expr) {}
 
-    bitmask<NondegeneracyStatus> checkNondegeneracyImpl() const { return NondegeneracyStatus::None; }
+    bitmask<NondegeneracyStatus> checkNondegeneracyImpl() const {
+        return NondegeneracyStatus::None;
+    }
 
     /// Returns `nullopt` if `disable iff` condition is always `true` (`1`)
     std::optional<SequenceRange> computeSequenceLengthImpl() const;

--- a/include/slang/ast/expressions/AssertionExpr.h
+++ b/include/slang/ast/expressions/AssertionExpr.h
@@ -234,8 +234,6 @@ struct SequenceRange {
 
     bool operator<(const SequenceRange& right) const;
 
-    // auto operator<=>(const SequenceRange&) const = default;
-
     /// `SequenceRange`s intersects if max delay of one range
     /// is greater than min delay of other range.
     bool isIntersect(const SequenceRange& other) const;

--- a/include/slang/ast/expressions/AssertionExpr.h
+++ b/include/slang/ast/expressions/AssertionExpr.h
@@ -232,7 +232,9 @@ struct SequenceRange {
 
     void serializeTo(ASTSerializer& serializer) const;
 
-    auto operator<=>(const SequenceRange&) const = default;
+    bool operator<(const SequenceRange& right) const;
+
+    //auto operator<=>(const SequenceRange&) const = default;
 
     /// `SequenceRange`s intersects if max delay of one range
     /// is greater than min delay of other range.

--- a/include/slang/ast/expressions/AssertionExpr.h
+++ b/include/slang/ast/expressions/AssertionExpr.h
@@ -234,7 +234,7 @@ struct SequenceRange {
 
     bool operator<(const SequenceRange& right) const;
 
-    //auto operator<=>(const SequenceRange&) const = default;
+    // auto operator<=>(const SequenceRange&) const = default;
 
     /// `SequenceRange`s intersects if max delay of one range
     /// is greater than min delay of other range.

--- a/include/slang/ast/expressions/AssertionExpr.h
+++ b/include/slang/ast/expressions/AssertionExpr.h
@@ -286,8 +286,8 @@ public:
 
     SimpleAssertionExpr(const Expression& expr, std::optional<SequenceRepetition> repetition,
                         bool isNullExpr = false) :
-        AssertionExpr(AssertionExprKind::Simple),
-        expr(expr), repetition(repetition), isNullExpr(isNullExpr) {}
+        AssertionExpr(AssertionExprKind::Simple), expr(expr), repetition(repetition),
+        isNullExpr(isNullExpr) {}
 
     void requireSequence(const ASTContext& context, DiagCode code) const;
     bool admitsEmptyImpl() const;
@@ -606,7 +606,9 @@ public:
 
     bool admitsNoMatchImpl() const { return false; }
 
-    std::optional<SequenceRange> computeSequenceLengthImpl() const { return expr.computeSequenceLength(); };
+    std::optional<SequenceRange> computeSequenceLengthImpl() const {
+        return expr.computeSequenceLength();
+    };
 
     static AssertionExpr& fromSyntax(const syntax::AcceptOnPropertyExprSyntax& syntax,
                                      const ASTContext& context);
@@ -684,7 +686,8 @@ public:
 
     CaseAssertionExpr(const Expression& expr, std::span<const ItemGroup> items,
                       const AssertionExpr* defaultCase) :
-        AssertionExpr(AssertionExprKind::Case), expr(expr), items(items), defaultCase(defaultCase) {}
+        AssertionExpr(AssertionExprKind::Case), expr(expr), items(items), defaultCase(defaultCase) {
+    }
 
     bool admitsEmptyImpl() const { return false; }
 

--- a/scripts/diagnostics.txt
+++ b/scripts/diagnostics.txt
@@ -860,7 +860,7 @@ note NoteWhileExpanding "while expanding {} '{}'"
 note NoteExpandedHere "expanded here"
 note SeqAdmitsEmptyMatches "sequence property admits empty matches"
 note SeqAdmitsNoMatches "sequence property can never be matched"
-note SeqAdmitsOnlyEmptyMatches "sequence property admits only empty matches"
+note SeqAcceptsOnlyEmptyMatches "sequence property admits only empty matches"
 note SeqPropCondAlwaysFalse "condition is always false"
 note DisableIffCondAlwaysTrue "disable iff condition is always true"
 

--- a/scripts/diagnostics.txt
+++ b/scripts/diagnostics.txt
@@ -840,7 +840,9 @@ error DisableIffLocalVar "local variables cannot be used in disable iff conditio
 error DisableIffMatched "'matched' method cannot be used in disable iff conditions"
 error PropAbortLocalVar "local variables cannot be used in property abort conditions"
 error PropAbortMatched "'matched' method cannot be used in property abort conditions"
-error SeqPropAdmitEmpty "sequence properties cannot admit an empty match"
+error SeqPropNondegenerate "any sequence that is used as a property shall be nondegenerate and shall not admit any empty match"
+error OverlapImplNondegenerate "any sequence that is used as the antecedent of an overlapping implication (|->) shall be nondegenerate"
+error NonOverlapImplNondegenerate "any sequence that is used as the antecedent of a nonoverlapping implication (|=>) shall admit at least one match. Such a sequence can admit only empty matches"
 error RecursivePropDisableIff "recursive properties cannot have disable iff conditions"
 error ConcurrentAssertActionBlock "cannot have '{}' statement in the action block of another concurrent assertion"
 error InvalidForStepExpression "for loop step expression must be an assignment, increment/decrement operator, or a subroutine call"
@@ -856,6 +858,11 @@ warning bad-procedural-force BadProceduralForce "lvalue of force/release must be
 warning multibit-edge MultiBitEdge "edge of expression of type {} will only trigger on changes to the first bit"
 note NoteWhileExpanding "while expanding {} '{}'"
 note NoteExpandedHere "expanded here"
+note SeqAdmitsEmptyMatches "sequence property admits empty matches"
+note SeqAdmitsNoMatches "sequence property can never be matched"
+note SeqAdmitsOnlyEmptyMatches "sequence property admits only empty matches"
+note SeqPropCondAlwaysFalse "condition is always false"
+note DisableIffCondAlwaysTrue "disable iff condition is always true"
 
 subsystem Types
 error InvalidEnumBase "invalid enum base type {} (must be a single dimensional integer type)"

--- a/source/ast/expressions/AssertionExpr.cpp
+++ b/source/ast/expressions/AssertionExpr.cpp
@@ -635,8 +635,11 @@ std::optional<SequenceRange> SimpleAssertionExpr::computeSequenceLengthImpl() co
             return aie.body.computeSequenceLength();
     }
 
+    SequenceRange res;
     // If there is only empty match sequence then it's have a zero delay length
-    return (checkNondegeneracy().has(NondegeneracyStatus::AcceptsOnlyEmpty)) ? SequenceRange(0, 0) : SequenceRange(1, 1);
+    res.min = (checkNondegeneracy().has(NondegeneracyStatus::AcceptsOnlyEmpty)) ? 0 : 1;
+    res.max = res.min;
+    return res;
 }
 
 void SimpleAssertionExpr::serializeTo(ASTSerializer& serializer) const {
@@ -775,7 +778,10 @@ std::optional<SequenceRange> SequenceConcatExpr::computeSequenceLengthImpl() con
                 NondegeneracyStatus::AcceptsOnlyEmpty);
     }
 
-    return SequenceRange(delayMin, delayMax);
+    SequenceRange res;
+    res.min = delayMin;
+    res.max = delayMax;
+    return res;
 }
 
 void SequenceConcatExpr::serializeTo(ASTSerializer& serializer) const {

--- a/source/ast/expressions/AssertionExpr.cpp
+++ b/source/ast/expressions/AssertionExpr.cpp
@@ -376,8 +376,8 @@ struct SampledValueExprVisitor {
 
     SampledValueExprVisitor(const ASTContext& context, bool isFutureGlobal, DiagCode localVarCode,
                             DiagCode matchedCode) :
-        context(context),
-        isFutureGlobal(isFutureGlobal), localVarCode(localVarCode), matchedCode(matchedCode) {}
+        context(context), isFutureGlobal(isFutureGlobal), localVarCode(localVarCode),
+        matchedCode(matchedCode) {}
 
     template<typename T>
     void visit(const T& expr) {

--- a/source/ast/expressions/AssertionExpr.cpp
+++ b/source/ast/expressions/AssertionExpr.cpp
@@ -147,7 +147,7 @@ const AssertionExpr& AssertionExpr::bind(const PropertyExprSyntax& syntax,
                     auto& diag = context.addDiag(diag::OverlapImplNondegenerate,
                                                  syntax.sourceRange());
                     diag.addNote((isSeqAcceptsOnlyEmpty) ? diag::SeqAcceptsOnlyEmptyMatches
-                                                        : diag::SeqAdmitsNoMatches,
+                                                         : diag::SeqAdmitsNoMatches,
                                  syntax.sourceRange());
                 }
             }
@@ -620,7 +620,9 @@ bitmask<NondegeneracyStatus> SimpleAssertionExpr::checkNondegeneracyImpl() const
 
     if (repetition) {
         auto result = repetition->admitsEmpty();
-        res = (result == SequenceRepetition::AdmitsEmpty::Yes) ? res | NondegeneracyStatus::AdmitsEmpty : res;
+        res = (result == SequenceRepetition::AdmitsEmpty::Yes)
+                  ? res | NondegeneracyStatus::AdmitsEmpty
+                  : res;
         if (result == SequenceRepetition::AdmitsEmpty::Only)
             res = res | NondegeneracyStatus::AcceptsOnlyEmpty | NondegeneracyStatus::AdmitsEmpty;
     }
@@ -896,7 +898,9 @@ bitmask<NondegeneracyStatus> SequenceWithMatchExpr::checkNondegeneracyImpl() con
 
     if (repetition) {
         const auto seqRepEmpty = repetition->admitsEmpty();
-        res = (seqRepEmpty == SequenceRepetition::AdmitsEmpty::Yes) ? res | NondegeneracyStatus::AdmitsEmpty : res;
+        res = (seqRepEmpty == SequenceRepetition::AdmitsEmpty::Yes)
+                  ? res | NondegeneracyStatus::AdmitsEmpty
+                  : res;
         if (seqRepEmpty == SequenceRepetition::AdmitsEmpty::Only)
             res = res | NondegeneracyStatus::AcceptsOnlyEmpty | NondegeneracyStatus::AdmitsEmpty;
     }
@@ -1239,7 +1243,8 @@ bitmask<NondegeneracyStatus> FirstMatchAssertionExpr::checkNondegeneracyImpl() c
     auto res = seq.checkNondegeneracy();
     if (!matchItems.empty()) {
         // Clear `admitEmpty` and `acceptOnlyEmpty` bits
-        res = (res.has(NondegeneracyStatus::AdmitsNoMatch)) ? NondegeneracyStatus::AdmitsNoMatch : NondegeneracyStatus::None;
+        res = (res.has(NondegeneracyStatus::AdmitsNoMatch)) ? NondegeneracyStatus::AdmitsNoMatch
+                                                            : NondegeneracyStatus::None;
     }
 
     return res;

--- a/source/ast/expressions/MiscExpressions.cpp
+++ b/source/ast/expressions/MiscExpressions.cpp
@@ -762,7 +762,8 @@ static const AssertionExpr& bindAssertionBody(const Symbol& symbol, const Syntax
         auto& result = AssertionExpr::bind(*sds.seqExpr, context);
         result.requireSequence(context);
 
-        if (outputLocalVarArgLoc && result.admitsEmpty()) {
+        if (outputLocalVarArgLoc &&
+            result.checkNondegeneracy().has(NondegeneracyStatus::AdmitsEmpty)) {
             auto& diag = context.addDiag(diag::LocalVarOutputEmptyMatch,
                                          sds.seqExpr->sourceRange());
             diag << symbol.name;

--- a/tests/unittests/ast/AssertionTests.cpp
+++ b/tests/unittests/ast/AssertionTests.cpp
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 #include "Test.h"
+
 #include "slang/diagnostics/StatementsDiags.h"
 
 TEST_CASE("Named sequences") {

--- a/tests/unittests/ast/AssertionTests.cpp
+++ b/tests/unittests/ast/AssertionTests.cpp
@@ -2692,7 +2692,7 @@ module top8(input clk);
 
     assert property (if (a) b intersect ##2 b);  // illegal
 
-    assert property (if (a) ##2 b intersect ##2 b);  // illegal
+    assert property (if (a) ##2 b intersect ##2 b);  // legal
 
     assert property (case (b) 1, 2, 3: 1 ##1 b; 4: a and b; default: 1 |-> b; endcase);  // legal
 
@@ -2703,11 +2703,47 @@ module top8(input clk);
     assert property (disable iff (1'b1) a);  // illegal
 
 endmodule
+
+module m9;
+    property p1;
+        1'b1 #=# 1;  // legal
+    endproperty
+    property p2;
+        1'b0 #=# 1;  // illegal
+    endproperty
+    property p3;
+        1[*2] #=# 1;  // legal
+    endproperty
+    property p4;
+        1[*0] #=# 1;  // legal
+    endproperty
+    property p5;
+        1'b1 #-# 1;  // legal
+    endproperty
+    property p6;
+        1'b0 #-# 1;  // illegal
+    endproperty
+    property p7;
+        1[*0] #-# 1;  // illegal
+    endproperty
+    property p8;
+        1[*0:2] #-# 1;  // legal
+    endproperty
+
+    assert property (p1);
+    assert property (p2);
+    assert property (p3);
+    assert property (p4);
+    assert property (p5);
+    assert property (p6);
+    assert property (p7);
+    assert property (p8);
+endmodule
 )");
 
     Compilation compilation;
     compilation.addSyntaxTree(tree);
 
     auto& diags = compilation.getAllDiagnostics();
-    REQUIRE(diags.size() == 45);
+    REQUIRE(diags.size() == 48);
 }

--- a/tests/unittests/ast/AssertionTests.cpp
+++ b/tests/unittests/ast/AssertionTests.cpp
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 #include "Test.h"
+#include "slang/diagnostics/StatementsDiags.h"
 
 TEST_CASE("Named sequences") {
     auto tree = SyntaxTree::fromText(R"(
@@ -52,7 +53,7 @@ module m;
 
     foo: assert property (a);
     assert property (a ##1 b ##[+] c ##[*] d ##[1:5] e);
-    assert property (##0 a[*0:4] ##0 b[=4] ##0 c[->1:2] ##0 c[*] ##1 d[+]);
+    assert property (##0 a[*1:4] ##0 b[=4] ##0 c[->1:2] ##0 c[*] ##1 d[+]);
     assert property (##[1:$] a[*0:$]);
     assert property ((a ##0 b) and (c or d));
     assert property ((a ##0 b) and (c or d));
@@ -1048,8 +1049,8 @@ endmodule
 
     auto& diags = compilation.getAllDiagnostics();
     REQUIRE(diags.size() == 2);
-    CHECK(diags[0].code == diag::SeqPropAdmitEmpty);
-    CHECK(diags[1].code == diag::SeqPropAdmitEmpty);
+    CHECK(diags[0].code == diag::SeqPropNondegenerate);
+    CHECK(diags[1].code == diag::SeqPropNondegenerate);
 }
 
 TEST_CASE("Illegal property recursion cases") {
@@ -1191,7 +1192,7 @@ TEST_CASE("$past in $bits regress GH #509") {
 module top;
     logic clk, reset, a, b, c;
     assert property(@(posedge clk) disable iff (reset)
-        a |-> {500-$bits($past(b)){1'b0}});
+        a |-> {500-$bits($past(b)){1'b1}});
 endmodule
 )");
 
@@ -2355,4 +2356,357 @@ endmodule
     auto& diags = compilation.getAllDiagnostics();
     REQUIRE(diags.size() == 1);
     CHECK(diags[0].code == diag::UndeclaredIdentifier);
+}
+
+TEST_CASE("Sequence nondegeneracy tests") {
+    auto tree = SyntaxTree::fromText(R"(
+module top();
+    assert property ((1'b1 ##[1:2] 1'b1) intersect (1'b1 ##[2:4] 1'b1));  // legal
+
+    assert property ((1'b1 ##[1:2] 1'b1) intersect (1'b1 ##[3:4] 1'b1));  // illegal
+
+    assert property ((1'b1) intersect (1'b1[*0] ##2 1'b1));  // illegal
+
+    assert property ((1'b1 ##1 1'b1) intersect (1'b1[*0] ##2 1'b1));  // legal
+
+    assert property ((1'b1 ##1 1'b0) intersect (1'b1[*0] ##2 1'b1));  // illegal
+
+    assert property( (1'b1) intersect (1'b1 ##[1:3] 1'b1));  // illegal
+
+    assert property( (1'b1 ##1 1'b1) intersect (1'b1 ##[1:3] 1'b1));  // legal
+
+    assert property( (1'b1 ##0 1'b1) intersect (1'b1 ##[1:3] 1'b1));  // illegal
+
+    assert property( (1'b1[*2]) intersect (1'b1 ##[1:3] 1'b1));  // illegal
+
+    assert property( (##2 1'b1[*2]) intersect (1'b1 ##[1:3] 1'b1));  // legal
+endmodule
+
+module top1();
+    string a;
+    logic b;
+    int c,d,e;
+
+    assert property (##0 a[*0:4] ##0 b[=4] ##0 c[->1:2] ##0 c[*] ##1 d[+]);  // legal
+
+    assert property (##0 a[*0:4] ##0 b[=4] ##0 c[->1:2] ##0 c[*0] ##1 d[+]);  // illegal
+
+    assert property (##0 a[*0] ##0 b[=4] ##0 c[->1:2] ##0 c[*] ##1 d[+]);  // illegal
+endmodule
+
+module top2(input a, input b);
+property p;
+         !(2'b01 - 2'b01 + 3'b010 - 3'b010 + 4'b0010);  // illegal
+endproperty
+
+property pp;
+         2'b01 - 2'b01 + 3'b010 - 3'b010 + 4'b0010;  // legal
+endproperty
+
+property p1;
+	a[*0] |-> b;  // illegal
+endproperty
+
+property pp1;
+	a[*1] |-> b;  // legal
+endproperty
+
+property p2;
+	1'b1 ##1 b;  // legal
+endproperty
+
+assert property (p);
+assert property (pp);
+assert property (p1);
+assert property (p2);
+
+endmodule
+
+module top3(a, b, e);
+    input a;
+    input b;
+    input e;
+    int c, d;
+    property p(int i, foo = 1);
+	    ##1 c ##1 d ##1 i;  // may be legal or not - depends on value of `i`
+    endproperty
+
+    property p1();
+        ##0 c;  // legal
+    endproperty
+
+    property p2();
+        1'b1 ##1 1'b0 ##0 d ##1 1'b1;  // illegal
+    endproperty
+
+    property p3();
+        1'b1 ##1 1'b1 ##0 d ##1 1'b1;  // legal
+    endproperty
+
+    property p4();
+        b ##0 a[*0];  // illegal
+    endproperty
+
+    property pp4();
+        b ##0 a[*1];  // legal
+    endproperty
+
+    property p5();
+        a[*0] ##1 b;  // legal
+    endproperty
+
+    property p6();
+        a ##1 b[*0] ##0 c;  // legal
+    endproperty
+
+    property p7();
+        a ##1(b[*0] ##0 c);  // illegal
+    endproperty
+
+    assert property (p (0, 0));  // illegal
+    assert property (p (1, 0));  // legal
+    assert property (p1);
+    assert property (p2);
+    assert property (p3);
+    assert property (p4);
+    assert property (pp4);
+    assert property (p5);
+    assert property (p6);
+    assert property (p7);
+endmodule
+
+module top4;
+    sequence s(int i);
+        int j, k = j;
+        (i == i, j = 1, j++)[*0:1];  // illegal - empty matches
+    endsequence
+
+    sequence s1(int i);
+        int j, k = j;
+        (i != i, j = 1, j++)[*1:1];  // illegal - always `false` condition
+    endsequence
+
+    sequence s2(int i);
+        int j, k = j;
+        (i != i, j = 1, j++)[*0:1];  // illegal - always `false` condition and empty matches
+    endsequence
+
+    sequence s3(int i);
+        int j, k = j;
+        (i == i, j = 1, j++)[*1:1];  // legal
+    endsequence
+
+    sequence s4(int i);
+        int j, k = j;
+        (i == i, j = 1, j++)[*0:0];  // illegal - only empty matches
+    endsequence
+
+    sequence s5(int i);
+        int j, k = j;
+        (i == i, j = 1, j++)[*0];  // illegal - only empty matches
+    endsequence
+
+    assert property (s(1));   // illegal
+    assert property (s1(1));  // illegal
+    assert property (s2(1));  // illegal
+    assert property (s3(1));  // legal
+    assert property (s4(1));  // illegal
+    assert property (s5(1));  // illegal
+endmodule
+
+module top5(input a, input b);
+    assert property ((1 ##1 0)[*0]);  // illegal
+    assert property ((a[*0] ##1 a[*0])[*1]);  // illegal
+    assert property ((a[*0] ##2 a[*0])[*1]);  // legal
+    assert property (not (a[*0] ##0 b));  // illegal
+    assert property (not (a[*0] ##1 b));  // legal
+endmodule
+
+module top6();
+    logic clk, reset, a, b;
+    assert property(@(posedge clk) disable iff (reset)
+        a |-> {500-$bits($past(b)){1'b0}});  // illegal
+
+    assert property(@(posedge clk) disable iff (reset)
+        {3 - 2{3'b111}});  // legal
+
+    assert property(@(posedge clk) disable iff (reset)
+        {500 - $bits(b){1'b1}});  // legal
+endmodule
+
+module top7;
+    property p;
+        (1'b1) intersect (##[1:3] 1'b1 ##0 1'b1[*0:3] ##[2:3] 1'b1[*1]);  // illegal
+    endproperty
+
+    property p1;
+        (1'b1) intersect (##[1:3] 1'b1 ##0 1'b1[*0:3] ##[2:3] 1'b1[*0]);  // illegal
+    endproperty
+
+    property p2;
+        (1'b1) intersect (##[0:3] 1'b1 ##1 1'b1[*0:2] ##[2:3] 1'b1[*0]);  // illegal
+    endproperty
+
+    property p3;
+        (1'b1) intersect (##[0:3] 1'b1[*0:2]);  // legal
+    endproperty
+
+    property p4;
+        (1'b1) intersect (##[0:3] 1'b1[*0]);  // legal
+    endproperty
+
+    property p5;
+        (1'b1) intersect (##[0:3] 1'b1);  // legal
+    endproperty
+
+    property p6;
+        (1'b1) intersect (1'b1[*0] ##[0:3] 1'b1);  // legal
+    endproperty
+
+    property p7;
+        (1'b1) intersect (1'b1[*0:2] ##[0:3] 1'b1);  // legal
+    endproperty
+
+    property p8;
+        (1'b1) intersect (1'b1 ##[1:3] 1'b1);  // illegal
+    endproperty
+
+    property p9;
+        1'b0 ##2 1'b1;  // illegal
+    endproperty
+
+    property p10;
+        1[*2];  // legal
+    endproperty
+
+    property p11;
+        1[*0];  // illegal
+    endproperty
+
+    property p12;
+        1[*0:2];  // illegal
+    endproperty
+
+    property p13;
+        1'b1;  // legal
+    endproperty
+
+    property p14;
+        1'b0;  // illegal
+    endproperty
+
+    property p15;
+        1'b1 |=> 1;  // legal
+    endproperty
+
+    property p16;
+        1'b0 |=> 1;  // illegal
+    endproperty
+
+    property p17;
+        1[*2] |=> 1;  // legal
+    endproperty
+
+    property p18;
+        1[*0] |=> 1;  // legal
+    endproperty
+
+    property p19;
+        1'b1 |-> 1;  // legal
+    endproperty
+
+    property p20;
+        1'b0 |-> 1;  // illegal
+    endproperty
+
+    property p21;
+        1[*0] |-> 1;  // illegal
+    endproperty
+
+    property p22;
+        1[*0:2] |-> 1;  // legal
+    endproperty
+
+    assert property (p);
+    assert property (p1);
+    assert property (p2);
+    assert property (p3);
+    assert property (p4);
+    assert property (p5);
+    assert property (p6);
+    assert property (p7);
+    assert property (p8);
+    assert property (p9);
+    assert property (p10);
+    assert property (p11);
+    assert property (p12);
+    assert property (p13);
+    assert property (p14);
+    assert property (p15);
+    assert property (p16);
+    assert property (p17);
+    assert property (p18);
+    assert property (p19);
+    assert property (p20);
+    assert property (p21);
+    assert property (p22);
+endmodule
+
+module top8(input clk);
+    logic a, b, c, d, e;
+
+    assert property (first_match(a and b));  // legal
+
+    assert property ((first_match(a and b))[*0]);  // illegal
+
+    assert property (first_match(a and (b[*0] ##0 b)));  // illegal
+
+    assert property (@clk a ##1 b); // legal
+
+    assert property (@clk a[*0] ##0 b); // illegal
+
+    assert property(strong(a ##1 b));  // legal
+
+    assert property(strong(a ##0 b[*0]));  // illegal
+
+    assert property(weak(a intersect b));  // legal
+
+    assert property(weak(a intersect ##2 b));  // illegal
+
+    assert property (accept_on(b) sync_reject_on(c) sync_accept_on(d) reject_on(e) b ##1 c);  // legal
+
+    assert property (accept_on(b) b intersect ##2 b);  // illegal
+
+    assert property (accept_on(b) ##2 b intersect ##2 b);  // legal
+
+    assert property (accept_on(b) b[*0] ##0 b);  // illegal
+
+    assert property (if (b) a ##1 c else d ##1 e);  // legal
+
+    assert property (if (1'b0) a ##1 c else d ##1 e);  // legal
+
+    assert property (if (1'b0) a ##1 c);  // illegal
+
+    assert property (if (1'b1) a ##1 c else d ##1 e);  // legal
+
+    assert property (if (a) b intersect ##2 b);  // illegal
+
+    assert property (if (a) ##2 b intersect ##2 b);  // illegal
+
+    assert property (case (b) 1, 2, 3: 1 ##1 b; 4: a and b; default: 1 |-> b; endcase);  // legal
+
+    assert property (case (b) 1, 2, 3: 1 ##1 b; 4: a and b; default: 1[*0] |-> b; endcase);  // illegal
+
+    assert property (disable iff (clk) a);  // legal
+
+    assert property (disable iff (1'b1) a);  // illegal
+
+endmodule
+)");
+
+    Compilation compilation;
+    compilation.addSyntaxTree(tree);
+
+    auto& diags = compilation.getAllDiagnostics();
+    REQUIRE(diags.size() == 45);
 }

--- a/tests/unittests/ast/MemberTests.cpp
+++ b/tests/unittests/ast/MemberTests.cpp
@@ -2265,7 +2265,7 @@ property myprop(k);
 endproperty
 
 genvar k;
-for (k=0; k < 4; k++) begin: m
+for (k=1; k < 4; k++) begin: m
     if (A)
         label1: assert property(myprop(k));
     else


### PR DESCRIPTION
Based on 16.12.22 SystemVerilog LRM section and partially (F.4.3/F.5.2/F.5.5).

Also Ben Cohen's [paper about nondegeneracy](https://systemverilog.us/vf/Degeneracy111723Ben.pdf) understanding from [here](https://systemverilog.us/vf/Cohen_Links_to_papers_books.pdf).

Complex sequences are not often used in industrial/open source designs, but I think these checks will help to verify restrictions from 16.12.22 in most cases.

I written about ~300 lines of `sv` tests but i need help with more complex test cases but if anyone could also come up with more complex tests to test heuristics, that would be nice.