### PR TITLE
Allow dynamic linking mimalloc

### DIFF
--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -99,15 +99,25 @@ if(SLANG_USE_MIMALLOC)
     ${find_pkg_args})
   FetchContent_MakeAvailable(mimalloc)
 
-  if(NOT TARGET mimalloc-static)
-    message(
-      FATAL_ERROR
-        "Could not find mimalloc package, min version: ${mimalloc_min_version}")
-  endif()
-
   if(mimalloc_FOUND)
-    message(STATUS "Found system mimalloc version: ${mimalloc_VERSION}")
+    if(NOT TARGET mimalloc)
+      message(
+        FATAL_ERROR
+          "Could not find mimalloc package, min version: ${mimalloc_min_version}")
+    endif()
+
+    get_target_property(MIMALLOC_CFG mimalloc IMPORTED_CONFIGURATIONS)
+    get_target_property(MIMALLOC_LIB mimalloc IMPORTED_LOCATION_${MIMALLOC_CFG})
+    get_target_property(MIMALLOC_INC mimalloc INTERFACE_INCLUDE_DIRECTORIES)
+    message(STATUS "Found system mimalloc library: ${MIMALLOC_LIB}")
+    message(STATUS "Using system mimalloc include: ${MIMALLOC_INC}")
   else()
+    if(NOT TARGET mimalloc-static)
+      message(
+        FATAL_ERROR
+          "Could not find mimalloc package, min version: ${mimalloc_min_version}")
+    endif()
+
     message(STATUS "Using remote mimalloc library")
     if(IS_DIRECTORY "${mimalloc_SOURCE_DIR}")
       set_property(DIRECTORY ${mimalloc_SOURCE_DIR} PROPERTY EXCLUDE_FROM_ALL

--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -100,15 +100,19 @@ if(SLANG_USE_MIMALLOC)
   FetchContent_MakeAvailable(mimalloc)
 
   if(mimalloc_FOUND)
-    if(NOT TARGET mimalloc)
+    if(TARGET mimalloc)
+      set(mimalloc_target "mimalloc")
+    elseif(TARGET mimalloc-static)
+      set(mimalloc_target "mimalloc-static")
+    else()
       message(
         FATAL_ERROR
           "Could not find mimalloc package, min version: ${mimalloc_min_version}")
     endif()
 
-    get_target_property(MIMALLOC_CFG mimalloc IMPORTED_CONFIGURATIONS)
-    get_target_property(MIMALLOC_LIB mimalloc IMPORTED_LOCATION_${MIMALLOC_CFG})
-    get_target_property(MIMALLOC_INC mimalloc INTERFACE_INCLUDE_DIRECTORIES)
+    get_target_property(MIMALLOC_CFG ${mimalloc_target} IMPORTED_CONFIGURATIONS)
+    get_target_property(MIMALLOC_LIB ${mimalloc_target} IMPORTED_LOCATION_${MIMALLOC_CFG})
+    get_target_property(MIMALLOC_INC ${mimalloc_target} INTERFACE_INCLUDE_DIRECTORIES)
     message(STATUS "Found system mimalloc library: ${MIMALLOC_LIB}")
     message(STATUS "Using system mimalloc include: ${MIMALLOC_INC}")
   else()
@@ -117,6 +121,7 @@ if(SLANG_USE_MIMALLOC)
         FATAL_ERROR
           "Could not find mimalloc package, min version: ${mimalloc_min_version}")
     endif()
+    set(mimalloc_target "mimalloc-static")
 
     message(STATUS "Using remote mimalloc library")
     if(IS_DIRECTORY "${mimalloc_SOURCE_DIR}")

--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -107,19 +107,23 @@ if(SLANG_USE_MIMALLOC)
     else()
       message(
         FATAL_ERROR
-          "Could not find mimalloc package, min version: ${mimalloc_min_version}")
+          "Could not find mimalloc package, min version: ${mimalloc_min_version}"
+      )
     endif()
 
     get_target_property(MIMALLOC_CFG ${mimalloc_target} IMPORTED_CONFIGURATIONS)
-    get_target_property(MIMALLOC_LIB ${mimalloc_target} IMPORTED_LOCATION_${MIMALLOC_CFG})
-    get_target_property(MIMALLOC_INC ${mimalloc_target} INTERFACE_INCLUDE_DIRECTORIES)
+    get_target_property(MIMALLOC_LIB ${mimalloc_target}
+                        IMPORTED_LOCATION_${MIMALLOC_CFG})
+    get_target_property(MIMALLOC_INC ${mimalloc_target}
+                        INTERFACE_INCLUDE_DIRECTORIES)
     message(STATUS "Found system mimalloc library: ${MIMALLOC_LIB}")
     message(STATUS "Using system mimalloc include: ${MIMALLOC_INC}")
   else()
     if(NOT TARGET mimalloc-static)
       message(
         FATAL_ERROR
-          "Could not find mimalloc package, min version: ${mimalloc_min_version}")
+          "Could not find mimalloc package, min version: ${mimalloc_min_version}"
+      )
     endif()
     set(mimalloc_target "mimalloc-static")
 

--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -131,7 +131,11 @@ target_link_libraries(slang_slang PUBLIC fmt::fmt Boost::headers
                                          ${CMAKE_THREAD_LIBS_INIT})
 
 if(SLANG_USE_MIMALLOC)
-  target_link_libraries(slang_slang PUBLIC mimalloc-static)
+  if(mimalloc_FOUND)
+    target_link_libraries(slang_slang PUBLIC mimalloc)
+  else()
+    target_link_libraries(slang_slang PUBLIC mimalloc-static)
+  endif()
   target_compile_definitions(slang_slang PUBLIC SLANG_USE_MIMALLOC)
 endif()
 

--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -131,11 +131,7 @@ target_link_libraries(slang_slang PUBLIC fmt::fmt Boost::headers
                                          ${CMAKE_THREAD_LIBS_INIT})
 
 if(SLANG_USE_MIMALLOC)
-  if(mimalloc_FOUND)
-    target_link_libraries(slang_slang PUBLIC mimalloc)
-  else()
-    target_link_libraries(slang_slang PUBLIC mimalloc-static)
-  endif()
+  target_link_libraries(slang_slang PUBLIC ${mimalloc_target})
   target_compile_definitions(slang_slang PUBLIC SLANG_USE_MIMALLOC)
 endif()
 


### PR DESCRIPTION
I attempted to build slang but got the following error when configuring:
```
CMake Error at external/CMakeLists.txt:103 (message):
  Could not find mimalloc package, min version: 2.1
Call Stack (most recent call first):
  CMakeLists.txt:173 (include)
```
This was because I had a dynamic library for mimalloc on my system, which cmake found, but the build is hard-coded to use the `mimalloc-static` target. This PR fixes the cmake configuration by choosing the dynamic `mimalloc` target if available.