### PR TITLE
FormatHelpers.cpp::checkArgType: disallow void in %p

### DIFF
--- a/source/ast/FmtHelpers.cpp
+++ b/source/ast/FmtHelpers.cpp
@@ -86,8 +86,9 @@ static bool checkArgType(TContext& context, const Expression& arg, char spec, So
                 return true;
             break;
         case 'p':
-            // Always valid.
-            return true;
+            if (!type.isVoid())
+                return true;
+            break;
         case 's':
             if (type.canBeStringLike())
                 return true;

--- a/tests/unittests/ast/SystemFuncTests.cpp
+++ b/tests/unittests/ast/SystemFuncTests.cpp
@@ -1440,3 +1440,22 @@ endmodule
     CHECK(diags[2].code == diag::ExpectedVariableName);
     CHECK(diags[3].code == diag::BadSystemSubroutineArg);
 }
+
+TEST_CASE("$sformat invalid %p call") {
+    auto tree = SyntaxTree::fromText(R"(
+function void void_fn;
+endfunction
+
+module m;
+  initial begin
+    $sformatf("%p", void_fn());
+  end
+endmodule
+)");
+
+    Compilation compilation;
+    compilation.addSyntaxTree(tree);
+    auto& diags = compilation.getAllDiagnostics();
+    REQUIRE(diags.size() == 1);
+    CHECK(diags[0].code == diag::FormatMismatchedType);
+}


### PR DESCRIPTION
It doesn't make sense to format the void type with any specifier, even %p (which displays "assignment patterns", according to the LRM).

From the LRM 21.2.1.7, "Assignment pattern format":

  The %p format specifier may be used to print aggregate expressions
  such as unpacked structures, arrays, and unions.

  [...]

  The %p and %0p format specifiers can also be used to print
  singular expressions, in which case the expression is formatted as
  an element of an aggregate expression previously described.