### PR TITLE
Fix hierarchical paths inside generate arrays

### DIFF
--- a/source/ast/Symbol.cpp
+++ b/source/ast/Symbol.cpp
@@ -124,7 +124,12 @@ static void getHierarchicalPathImpl(const Symbol& symbol, FormatBuffer& buffer) 
     if (!current->name.empty())
         addName(current->name);
 
-    if (current->kind == SymbolKind::GenerateBlock) {
+    if (current->kind == SymbolKind::GenerateBlockArray) {
+        auto& array = current->as<GenerateBlockArraySymbol>();
+        if (current->name.empty())
+            addName(array.getExternalName());
+    }
+    else if (current->kind == SymbolKind::GenerateBlock) {
         auto& block = current->as<GenerateBlockSymbol>();
         if (auto index = block.arrayIndex) {
             buffer.append("[");

--- a/tests/unittests/ast/MemberTests.cpp
+++ b/tests/unittests/ast/MemberTests.cpp
@@ -1374,9 +1374,8 @@ endmodule
     NO_COMPILATION_ERRORS;
 
     std::string path;
-    compilation.getRoot().visit(makeVisitor([&](auto& v, const VariableSymbol &sym) {
-        sym.getHierarchicalPath(path);
-    }));
+    compilation.getRoot().visit(
+        makeVisitor([&](auto& v, const VariableSymbol& sym) { sym.getHierarchicalPath(path); }));
     CHECK(path == "top.genblk1[0].a");
 }
 


### PR DESCRIPTION
Take some input with an unnamed generate array, e.g.

    module top;
      genvar i;
      for (i = 0; i < 1; i = i + 1) begin
        logic a;
      end
    endmodule

make a fix so that the hierpath of the wire is `top.genblk1[0].a` not
 `top[0].a`.