### PR TITLE
 [slang-tidy] Add quiet options and IDs to slang-tidy checks

### DIFF
--- a/tools/tidy/include/ASTHelperVisitors.h
+++ b/tools/tidy/include/ASTHelperVisitors.h
@@ -28,7 +28,7 @@ protected:
 
     [[nodiscard]] bool skip(std::string_view path) const {
         auto file = std::filesystem::path(path).filename().string();
-        auto parentPath = weakly_canonical(std::filesystem::path(path));
+        auto parentPath = weakly_canonical(std::filesystem::path(path).parent_path());
         const auto& skipFiles = config.getSkipFiles();
         const auto& skipPaths = config.getSkipPaths();
         return std::find(skipFiles.begin(), skipFiles.end(), file) != skipFiles.end() ||

--- a/tools/tidy/include/TidyFactory.h
+++ b/tools/tidy/include/TidyFactory.h
@@ -109,6 +109,12 @@ public:
     virtual slang::DiagnosticSeverity diagSeverity() const = 0;
     virtual std::string diagString() const = 0;
 
+    std::string diagMessage() const {
+        auto kindStr = std::string(toString(kind));
+        std::transform(kindStr.begin(), kindStr.end(), kindStr.begin(), ::toupper);
+        return fmt::format("[{}-{}] {}", kindStr, diagCode().getCode(), diagString());
+    }
+
     [[nodiscard]] virtual const slang::Diagnostics& getDiagnostics() const { return diagnostics; }
     [[nodiscard]] virtual const slang::TidyKind getKind() const { return kind; }
 

--- a/tools/tidy/include/TidyKind.h
+++ b/tools/tidy/include/TidyKind.h
@@ -25,7 +25,7 @@ SLANG_ENUM(TidyKind, KIND)
 
 inline std::optional<slang::TidyKind> tidyKindFromStr(std::string str) {
     std::transform(str.begin(), str.end(), str.begin(), ::tolower);
-    if (str == "synthesis")
+    if (str == "synthesis" || str == "synth")
         return slang::TidyKind::Synthesis;
     if (str == "style")
         return slang::TidyKind::Style;


### PR DESCRIPTION
This MR adds improvements in the slang-tidy by adding new CLI options to control verbosity, adds an explicit ID to the checks.

Also fixes a bug which made the feature of avoiding checks for certain files to not work properly