### PR TITLE
[fix][slang][nondegeneracy] Fix implication consequent nondegeneracy check

### DIFF
--- a/include/slang/ast/expressions/AssertionExpr.h
+++ b/include/slang/ast/expressions/AssertionExpr.h
@@ -151,6 +151,9 @@ public:
         /// or followed-by operator shall admit at least one match. Such a sequence can
         /// admit only empty matches.
         NonOverlapOp,
+
+        /// Don't perform any nondegeneracy check
+        None,
     };
 
     static const AssertionExpr& bind(const syntax::SequenceExprSyntax& syntax,


### PR DESCRIPTION
Fixes https://github.com/MikePopoloski/slang/issues/1022

The consequent of the implication should be ignored, since there are no restrictions on it in the standard.