### PR TITLE
Add multiple slang-tidy checks and minor fixes in existing ones

### DIFF
--- a/tools/tidy/CMakeLists.txt
+++ b/tools/tidy/CMakeLists.txt
@@ -22,6 +22,7 @@ add_library(
   src/style/NoDotStarInPortConnection.cpp
   src/style/NoImplicitPortNameInPortConnection.cpp
   src/style/AlwaysCombNamed.cpp
+  src/style/GenerateNamed.cpp
   )
 
 target_include_directories(slang_tidy_obj_lib PUBLIC include ../../include)

--- a/tools/tidy/CMakeLists.txt
+++ b/tools/tidy/CMakeLists.txt
@@ -25,6 +25,7 @@ add_library(
   src/style/GenerateNamed.cpp
   src/style/NoDotVarInPortConnection.cpp
   src/style/NoLegacyGenerate.cpp
+  src/synthesis/AlwaysFFAssignmentOutsideConditional.cpp
   )
 
 target_include_directories(slang_tidy_obj_lib PUBLIC include ../../include)

--- a/tools/tidy/CMakeLists.txt
+++ b/tools/tidy/CMakeLists.txt
@@ -23,6 +23,7 @@ add_library(
   src/style/NoImplicitPortNameInPortConnection.cpp
   src/style/AlwaysCombNamed.cpp
   src/style/GenerateNamed.cpp
+  src/style/NoDotVarInPortConnection.cpp
   )
 
 target_include_directories(slang_tidy_obj_lib PUBLIC include ../../include)

--- a/tools/tidy/CMakeLists.txt
+++ b/tools/tidy/CMakeLists.txt
@@ -26,6 +26,7 @@ add_library(
   src/style/NoDotVarInPortConnection.cpp
   src/style/NoLegacyGenerate.cpp
   src/synthesis/AlwaysFFAssignmentOutsideConditional.cpp
+  src/synthesis/UnusedSensitiveSignal.cpp
   )
 
 target_include_directories(slang_tidy_obj_lib PUBLIC include ../../include)

--- a/tools/tidy/CMakeLists.txt
+++ b/tools/tidy/CMakeLists.txt
@@ -24,6 +24,7 @@ add_library(
   src/style/AlwaysCombNamed.cpp
   src/style/GenerateNamed.cpp
   src/style/NoDotVarInPortConnection.cpp
+  src/style/NoLegacyGenerate.cpp
   )
 
 target_include_directories(slang_tidy_obj_lib PUBLIC include ../../include)

--- a/tools/tidy/CMakeLists.txt
+++ b/tools/tidy/CMakeLists.txt
@@ -20,7 +20,9 @@ add_library(
   src/synthesis/XilinxDoNotCareValues.cpp
   src/synthesis/CastSignedIndex.cpp
   src/style/NoDotStarInPortConnection.cpp
-  src/style/NoImplicitPortNameInPortConnection.cpp)
+  src/style/NoImplicitPortNameInPortConnection.cpp
+  src/style/AlwaysCombNamed.cpp
+  )
 
 target_include_directories(slang_tidy_obj_lib PUBLIC include ../../include)
 target_link_libraries(slang_tidy_obj_lib PUBLIC slang::slang)

--- a/tools/tidy/include/ASTHelperVisitors.h
+++ b/tools/tidy/include/ASTHelperVisitors.h
@@ -20,6 +20,10 @@
 // Function that tries to get the name of the variable in an expression
 std::optional<std::string_view> getIdentifier(const slang::ast::Expression& expr);
 
+// Function that tries to get the source location of an expression
+std::optional<slang::SourceLocation> getExpressionSourceLocation(
+    const slang::ast::Expression& expr);
+
 struct TidyVisitor {
 protected:
     explicit TidyVisitor(slang::Diagnostics& diagnostics) :
@@ -52,6 +56,46 @@ struct CollectIdentifiers : public slang::ast::ASTVisitor<CollectIdentifiers, fa
     std::vector<std::string_view> identifiers;
 };
 
+/// ASTVisitor that will try to find the provided name in the identifiers under a node
+struct LookupIdentifier : public slang::ast::ASTVisitor<LookupIdentifier, true, true> {
+    explicit LookupIdentifier(const std::string_view& name, const bool exactMatching = true) :
+        name(name), exactMatching(exactMatching) {}
+
+    void handle(const slang::ast::NamedValueExpression& expression) {
+        if (hasIdentifier(name, exactMatching, expression)) {
+            _found = true;
+            _foundLocation = getExpressionSourceLocation(expression);
+        }
+    }
+
+    // Checks if the symbol reference of the expression has the provided name
+    static bool hasIdentifier(const std::string_view& name, const bool exactMatching,
+                              const slang::ast::NamedValueExpression& expression) {
+        auto symbol = expression.getSymbolReference();
+
+        return symbol && exactMatching ? symbol->name == name
+                                       : symbol->name.find(name) != std::string_view::npos;
+    }
+
+    // Retrieves whether the identifier has been found
+    [[nodiscard]] bool found() const { return _found; }
+
+    // Retrieves the identifier location in case it has been found
+    std::optional<slang::SourceLocation> foundLocation() const { return _foundLocation; }
+
+    // Resets the state of the visitor, so it can be used again without having to create a new one
+    void reset() {
+        _found = false;
+        _foundLocation = {};
+    }
+
+private:
+    const std::string_view name;
+    const bool exactMatching;
+    bool _found = false;
+    std::optional<slang::SourceLocation> _foundLocation;
+};
+
 /// ASTVisitor that will collect all LHS assignment symbols under a node
 struct CollectLHSSymbols : public slang::ast::ASTVisitor<CollectLHSSymbols, true, true> {
     void handle(const slang::ast::AssignmentExpression& expression) {
@@ -67,7 +111,10 @@ struct LookupLhsIdentifier : public slang::ast::ASTVisitor<LookupLhsIdentifier, 
     explicit LookupLhsIdentifier(const std::string_view& name) : name(name) {}
 
     void handle(const slang::ast::AssignmentExpression& expression) {
-        _found |= hasIdentifier(name, expression);
+        if (hasIdentifier(name, expression)) {
+            _found = true;
+            _foundLocation = getExpressionSourceLocation(expression);
+        }
     }
 
     // Checks if the symbol on the LHS of the expression has the provided name
@@ -75,19 +122,23 @@ struct LookupLhsIdentifier : public slang::ast::ASTVisitor<LookupLhsIdentifier, 
                               const slang::ast::AssignmentExpression& expression) {
         auto identifier = getIdentifier(expression.left());
 
-        if (identifier && identifier.value() == name) {
-            return true;
-        }
-        return false;
+        return identifier && identifier.value() == name;
     }
 
     // Retrieves whether the identifier has been found
     [[nodiscard]] bool found() const { return _found; }
 
+    // Retrieves the identifier location in case it has been found
+    std::optional<slang::SourceLocation> foundLocation() const { return _foundLocation; }
+
     // Resets the state of the visitor, so it can be used again without having to create a new one
-    void reset() { _found = false; }
+    void reset() {
+        _found = false;
+        _foundLocation = {};
+    }
 
 private:
     const std::string_view name;
     bool _found = false;
+    std::optional<slang::SourceLocation> _foundLocation;
 };

--- a/tools/tidy/include/TidyDiags.h
+++ b/tools/tidy/include/TidyDiags.h
@@ -24,5 +24,6 @@ inline constexpr DiagCode XilinxDoNotCareValues(DiagSubsystem::Tidy, 9);
 inline constexpr DiagCode CastSignedIndex(DiagSubsystem::Tidy, 10);
 inline constexpr DiagCode NoDotStarInPortConnection(DiagSubsystem::Tidy, 11);
 inline constexpr DiagCode NoImplicitPortNameInPortConnection(DiagSubsystem::Tidy, 12);
+inline constexpr DiagCode AlwaysCombBlockNamed(DiagSubsystem::Tidy, 13);
 
 } // namespace slang::diag

--- a/tools/tidy/include/TidyDiags.h
+++ b/tools/tidy/include/TidyDiags.h
@@ -25,5 +25,6 @@ inline constexpr DiagCode CastSignedIndex(DiagSubsystem::Tidy, 10);
 inline constexpr DiagCode NoDotStarInPortConnection(DiagSubsystem::Tidy, 11);
 inline constexpr DiagCode NoImplicitPortNameInPortConnection(DiagSubsystem::Tidy, 12);
 inline constexpr DiagCode AlwaysCombBlockNamed(DiagSubsystem::Tidy, 13);
+inline constexpr DiagCode GenerateNamed(DiagSubsystem::Tidy, 14);
 
 } // namespace slang::diag

--- a/tools/tidy/include/TidyDiags.h
+++ b/tools/tidy/include/TidyDiags.h
@@ -29,5 +29,6 @@ inline constexpr DiagCode GenerateNamed(DiagSubsystem::Tidy, 14);
 inline constexpr DiagCode NoDotVarInPortConnection(DiagSubsystem::Tidy, 15);
 inline constexpr DiagCode NoLegacyGenerate(DiagSubsystem::Tidy, 16);
 inline constexpr DiagCode AlwaysFFAssignmentOutsideConditional(DiagSubsystem::Tidy, 17);
+inline constexpr DiagCode UnusedSensitiveSignal(DiagSubsystem::Tidy, 18);
 
 } // namespace slang::diag

--- a/tools/tidy/include/TidyDiags.h
+++ b/tools/tidy/include/TidyDiags.h
@@ -27,5 +27,6 @@ inline constexpr DiagCode NoImplicitPortNameInPortConnection(DiagSubsystem::Tidy
 inline constexpr DiagCode AlwaysCombBlockNamed(DiagSubsystem::Tidy, 13);
 inline constexpr DiagCode GenerateNamed(DiagSubsystem::Tidy, 14);
 inline constexpr DiagCode NoDotVarInPortConnection(DiagSubsystem::Tidy, 15);
+inline constexpr DiagCode NoLegacyGenerate(DiagSubsystem::Tidy, 16);
 
 } // namespace slang::diag

--- a/tools/tidy/include/TidyDiags.h
+++ b/tools/tidy/include/TidyDiags.h
@@ -26,5 +26,6 @@ inline constexpr DiagCode NoDotStarInPortConnection(DiagSubsystem::Tidy, 11);
 inline constexpr DiagCode NoImplicitPortNameInPortConnection(DiagSubsystem::Tidy, 12);
 inline constexpr DiagCode AlwaysCombBlockNamed(DiagSubsystem::Tidy, 13);
 inline constexpr DiagCode GenerateNamed(DiagSubsystem::Tidy, 14);
+inline constexpr DiagCode NoDotVarInPortConnection(DiagSubsystem::Tidy, 15);
 
 } // namespace slang::diag

--- a/tools/tidy/include/TidyDiags.h
+++ b/tools/tidy/include/TidyDiags.h
@@ -28,5 +28,6 @@ inline constexpr DiagCode AlwaysCombBlockNamed(DiagSubsystem::Tidy, 13);
 inline constexpr DiagCode GenerateNamed(DiagSubsystem::Tidy, 14);
 inline constexpr DiagCode NoDotVarInPortConnection(DiagSubsystem::Tidy, 15);
 inline constexpr DiagCode NoLegacyGenerate(DiagSubsystem::Tidy, 16);
+inline constexpr DiagCode AlwaysFFAssignmentOutsideConditional(DiagSubsystem::Tidy, 17);
 
 } // namespace slang::diag

--- a/tools/tidy/src/ASTHelperVisitors.cpp
+++ b/tools/tidy/src/ASTHelperVisitors.cpp
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 #include "ASTHelperVisitors.h"
+#include "slang/syntax/AllSyntax.h"
 
 std::optional<std::string_view> getIdentifier(const slang::ast::Expression& expr) {
     const slang::ast::Symbol* symbol = nullptr;
@@ -18,4 +19,9 @@ std::optional<std::string_view> getIdentifier(const slang::ast::Expression& expr
         return symbol->name;
     }
     return {};
+}
+
+std::optional<slang::SourceLocation> getExpressionSourceLocation(
+    const slang::ast::Expression& expr) {
+    return expr.syntax->getFirstToken().location();
 }

--- a/tools/tidy/src/TidyConfig.cpp
+++ b/tools/tidy/src/TidyConfig.cpp
@@ -26,6 +26,7 @@ TidyConfig::TidyConfig() {
     styleChecks.emplace("OnlyANSIPortDecl", CheckStatus::ENABLED);
     styleChecks.emplace("NoDotStarInPortConnection", CheckStatus::ENABLED);
     styleChecks.emplace("NoImplicitPortNameInPortConnection", CheckStatus::ENABLED);
+    styleChecks.emplace("AlwaysCombBlockNamed", CheckStatus::ENABLED);
     checkKinds.insert({slang::TidyKind::Style, styleChecks});
 
     auto synthesisChecks = std::unordered_map<std::string, CheckStatus>();

--- a/tools/tidy/src/TidyConfig.cpp
+++ b/tools/tidy/src/TidyConfig.cpp
@@ -39,6 +39,7 @@ TidyConfig::TidyConfig() {
     synthesisChecks.emplace("XilinxDoNotCareValues", CheckStatus::ENABLED);
     synthesisChecks.emplace("CastSignedIndex", CheckStatus::ENABLED);
     synthesisChecks.emplace("AlwaysFFAssignmentOutsideConditional", CheckStatus::ENABLED);
+    synthesisChecks.emplace("UnusedSensitiveSignal", CheckStatus::ENABLED);
     checkKinds.insert({slang::TidyKind::Synthesis, synthesisChecks});
 }
 

--- a/tools/tidy/src/TidyConfig.cpp
+++ b/tools/tidy/src/TidyConfig.cpp
@@ -27,6 +27,7 @@ TidyConfig::TidyConfig() {
     styleChecks.emplace("NoDotStarInPortConnection", CheckStatus::ENABLED);
     styleChecks.emplace("NoImplicitPortNameInPortConnection", CheckStatus::ENABLED);
     styleChecks.emplace("AlwaysCombBlockNamed", CheckStatus::ENABLED);
+    styleChecks.emplace("GenerateNamed", CheckStatus::ENABLED);
     checkKinds.insert({slang::TidyKind::Style, styleChecks});
 
     auto synthesisChecks = std::unordered_map<std::string, CheckStatus>();

--- a/tools/tidy/src/TidyConfig.cpp
+++ b/tools/tidy/src/TidyConfig.cpp
@@ -29,6 +29,7 @@ TidyConfig::TidyConfig() {
     styleChecks.emplace("AlwaysCombBlockNamed", CheckStatus::ENABLED);
     styleChecks.emplace("GenerateNamed", CheckStatus::ENABLED);
     styleChecks.emplace("NoDotVarInPortConnection", CheckStatus::ENABLED);
+    styleChecks.emplace("NoLegacyGenerate", CheckStatus::ENABLED);
     checkKinds.insert({slang::TidyKind::Style, styleChecks});
 
     auto synthesisChecks = std::unordered_map<std::string, CheckStatus>();

--- a/tools/tidy/src/TidyConfig.cpp
+++ b/tools/tidy/src/TidyConfig.cpp
@@ -38,6 +38,7 @@ TidyConfig::TidyConfig() {
     synthesisChecks.emplace("RegisterHasNoReset", CheckStatus::ENABLED);
     synthesisChecks.emplace("XilinxDoNotCareValues", CheckStatus::ENABLED);
     synthesisChecks.emplace("CastSignedIndex", CheckStatus::ENABLED);
+    synthesisChecks.emplace("AlwaysFFAssignmentOutsideConditional", CheckStatus::ENABLED);
     checkKinds.insert({slang::TidyKind::Synthesis, synthesisChecks});
 }
 

--- a/tools/tidy/src/TidyConfig.cpp
+++ b/tools/tidy/src/TidyConfig.cpp
@@ -28,6 +28,7 @@ TidyConfig::TidyConfig() {
     styleChecks.emplace("NoImplicitPortNameInPortConnection", CheckStatus::ENABLED);
     styleChecks.emplace("AlwaysCombBlockNamed", CheckStatus::ENABLED);
     styleChecks.emplace("GenerateNamed", CheckStatus::ENABLED);
+    styleChecks.emplace("NoDotVarInPortConnection", CheckStatus::ENABLED);
     checkKinds.insert({slang::TidyKind::Style, styleChecks});
 
     auto synthesisChecks = std::unordered_map<std::string, CheckStatus>();

--- a/tools/tidy/src/style/AlwaysCombNamed.cpp
+++ b/tools/tidy/src/style/AlwaysCombNamed.cpp
@@ -1,0 +1,58 @@
+// SPDX-FileCopyrightText: Michael Popoloski
+// SPDX-License-Identifier: MIT
+
+#include "ASTHelperVisitors.h"
+#include "TidyDiags.h"
+#include "fmt/color.h"
+
+#include "slang/syntax/AllSyntax.h"
+
+using namespace slang;
+using namespace slang::ast;
+
+namespace always_comb_named {
+struct MainVisitor : public TidyVisitor, ASTVisitor<MainVisitor, true, false> {
+    explicit MainVisitor(Diagnostics& diagnostics) : TidyVisitor(diagnostics) {}
+
+    void handle(const ProceduralBlockSymbol& symbol) {
+
+        NEEDS_SKIP_SYMBOL(symbol)
+
+        if (symbol.procedureKind != ProceduralBlockKind::AlwaysComb ||
+            symbol.getBody().kind != StatementKind::Block)
+            return;
+
+        bool isUnnamed = (symbol.getBody().as<ast::BlockStatement>().blockSymbol == nullptr ||
+                          symbol.getBody().as<ast::BlockStatement>().blockSymbol->name.empty());
+
+        if (isUnnamed) {
+            diags.add(diag::AlwaysCombBlockNamed, symbol.location);
+        }
+    }
+};
+} // namespace always_comb_named
+
+using namespace always_comb_named;
+class AlwaysCombBlockNamed : public TidyCheck {
+public:
+    [[maybe_unused]] explicit AlwaysCombBlockNamed(TidyKind kind) : TidyCheck(kind) {}
+
+    bool check(const ast::RootSymbol& root) override {
+        MainVisitor visitor(diagnostics);
+        root.visit(visitor);
+        if (!diagnostics.empty())
+            return false;
+        return true;
+    }
+
+    DiagCode diagCode() const override { return diag::AlwaysCombBlockNamed; }
+    DiagnosticSeverity diagSeverity() const override { return DiagnosticSeverity::Warning; }
+    std::string diagString() const override { return "definition of an unnamed always_comb block"; }
+    std::string name() const override { return "AlwaysCombBlockNamed"; }
+    std::string description() const override { return shortDescription(); }
+    std::string shortDescription() const override {
+        return "Enforces that each always_comb block is named";
+    }
+};
+
+REGISTER(AlwaysCombBlockNamed, AlwaysCombBlockNamed, TidyKind::Style)

--- a/tools/tidy/src/style/AlwaysCombNamed.cpp
+++ b/tools/tidy/src/style/AlwaysCombNamed.cpp
@@ -40,9 +40,7 @@ public:
     bool check(const ast::RootSymbol& root) override {
         MainVisitor visitor(diagnostics);
         root.visit(visitor);
-        if (!diagnostics.empty())
-            return false;
-        return true;
+        return diagnostics.empty();
     }
 
     DiagCode diagCode() const override { return diag::AlwaysCombBlockNamed; }

--- a/tools/tidy/src/style/AlwaysCombNonBlocking.cpp
+++ b/tools/tidy/src/style/AlwaysCombNonBlocking.cpp
@@ -40,9 +40,7 @@ public:
     bool check(const ast::RootSymbol& root) override {
         MainVisitor visitor(diagnostics);
         root.visit(visitor);
-        if (!diagnostics.empty())
-            return false;
-        return true;
+        return diagnostics.empty();
     }
 
     DiagCode diagCode() const override { return diag::AlwaysCombNonBlocking; }

--- a/tools/tidy/src/style/AlwaysFFBlocking.cpp
+++ b/tools/tidy/src/style/AlwaysFFBlocking.cpp
@@ -51,9 +51,7 @@ public:
     bool check(const ast::RootSymbol& root) override {
         MainVisitor visitor(diagnostics);
         root.visit(visitor);
-        if (!diagnostics.empty())
-            return false;
-        return true;
+        return diagnostics.empty();
     }
 
     DiagCode diagCode() const override { return diag::AlwaysFFBlocking; }

--- a/tools/tidy/src/style/EnforceModuleInstantiationPrefix.cpp
+++ b/tools/tidy/src/style/EnforceModuleInstantiationPrefix.cpp
@@ -38,9 +38,7 @@ public:
     bool check(const ast::RootSymbol& root) override {
         MainVisitor visitor(diagnostics);
         root.visit(visitor);
-        if (!diagnostics.empty())
-            return false;
-        return true;
+        return diagnostics.empty();
     }
 
     DiagCode diagCode() const override { return diag::EnforceModuleInstantiationPrefix; }

--- a/tools/tidy/src/style/EnforcePortSuffix.cpp
+++ b/tools/tidy/src/style/EnforcePortSuffix.cpp
@@ -61,9 +61,7 @@ public:
     bool check(const ast::RootSymbol& root) override {
         MainVisitor visitor(diagnostics);
         root.visit(visitor);
-        if (!diagnostics.empty())
-            return false;
-        return true;
+        return diagnostics.empty();
     }
 
     DiagCode diagCode() const override { return diag::EnforcePortSuffix; }

--- a/tools/tidy/src/style/GenerateNamed.cpp
+++ b/tools/tidy/src/style/GenerateNamed.cpp
@@ -1,0 +1,63 @@
+// SPDX-FileCopyrightText: Michael Popoloski
+// SPDX-License-Identifier: MIT
+
+#include "ASTHelperVisitors.h"
+#include "TidyDiags.h"
+#include "fmt/color.h"
+
+#include "slang/syntax/AllSyntax.h"
+
+using namespace slang;
+using namespace slang::ast;
+
+namespace generate_named {
+struct MainVisitor : public TidyVisitor, ASTVisitor<MainVisitor, true, false> {
+    explicit MainVisitor(Diagnostics& diagnostics) : TidyVisitor(diagnostics) {}
+
+    void handle(const GenerateBlockSymbol& symbol) {
+
+        NEEDS_SKIP_SYMBOL(symbol)
+
+        if (!symbol.getParentScope())
+            return;
+
+        auto& parSymbol = symbol.getParentScope()->asSymbol();
+
+        bool isUnnamed = symbol.name.empty();
+        if (parSymbol.kind == SymbolKind::GenerateBlockArray) {
+            if (symbol.constructIndex != 0)
+                return;
+            isUnnamed = parSymbol.name.empty();
+        }
+
+        if (isUnnamed) {
+            diags.add(diag::GenerateNamed, symbol.location);
+        }
+    }
+};
+} // namespace generate_named
+
+using namespace generate_named;
+class GenerateNamed : public TidyCheck {
+public:
+    [[maybe_unused]] explicit GenerateNamed(TidyKind kind) : TidyCheck(kind) {}
+
+    bool check(const ast::RootSymbol& root) override {
+        MainVisitor visitor(diagnostics);
+        root.visit(visitor);
+        if (!diagnostics.empty())
+            return false;
+        return true;
+    }
+
+    DiagCode diagCode() const override { return diag::GenerateNamed; }
+    DiagnosticSeverity diagSeverity() const override { return DiagnosticSeverity::Warning; }
+    std::string diagString() const override { return "definition of an unnamed generate block"; }
+    std::string name() const override { return "GenerateNamed"; }
+    std::string description() const override { return shortDescription(); }
+    std::string shortDescription() const override {
+        return "Enforces that each generate block is named";
+    }
+};
+
+REGISTER(GenerateNamed, GenerateNamed, TidyKind::Style)

--- a/tools/tidy/src/style/GenerateNamed.cpp
+++ b/tools/tidy/src/style/GenerateNamed.cpp
@@ -45,9 +45,7 @@ public:
     bool check(const ast::RootSymbol& root) override {
         MainVisitor visitor(diagnostics);
         root.visit(visitor);
-        if (!diagnostics.empty())
-            return false;
-        return true;
+        return diagnostics.empty();
     }
 
     DiagCode diagCode() const override { return diag::GenerateNamed; }

--- a/tools/tidy/src/style/NoDotStarInPortConnection.cpp
+++ b/tools/tidy/src/style/NoDotStarInPortConnection.cpp
@@ -42,9 +42,7 @@ public:
     bool check(const RootSymbol& root) override {
         MainVisitor visitor(diagnostics);
         root.visit(visitor);
-        if (!diagnostics.empty())
-            return false;
-        return true;
+        return diagnostics.empty();
     }
 
     DiagCode diagCode() const override { return diag::NoDotStarInPortConnection; }

--- a/tools/tidy/src/style/NoDotStarInPortConnection.cpp
+++ b/tools/tidy/src/style/NoDotStarInPortConnection.cpp
@@ -14,10 +14,10 @@ using namespace slang::syntax;
 namespace no_dot_start_in_port_connection {
 
 struct PortConnectionVisitor : public SyntaxVisitor<PortConnectionVisitor> {
-    void handle(const WildcardPortConnectionSyntax&) { found = true; }
+    void handle(const WildcardPortConnectionSyntax& port) { foundPorts.push_back(&port); }
 
 public:
-    bool found{false};
+    std::vector<const WildcardPortConnectionSyntax*> foundPorts;
 };
 
 struct MainVisitor : public TidyVisitor, ASTVisitor<MainVisitor, true, true> {
@@ -27,8 +27,8 @@ struct MainVisitor : public TidyVisitor, ASTVisitor<MainVisitor, true, true> {
         NEEDS_SKIP_SYMBOL(symbol)
         PortConnectionVisitor visitor;
         symbol.getSyntax()->visit(visitor);
-        if (visitor.found)
-            diags.add(diag::NoDotStarInPortConnection, symbol.location);
+        for (const auto port : visitor.foundPorts)
+            diags.add(diag::NoDotStarInPortConnection, port->star.location());
     }
 };
 } // namespace no_dot_start_in_port_connection

--- a/tools/tidy/src/style/NoDotVarInPortConnection.cpp
+++ b/tools/tidy/src/style/NoDotVarInPortConnection.cpp
@@ -1,0 +1,75 @@
+// SPDX-FileCopyrightText: Michael Popoloski
+// SPDX-License-Identifier: MIT
+
+#include "ASTHelperVisitors.h"
+#include "TidyDiags.h"
+
+#include "slang/syntax/AllSyntax.h"
+#include "slang/syntax/SyntaxVisitor.h"
+
+using namespace slang;
+using namespace slang::ast;
+using namespace slang::syntax;
+
+namespace no_dot_var_in_port_connection {
+
+struct PortConnectionVisitor : public SyntaxVisitor<PortConnectionVisitor> {
+    void handle(const NamedPortConnectionSyntax& port) {
+        if (!port.expr)
+            foundPorts.push_back(&port);
+    }
+
+public:
+    std::vector<const NamedPortConnectionSyntax*> foundPorts;
+};
+
+struct MainVisitor : public TidyVisitor, ASTVisitor<MainVisitor, true, true> {
+    explicit MainVisitor(Diagnostics& diagnostics) : TidyVisitor(diagnostics) {}
+
+    void handle(const InstanceBodySymbol& symbol) {
+        NEEDS_SKIP_SYMBOL(symbol)
+        if (!symbol.getSyntax())
+            return;
+
+        PortConnectionVisitor visitor;
+        symbol.getSyntax()->visit(visitor);
+
+        for (const auto port : visitor.foundPorts)
+            diags.add(diag::NoDotVarInPortConnection, port->name.location())
+                << port->toString() << port->toString() << port->name.valueText();
+    }
+};
+} // namespace no_dot_var_in_port_connection
+
+using namespace no_dot_var_in_port_connection;
+
+class NoDotVarInPortConnection : public TidyCheck {
+public:
+    [[maybe_unused]] explicit NoDotVarInPortConnection(TidyKind kind) : TidyCheck(kind) {}
+
+    bool check(const RootSymbol& root) override {
+        MainVisitor visitor(diagnostics);
+        root.visit(visitor);
+        if (!diagnostics.empty())
+            return false;
+        return true;
+    }
+
+    DiagCode diagCode() const override { return diag::NoDotVarInPortConnection; }
+
+    std::string diagString() const override {
+        return "use of '{}' in port connection list, consider using '{}({})' instead";
+    }
+
+    DiagnosticSeverity diagSeverity() const override { return DiagnosticSeverity::Warning; }
+
+    std::string name() const override { return "NoDotVarInPortConnection"; }
+
+    std::string description() const override { return shortDescription(); }
+
+    std::string shortDescription() const override {
+        return "Checks if in a module instantiation any port is connected using .var syntax.";
+    }
+};
+
+REGISTER(NoDotVarInPortConnection, NoDotVarInPortConnection, TidyKind::Style)

--- a/tools/tidy/src/style/NoDotVarInPortConnection.cpp
+++ b/tools/tidy/src/style/NoDotVarInPortConnection.cpp
@@ -50,9 +50,7 @@ public:
     bool check(const RootSymbol& root) override {
         MainVisitor visitor(diagnostics);
         root.visit(visitor);
-        if (!diagnostics.empty())
-            return false;
-        return true;
+        return diagnostics.empty();
     }
 
     DiagCode diagCode() const override { return diag::NoDotVarInPortConnection; }

--- a/tools/tidy/src/style/NoImplicitPortNameInPortConnection.cpp
+++ b/tools/tidy/src/style/NoImplicitPortNameInPortConnection.cpp
@@ -46,9 +46,7 @@ public:
     bool check(const RootSymbol& root) override {
         MainVisitor visitor(diagnostics);
         root.visit(visitor);
-        if (!diagnostics.empty())
-            return false;
-        return true;
+        return diagnostics.empty();
     }
 
     DiagCode diagCode() const override { return diag::NoImplicitPortNameInPortConnection; }

--- a/tools/tidy/src/style/NoLegacyGenerate.cpp
+++ b/tools/tidy/src/style/NoLegacyGenerate.cpp
@@ -47,9 +47,7 @@ public:
     bool check(const ast::RootSymbol& root) override {
         MainVisitor visitor(diagnostics);
         root.visit(visitor);
-        if (!diagnostics.empty())
-            return false;
-        return true;
+        return diagnostics.empty();
     }
 
     DiagCode diagCode() const override { return diag::NoLegacyGenerate; }

--- a/tools/tidy/src/style/NoLegacyGenerate.cpp
+++ b/tools/tidy/src/style/NoLegacyGenerate.cpp
@@ -1,0 +1,65 @@
+// SPDX-FileCopyrightText: Michael Popoloski
+// SPDX-License-Identifier: MIT
+
+#include "ASTHelperVisitors.h"
+#include "TidyDiags.h"
+#include "fmt/color.h"
+
+#include "slang/syntax/AllSyntax.h"
+#include "slang/syntax/SyntaxVisitor.h"
+
+using namespace slang;
+using namespace slang::ast;
+using namespace slang::syntax;
+
+namespace no_legacy_generate {
+
+struct GenerateVisitor : public SyntaxVisitor<GenerateVisitor> {
+    void handle(const GenerateRegionSyntax& syntax) { foundGenerate.push_back(&syntax); }
+
+public:
+    std::vector<const GenerateRegionSyntax*> foundGenerate;
+};
+
+struct MainVisitor : public TidyVisitor, ASTVisitor<MainVisitor, true, true> {
+    explicit MainVisitor(Diagnostics& diagnostics) : TidyVisitor(diagnostics) {}
+
+    void handle(const InstanceBodySymbol& symbol) {
+        NEEDS_SKIP_SYMBOL(symbol)
+        if (!symbol.getSyntax())
+            return;
+
+        GenerateVisitor visitor;
+        symbol.getSyntax()->visit(visitor);
+
+        for (const auto& syntax : visitor.foundGenerate) {
+            diags.add(diag::NoLegacyGenerate, syntax->keyword.location());
+        }
+    }
+};
+} // namespace no_legacy_generate
+
+using namespace no_legacy_generate;
+class NoLegacyGenerate : public TidyCheck {
+public:
+    [[maybe_unused]] explicit NoLegacyGenerate(TidyKind kind) : TidyCheck(kind) {}
+
+    bool check(const ast::RootSymbol& root) override {
+        MainVisitor visitor(diagnostics);
+        root.visit(visitor);
+        if (!diagnostics.empty())
+            return false;
+        return true;
+    }
+
+    DiagCode diagCode() const override { return diag::NoLegacyGenerate; }
+    DiagnosticSeverity diagSeverity() const override { return DiagnosticSeverity::Warning; }
+    std::string diagString() const override { return "usage of generate block is deprecated"; }
+    std::string name() const override { return "NoLegacyGenerate"; }
+    std::string description() const override { return shortDescription(); }
+    std::string shortDescription() const override {
+        return "Enforces that no generate block is declared since it is deprecated";
+    }
+};
+
+REGISTER(NoLegacyGenerate, NoLegacyGenerate, TidyKind::Style)

--- a/tools/tidy/src/style/NoOldAlwaysSyntax.cpp
+++ b/tools/tidy/src/style/NoOldAlwaysSyntax.cpp
@@ -48,9 +48,7 @@ public:
     bool check(const RootSymbol& root) override {
         MainVisitor visitor(diagnostics);
         root.visit(visitor);
-        if (!diagnostics.empty())
-            return false;
-        return true;
+        return diagnostics.empty();
     }
 
     DiagCode diagCode() const override { return diag::NoOldAlwaysSyntax; }

--- a/tools/tidy/src/style/OnlyANSIPortDecl.cpp
+++ b/tools/tidy/src/style/OnlyANSIPortDecl.cpp
@@ -31,9 +31,7 @@ public:
     bool check(const ast::RootSymbol& root) override {
         MainVisitor visitor(diagnostics);
         root.visit(visitor);
-        if (!diagnostics.empty())
-            return false;
-        return true;
+        return diagnostics.empty();
     }
 
     DiagCode diagCode() const override { return diag::OnlyANSIPortDecl; }

--- a/tools/tidy/src/synthesis/AlwaysFFAssignmentOutsideConditional.cpp
+++ b/tools/tidy/src/synthesis/AlwaysFFAssignmentOutsideConditional.cpp
@@ -1,0 +1,111 @@
+// SPDX-FileCopyrightText: Michael Popoloski
+// SPDX-License-Identifier: MIT
+
+#include "ASTHelperVisitors.h"
+#include "TidyDiags.h"
+#include "TidyFactory.h"
+#include "fmt/color.h"
+
+#include "slang/syntax/AllSyntax.h"
+
+using namespace slang;
+using namespace slang::ast;
+
+namespace always_ff_assignment_outside_conditional {
+struct AlwaysFFVisitor : public ASTVisitor<AlwaysFFVisitor, true, true> {
+    explicit AlwaysFFVisitor(const std::string_view name, const std::string_view resetName) :
+        name(name), resetName(resetName){};
+
+    void handle(const ConditionalStatement& statement) {
+        // Early return, if there's no else clause on the conditional statement
+        if (!statement.ifFalse) {
+            return;
+        }
+
+        // Collect all the identifiers in the conditions
+        CollectIdentifiers collectIdentifiersVisitor;
+        for (const auto& condition : statement.conditions) {
+            condition.expr->visit(collectIdentifiersVisitor);
+        }
+
+        // Check if one of the identifiers is a reset
+        const auto isReset =
+            std::ranges::any_of(collectIdentifiersVisitor.identifiers, [this](auto id) {
+                return id.find(resetName) != std::string_view::npos;
+            });
+
+        condStatmenentWithReset = isReset;
+    }
+
+    void handle(const AssignmentExpression& expression) {
+        if (LookupLhsIdentifier::hasIdentifier(name, expression)) {
+            assignedOutsideIfWithReset = true;
+            errorLocation = expression.left().syntax->getFirstToken().location();
+        }
+    }
+
+    bool hasError() { return condStatmenentWithReset && assignedOutsideIfWithReset; }
+
+    const std::string_view name;
+    const std::string_view resetName;
+    bool condStatmenentWithReset = false;
+    bool assignedOutsideIfWithReset = false;
+    SourceLocation errorLocation = SourceLocation();
+};
+
+struct MainVisitor : public TidyVisitor, ASTVisitor<MainVisitor, true, true> {
+    explicit MainVisitor(Diagnostics& diagnostics) : TidyVisitor(diagnostics) {}
+
+    void handle(const VariableSymbol& symbol) {
+        NEEDS_SKIP_SYMBOL(symbol)
+        if (symbol.drivers().empty())
+            return;
+
+        auto firstDriver = *symbol.drivers().begin();
+        if (firstDriver && firstDriver->isInAlwaysFFBlock()) {
+            AlwaysFFVisitor visitor(symbol.name, config.getCheckConfigs().resetName);
+            firstDriver->containingSymbol->visit(visitor);
+            if (visitor.hasError()) {
+                diags.add(diag::RegisterNotAssignedOnReset, visitor.errorLocation) << symbol.name;
+            }
+        }
+    }
+};
+} // namespace always_ff_assignment_outside_conditional
+
+using namespace always_ff_assignment_outside_conditional;
+
+class AlwaysFFAssignmentOutsideConditional : public TidyCheck {
+public:
+    explicit AlwaysFFAssignmentOutsideConditional(TidyKind kind) : TidyCheck(kind) {}
+
+    bool check(const RootSymbol& root) override {
+        MainVisitor visitor(diagnostics);
+        root.visit(visitor);
+        if (!diagnostics.empty())
+            return false;
+        return true;
+    }
+
+    DiagCode diagCode() const override { return diag::RegisterNotAssignedOnReset; }
+
+    std::string diagString() const override {
+        return "register '{}' has an assignment outside a conditional block with reset. Consider "
+               "moving the register to an always_ff that has no reset or moving the assignment "
+               "inside the conditional block";
+    }
+
+    DiagnosticSeverity diagSeverity() const override { return DiagnosticSeverity::Warning; }
+
+    std::string name() const override { return "AlwaysFFAssignmentOutsideConditional"; }
+
+    std::string description() const override { return shortDescription(); }
+
+    std::string shortDescription() const override {
+        return "A register in an always_ff with an assignment outside a conditional block with a "
+               "reset signal on its sensitivity list";
+    }
+};
+
+REGISTER(AlwaysFFAssignmentOutsideConditional, AlwaysFFAssignmentOutsideConditional,
+         TidyKind::Synthesis)

--- a/tools/tidy/src/synthesis/AlwaysFFAssignmentOutsideConditional.cpp
+++ b/tools/tidy/src/synthesis/AlwaysFFAssignmentOutsideConditional.cpp
@@ -84,9 +84,7 @@ public:
     bool check(const RootSymbol& root) override {
         MainVisitor visitor(diagnostics);
         root.visit(visitor);
-        if (!diagnostics.empty())
-            return false;
-        return true;
+        return diagnostics.empty();
     }
 
     DiagCode diagCode() const override { return diag::RegisterNotAssignedOnReset; }

--- a/tools/tidy/src/synthesis/NoLatchesOnDesign.cpp
+++ b/tools/tidy/src/synthesis/NoLatchesOnDesign.cpp
@@ -37,9 +37,7 @@ public:
     bool check(const RootSymbol& root) override {
         MainVisitor visitor(diagnostics);
         root.visit(visitor);
-        if (!diagnostics.empty())
-            return false;
-        return true;
+        return diagnostics.empty();
     }
 
     DiagCode diagCode() const override { return diag::NoLatchesOnDesign; }

--- a/tools/tidy/src/synthesis/OnlyAssignedOnReset.cpp
+++ b/tools/tidy/src/synthesis/OnlyAssignedOnReset.cpp
@@ -117,9 +117,7 @@ public:
     bool check(const RootSymbol& root) override {
         MainVisitor visitor(diagnostics);
         root.visit(visitor);
-        if (!diagnostics.empty())
-            return false;
-        return true;
+        return diagnostics.empty();
     }
 
     DiagCode diagCode() const override { return diag::OnlyAssignedOnReset; }

--- a/tools/tidy/src/synthesis/OnlyAssignedOnReset.cpp
+++ b/tools/tidy/src/synthesis/OnlyAssignedOnReset.cpp
@@ -12,8 +12,10 @@ using namespace slang::ast;
 
 namespace only_assigned_on_reset {
 struct AlwaysFFVisitor : public ASTVisitor<AlwaysFFVisitor, true, true> {
-    explicit AlwaysFFVisitor(const std::string_view name, const std::string_view resetName) :
-        name(name), resetName(resetName) {};
+    explicit AlwaysFFVisitor(const std::string_view name, const std::string_view resetName,
+                             const bool resetIsActiveHigh) :
+        name(name),
+        resetName(resetName), resetIsActiveHigh(resetIsActiveHigh){};
 
     void handle(const ConditionalStatement& statement) {
         // Early return, if there's no else clause on the conditional statement
@@ -21,27 +23,46 @@ struct AlwaysFFVisitor : public ASTVisitor<AlwaysFFVisitor, true, true> {
             return;
         }
 
-        // Collect all the identifiers in the conditions
-        CollectIdentifiers collectIdentifiersVisitor;
+        // Check if there is a reset in the conditional statement and if the signal is negated
+        bool isReset = false;
+        bool isResetNeg = false;
+
+        LookupIdentifier lookupIdentifierVisitor(resetName, false);
         for (const auto& condition : statement.conditions) {
-            condition.expr->visit(collectIdentifiersVisitor);
+            condition.expr->visit(lookupIdentifierVisitor);
+            isReset = lookupIdentifierVisitor.found();
+
+            if (isReset) {
+                if (condition.expr->kind == ExpressionKind::UnaryOp) {
+                    auto op = condition.expr->as<UnaryExpression>().op;
+                    isResetNeg = (op == UnaryOperator::BitwiseNot) ||
+                                 (op == UnaryOperator::LogicalNot);
+                }
+                break;
+            }
         }
 
-        // Check if one of the identifiers is a reset
-        const auto isReset =
-            std::ranges::any_of(collectIdentifiersVisitor.identifiers, [this](auto id) {
-                return id.find(resetName) != std::string_view::npos;
-            });
+        if (!isReset)
+            return;
 
-        if (isReset) {
-            LookupLhsIdentifier visitor(name);
-            statement.ifTrue.visit(visitor);
-            if (visitor.found()) {
-                visitor.reset();
-                statement.ifFalse->visit(visitor);
-                if (!visitor.found()) {
-                    correctlyAssignedOnIfReset = true;
-                }
+        auto resetStatement = &statement.ifTrue;
+        auto noResetStatement = statement.ifFalse;
+
+        bool swapStatements = isResetNeg ? !resetIsActiveHigh : resetIsActiveHigh;
+
+        if (swapStatements) {
+            std::swap(resetStatement, noResetStatement);
+        }
+
+        LookupLhsIdentifier visitor(name);
+        resetStatement->visit(visitor);
+        if (visitor.found()) {
+            auto foundLocation = visitor.foundLocation();
+            visitor.reset();
+            noResetStatement->visit(visitor);
+            if (!visitor.found()) {
+                correctlyAssignedOnIfReset = true;
+                errorLocation = foundLocation;
             }
         }
     }
@@ -54,27 +75,34 @@ struct AlwaysFFVisitor : public ASTVisitor<AlwaysFFVisitor, true, true> {
 
     bool hasError() { return correctlyAssignedOnIfReset && !assignedOutsideIfReset; }
 
+    std::optional<SourceLocation> getErrorLocation() const { return errorLocation; }
+
+private:
     const std::string_view name;
     const std::string_view resetName;
+    const bool resetIsActiveHigh;
     bool correctlyAssignedOnIfReset = false;
     bool assignedOutsideIfReset = false;
+    std::optional<SourceLocation> errorLocation;
 };
 
-struct MainVisitor : public TidyVisitor, ASTVisitor<MainVisitor, true, false> {
+struct MainVisitor : public TidyVisitor, ASTVisitor<MainVisitor, true, true> {
     explicit MainVisitor(Diagnostics& diagnostics) : TidyVisitor(diagnostics) {}
 
     void handle(const VariableSymbol& symbol) {
         NEEDS_SKIP_SYMBOL(symbol)
-
         if (symbol.drivers().empty())
             return;
 
         auto firstDriver = *symbol.drivers().begin();
         if (firstDriver && firstDriver->isInAlwaysFFBlock()) {
-            AlwaysFFVisitor visitor(symbol.name, config.getCheckConfigs().resetName);
+            auto& configs = config.getCheckConfigs();
+            AlwaysFFVisitor visitor(symbol.name, configs.resetName, configs.resetIsActiveHigh);
             firstDriver->containingSymbol->visit(visitor);
             if (visitor.hasError()) {
-                diags.add(diag::OnlyAssignedOnReset, symbol.location) << symbol.name;
+                diags.add(diag::RegisterNotAssignedOnReset,
+                          visitor.getErrorLocation().value_or(symbol.location))
+                    << symbol.name;
             }
         }
     }

--- a/tools/tidy/src/synthesis/RegisterHasNoReset.cpp
+++ b/tools/tidy/src/synthesis/RegisterHasNoReset.cpp
@@ -120,9 +120,7 @@ public:
     bool check(const RootSymbol& root) override {
         MainVisitor visitor(diagnostics);
         root.visit(visitor);
-        if (!diagnostics.empty())
-            return false;
-        return true;
+        return diagnostics.empty();
     }
 
     DiagCode diagCode() const override { return diag::RegisterNotAssignedOnReset; }

--- a/tools/tidy/src/synthesis/RegisterHasNoReset.cpp
+++ b/tools/tidy/src/synthesis/RegisterHasNoReset.cpp
@@ -13,8 +13,10 @@ using namespace slang::ast;
 
 namespace register_has_no_reset {
 struct AlwaysFFVisitor : public ASTVisitor<AlwaysFFVisitor, true, true> {
-    explicit AlwaysFFVisitor(const std::string_view name, const std::string_view resetName) :
-        name(name), resetName(resetName) {};
+    explicit AlwaysFFVisitor(const std::string_view name, const std::string_view resetName,
+                             const bool resetIsActiveHigh) :
+        name(name),
+        resetName(resetName), resetIsActiveHigh(resetIsActiveHigh){};
 
     void handle(const ConditionalStatement& statement) {
         // Early return, if there's no else clause on the conditional statement
@@ -22,27 +24,46 @@ struct AlwaysFFVisitor : public ASTVisitor<AlwaysFFVisitor, true, true> {
             return;
         }
 
-        // Collect all the identifiers in the conditions
-        CollectIdentifiers collectIdentifiersVisitor;
+        // Check if there is a reset in the conditional statement and if the signal is negated
+        bool isReset = false;
+        bool isResetNeg = false;
+
+        LookupIdentifier lookupIdentifierVisitor(resetName, false);
         for (const auto& condition : statement.conditions) {
-            condition.expr->visit(collectIdentifiersVisitor);
+            condition.expr->visit(lookupIdentifierVisitor);
+            isReset = lookupIdentifierVisitor.found();
+
+            if (isReset) {
+                if (condition.expr->kind == ExpressionKind::UnaryOp) {
+                    auto op = condition.expr->as<UnaryExpression>().op;
+                    isResetNeg = (op == UnaryOperator::BitwiseNot) ||
+                                 (op == UnaryOperator::LogicalNot);
+                }
+                break;
+            }
         }
 
-        // Check if one of the identifiers is a reset
-        const auto isReset =
-            std::ranges::any_of(collectIdentifiersVisitor.identifiers, [this](auto id) {
-                return id.find(resetName) != std::string_view::npos;
-            });
+        if (!isReset)
+            return;
 
-        if (isReset) {
-            LookupLhsIdentifier visitor(name);
-            statement.ifFalse->visit(visitor);
-            if (visitor.found()) {
-                visitor.reset();
-                statement.ifTrue.visit(visitor);
-                if (!visitor.found()) {
-                    correctlyAssignedOnIfReset = true;
-                }
+        auto resetStatement = &statement.ifTrue;
+        auto noResetStatement = statement.ifFalse;
+
+        bool swapStatements = isResetNeg ? !resetIsActiveHigh : resetIsActiveHigh;
+
+        if (swapStatements) {
+            std::swap(resetStatement, noResetStatement);
+        }
+
+        LookupLhsIdentifier visitor(name);
+        noResetStatement->visit(visitor);
+        if (visitor.found()) {
+            auto foundLocation = visitor.foundLocation();
+            visitor.reset();
+            resetStatement->visit(visitor);
+            if (!visitor.found()) {
+                correctlyAssignedOnIfReset = true;
+                errorLocation = foundLocation;
             }
         }
     }
@@ -55,10 +76,16 @@ struct AlwaysFFVisitor : public ASTVisitor<AlwaysFFVisitor, true, true> {
 
     bool hasError() { return correctlyAssignedOnIfReset && !assignedOutsideIfReset; }
 
+    std::optional<SourceLocation> getErrorLocation() const { return errorLocation; }
+
+private:
     const std::string_view name;
     const std::string_view resetName;
+    const bool resetIsActiveHigh;
+
     bool correctlyAssignedOnIfReset = false;
     bool assignedOutsideIfReset = false;
+    std::optional<SourceLocation> errorLocation;
 };
 
 struct MainVisitor : public TidyVisitor, ASTVisitor<MainVisitor, true, true> {
@@ -71,10 +98,13 @@ struct MainVisitor : public TidyVisitor, ASTVisitor<MainVisitor, true, true> {
 
         auto firstDriver = *symbol.drivers().begin();
         if (firstDriver && firstDriver->isInAlwaysFFBlock()) {
-            AlwaysFFVisitor visitor(symbol.name, config.getCheckConfigs().resetName);
+            auto& configs = config.getCheckConfigs();
+            AlwaysFFVisitor visitor(symbol.name, configs.resetName, configs.resetIsActiveHigh);
             firstDriver->containingSymbol->visit(visitor);
             if (visitor.hasError()) {
-                diags.add(diag::RegisterNotAssignedOnReset, symbol.location) << symbol.name;
+                diags.add(diag::RegisterNotAssignedOnReset,
+                          visitor.getErrorLocation().value_or(symbol.location))
+                    << symbol.name;
             }
         }
     }

--- a/tools/tidy/src/synthesis/UnusedSensitiveSignal.cpp
+++ b/tools/tidy/src/synthesis/UnusedSensitiveSignal.cpp
@@ -1,0 +1,92 @@
+// SPDX-FileCopyrightText: Michael Popoloski
+// SPDX-License-Identifier: MIT
+
+#include "ASTHelperVisitors.h"
+#include "TidyDiags.h"
+#include "fmt/color.h"
+#include <algorithm>
+
+#include "slang/syntax/AllSyntax.h"
+
+using namespace slang;
+using namespace slang::ast;
+
+namespace unused_sensitive_signal {
+
+struct MainVisitor : public TidyVisitor, ASTVisitor<MainVisitor, true, true> {
+    explicit MainVisitor(Diagnostics& diagnostics) : TidyVisitor(diagnostics) {}
+
+    struct CollectAllIdentifiers
+        : public slang::ast::ASTVisitor<CollectAllIdentifiers, true, true> {
+        void handle(const slang::ast::NamedValueExpression& expression) {
+            if (auto* symbol = expression.getSymbolReference(); symbol && expression.syntax) {
+                identifiers.push_back(
+                    std::make_pair(symbol->name, getExpressionSourceLocation(expression).value()));
+            }
+        }
+        std::vector<std::pair<std::string_view, SourceLocation>> identifiers;
+    };
+
+    void handle(const ProceduralBlockSymbol& block) {
+        NEEDS_SKIP_SYMBOL(block)
+
+        if (block.procedureKind != ProceduralBlockKind::AlwaysFF &&
+            block.procedureKind != ProceduralBlockKind::Always)
+            return;
+
+        CollectAllIdentifiers stmtIdVisitor, timingIdVisitor;
+        block.getBody().as<TimedStatement>().stmt.as<BlockStatement>().visitStmts(stmtIdVisitor);
+        block.getBody().as<TimedStatement>().timing.visit(timingIdVisitor);
+
+        auto compare = [](const auto& a, const auto& b) { return a.first < b.first; };
+
+        std::sort(timingIdVisitor.identifiers.begin(), timingIdVisitor.identifiers.end(), compare);
+        std::sort(stmtIdVisitor.identifiers.begin(), stmtIdVisitor.identifiers.end(), compare);
+
+        std::vector<std::pair<std::string_view, SourceLocation>> unusedSignals;
+
+        std::set_difference(timingIdVisitor.identifiers.begin(), timingIdVisitor.identifiers.end(),
+                            stmtIdVisitor.identifiers.begin(), stmtIdVisitor.identifiers.end(),
+                            std::back_inserter(unusedSignals), compare);
+
+        for (auto signal : unusedSignals) {
+            if (signal.first != config.getCheckConfigs().clkName)
+                diags.add(diag::UnusedSensitiveSignal, signal.second) << signal.first;
+        }
+    }
+};
+} // namespace unused_sensitive_signal
+
+using namespace unused_sensitive_signal;
+
+class UnusedSensitiveSignal : public TidyCheck {
+public:
+    [[maybe_unused]] explicit UnusedSensitiveSignal(TidyKind kind) : TidyCheck(kind) {}
+
+    bool check(const RootSymbol& root) override {
+        MainVisitor visitor(diagnostics);
+        root.visit(visitor);
+        return diagnostics.empty();
+    }
+
+    DiagCode diagCode() const override { return diag::UnusedSensitiveSignal; }
+
+    std::string diagString() const override {
+        return "the signal '{}' is in the sensitivity list of a procedural block but is never "
+               "referenced in the statement. Consider using the signal inside the procedural block "
+               "or removing it from the sensitivity list";
+    }
+
+    DiagnosticSeverity diagSeverity() const override { return DiagnosticSeverity::Warning; }
+
+    std::string name() const override { return "UnusedSensitiveSignal"; }
+
+    std::string description() const override { return shortDescription(); }
+
+    std::string shortDescription() const override {
+        return "A signal inside the sensitivity list is never used in the statement of the "
+               "procedural block.";
+    }
+};
+
+REGISTER(UnusedSensitiveSignal, UnusedSensitiveSignal, TidyKind::Synthesis)

--- a/tools/tidy/tests/AlwaysCombNamedTest.cpp
+++ b/tools/tidy/tests/AlwaysCombNamedTest.cpp
@@ -1,0 +1,82 @@
+// SPDX-FileCopyrightText: Michael Popoloski
+// SPDX-License-Identifier: MIT
+
+#include "Test.h"
+#include "TidyFactory.h"
+
+TEST_CASE("AlwaysCombBlockNamed: Unnamed always_comb block") {
+    auto tree = SyntaxTree::fromText(R"(
+module top ();
+    logic a, b;
+    always_comb begin
+        a = b;
+    end
+endmodule
+)");
+
+    Compilation compilation;
+    compilation.addSyntaxTree(tree);
+    compilation.getAllDiagnostics();
+    auto& root = compilation.getRoot();
+
+    TidyConfig config;
+    Registry::setConfig(config);
+    Registry::setSourceManager(compilation.getSourceManager());
+    auto visitor = Registry::create("AlwaysCombBlockNamed");
+    bool result = visitor->check(root);
+    CHECK_FALSE(result);
+}
+
+TEST_CASE("AlwaysCombBlockNamed: Named always_comb block") {
+    auto tree = SyntaxTree::fromText(R"(
+module top ();
+    logic a, b;
+    always_comb begin : named_comb2
+        a = b;
+    end
+endmodule
+)");
+
+    Compilation compilation;
+    compilation.addSyntaxTree(tree);
+    compilation.getAllDiagnostics();
+    auto& root = compilation.getRoot();
+
+    TidyConfig config;
+    Registry::setConfig(config);
+    Registry::setSourceManager(compilation.getSourceManager());
+    auto visitor = Registry::create("AlwaysCombBlockNamed");
+    bool result = visitor->check(root);
+    CHECK(result);
+}
+
+TEST_CASE("AlwaysCombBlockNamed: Unnamed simple always_comb block") {
+    auto tree = SyntaxTree::fromText(R"(
+module add_or_sub
+    #(parameter N = 4)
+    (
+        input logic [N-1:0] x_i, y_i,
+        input logic add,
+        output logic [N-1:0] z_o
+    );
+    
+    always_comb
+        if (add)
+            z = x + y;
+        else
+            z = x - y;
+endmodule
+)");
+
+    Compilation compilation;
+    compilation.addSyntaxTree(tree);
+    compilation.getAllDiagnostics();
+    auto& root = compilation.getRoot();
+
+    TidyConfig config;
+    Registry::setConfig(config);
+    Registry::setSourceManager(compilation.getSourceManager());
+    auto visitor = Registry::create("AlwaysCombBlockNamed");
+    bool result = visitor->check(root);
+    CHECK(result);
+}

--- a/tools/tidy/tests/AlwaysFFAssignmentOutsideConditionalTest.cpp
+++ b/tools/tidy/tests/AlwaysFFAssignmentOutsideConditionalTest.cpp
@@ -1,0 +1,67 @@
+// SPDX-FileCopyrightText: Michael Popoloski
+// SPDX-License-Identifier: MIT
+
+#include "Test.h"
+#include "TidyFactory.h"
+
+TEST_CASE("AlwaysFFAssignmentOutsideConditional: Assignment inside always_ff and outside if "
+          "statement with reset") {
+    auto tree = SyntaxTree::fromText(R"(
+module top;
+    logic clk_i;
+    logic rst_ni;
+    logic foo, bar;
+    int a;
+
+    always_ff @(posedge clk_i or negedge rst_ni) begin
+        foo <= bar;
+        if(rst_ni) a <= '0;
+        else    a <= a +1;
+    end
+endmodule
+)");
+
+    Compilation compilation;
+    compilation.addSyntaxTree(tree);
+    compilation.getAllDiagnostics();
+    auto& root = compilation.getRoot();
+
+    TidyConfig config;
+    Registry::setConfig(config);
+    Registry::setSourceManager(compilation.getSourceManager());
+    auto visitor = Registry::create("AlwaysFFAssignmentOutsideConditional");
+    bool result = visitor->check(root);
+    CHECK_FALSE(result);
+}
+
+TEST_CASE("AlwaysFFAssignmentOutsideConditional: All assignments inside either if or else "
+          "statements inside the always_ff block") {
+    auto tree = SyntaxTree::fromText(R"(
+module top;
+    logic clk_i;
+    logic rst_ni;
+    logic a, b;
+
+    always_ff @(posedge clk_i or negedge rst_ni) begin
+        if (~rst_ni) begin
+            a <= '0;
+        end else begin
+            a <= 1'b1;
+            b <= 1'b1;
+        end
+    end
+endmodule
+)");
+
+    Compilation compilation;
+    compilation.addSyntaxTree(tree);
+    compilation.getAllDiagnostics();
+    auto& root = compilation.getRoot();
+
+    TidyConfig config;
+    Registry::setConfig(config);
+    Registry::setSourceManager(compilation.getSourceManager());
+    auto visitor = Registry::create("AlwaysFFAssignmentOutsideConditional");
+    bool result = visitor->check(root);
+    CHECK(result);
+}

--- a/tools/tidy/tests/CMakeLists.txt
+++ b/tools/tidy/tests/CMakeLists.txt
@@ -25,6 +25,7 @@ add_executable(
   GenerateNamedTest.cpp
   NoDotVarInPortConnectionTest.cpp
   NoLegacyGenerateTest.cpp
+  AlwaysFFAssignmentOutsideConditionalTest.cpp
   )
 
 target_link_libraries(tidy_unittests PRIVATE Catch2::Catch2 slang_tidy_obj_lib)

--- a/tools/tidy/tests/CMakeLists.txt
+++ b/tools/tidy/tests/CMakeLists.txt
@@ -20,7 +20,9 @@ add_executable(
   XilinxDoNotCareValuesTest.cpp
   CastSignedIndexTest.cpp
   NoDotStarInPortConnectionTest.cpp
-  NoImplicitPortNameInPortConnectionTest.cpp)
+  NoImplicitPortNameInPortConnectionTest.cpp
+  AlwaysCombNamedTest.cpp
+  )
 
 target_link_libraries(tidy_unittests PRIVATE Catch2::Catch2 slang_tidy_obj_lib)
 target_compile_definitions(tidy_unittests PRIVATE UNITTESTS)

--- a/tools/tidy/tests/CMakeLists.txt
+++ b/tools/tidy/tests/CMakeLists.txt
@@ -23,6 +23,7 @@ add_executable(
   NoImplicitPortNameInPortConnectionTest.cpp
   AlwaysCombNamedTest.cpp
   GenerateNamedTest.cpp
+  NoDotVarInPortConnectionTest.cpp
   )
 
 target_link_libraries(tidy_unittests PRIVATE Catch2::Catch2 slang_tidy_obj_lib)

--- a/tools/tidy/tests/CMakeLists.txt
+++ b/tools/tidy/tests/CMakeLists.txt
@@ -26,6 +26,7 @@ add_executable(
   NoDotVarInPortConnectionTest.cpp
   NoLegacyGenerateTest.cpp
   AlwaysFFAssignmentOutsideConditionalTest.cpp
+  UnusedSensitiveSignalTest.cpp
   )
 
 target_link_libraries(tidy_unittests PRIVATE Catch2::Catch2 slang_tidy_obj_lib)

--- a/tools/tidy/tests/CMakeLists.txt
+++ b/tools/tidy/tests/CMakeLists.txt
@@ -22,6 +22,7 @@ add_executable(
   NoDotStarInPortConnectionTest.cpp
   NoImplicitPortNameInPortConnectionTest.cpp
   AlwaysCombNamedTest.cpp
+  GenerateNamedTest.cpp
   )
 
 target_link_libraries(tidy_unittests PRIVATE Catch2::Catch2 slang_tidy_obj_lib)

--- a/tools/tidy/tests/CMakeLists.txt
+++ b/tools/tidy/tests/CMakeLists.txt
@@ -24,6 +24,7 @@ add_executable(
   AlwaysCombNamedTest.cpp
   GenerateNamedTest.cpp
   NoDotVarInPortConnectionTest.cpp
+  NoLegacyGenerateTest.cpp
   )
 
 target_link_libraries(tidy_unittests PRIVATE Catch2::Catch2 slang_tidy_obj_lib)

--- a/tools/tidy/tests/GenerateNamedTest.cpp
+++ b/tools/tidy/tests/GenerateNamedTest.cpp
@@ -1,0 +1,178 @@
+// SPDX-FileCopyrightText: Michael Popoloski
+// SPDX-License-Identifier: MIT
+
+#include "Test.h"
+#include "TidyFactory.h"
+
+TEST_CASE("GenerateNamed: Unnamed generate block") {
+    auto tree = SyntaxTree::fromText(R"(
+module eq_n
+	#( parameter N =4)
+	(
+		input logic [N -1:0] a , b ,
+		output logic eq
+	) ;
+	logic [N -1:0] tmp ;
+	generate begin
+		genvar i ;
+		for ( i = 0; i < N ; i = i + 1)
+			xnor gen_u ( tmp [ i ] , a [ i ] , b [ i ]) ;
+	end
+	endgenerate
+
+	assign eq = & tmp ;
+endmodule
+
+)");
+
+    Compilation compilation;
+    compilation.addSyntaxTree(tree);
+    compilation.getAllDiagnostics();
+    auto& root = compilation.getRoot();
+
+    TidyConfig config;
+    Registry::setConfig(config);
+    Registry::setSourceManager(compilation.getSourceManager());
+    auto visitor = Registry::create("GenerateNamed");
+    bool result = visitor->check(root);
+    CHECK_FALSE(result);
+}
+
+TEST_CASE("GenerateNamed: Named generate block") {
+    auto tree = SyntaxTree::fromText(R"(
+module eq_n
+	#( parameter N =4)
+	(
+		input logic [N -1:0] a , b ,
+		output logic eq
+	) ;
+	logic [N -1:0] tmp ;
+	generate begin : gen_named
+		genvar i ;
+		for ( i = 0; i < N ; i = i + 1)
+			xnor gen_u ( tmp [ i ] , a [ i ] , b [ i ]) ;
+	end
+	endgenerate
+
+	assign eq = & tmp ;
+endmodule
+
+)");
+
+    Compilation compilation;
+    compilation.addSyntaxTree(tree);
+    compilation.getAllDiagnostics();
+    auto& root = compilation.getRoot();
+
+    TidyConfig config;
+    Registry::setConfig(config);
+    Registry::setSourceManager(compilation.getSourceManager());
+    auto visitor = Registry::create("GenerateNamed");
+    bool result = visitor->check(root);
+    CHECK(result);
+}
+
+TEST_CASE("GenerateNamed: Unnamed simple generate block") {
+    auto tree = SyntaxTree::fromText(R"(
+module eq_n
+	#( parameter N =4)
+	(
+		input logic [N -1:0] a , b ,
+		output logic eq
+	) ;
+	logic [N -1:0] tmp ;
+	generate
+		genvar i ;
+		for ( i = 0; i < N ; i = i + 1)
+			xnor gen_u ( tmp [ i ] , a [ i ] , b [ i ]) ;
+	endgenerate
+
+	assign eq = & tmp ;
+endmodule
+
+)");
+
+    Compilation compilation;
+    compilation.addSyntaxTree(tree);
+    compilation.getAllDiagnostics();
+    auto& root = compilation.getRoot();
+
+    TidyConfig config;
+    Registry::setConfig(config);
+    Registry::setSourceManager(compilation.getSourceManager());
+    auto visitor = Registry::create("GenerateNamed");
+    bool result = visitor->check(root);
+    CHECK_FALSE(result);
+}
+
+TEST_CASE("GenerateNamed: Unnamed for block") {
+    auto tree = SyntaxTree::fromText(R"(
+module full_adder(
+  input a, b, cin,
+  output sum, cout
+);
+  
+  assign {sum, cout} = {a^b^cin, ((a & b) | (b & cin) | (a & cin))};
+endmodule
+
+module ripple_carry_adder #(parameter SIZE = 4) (
+  input [SIZE-1:0] A, B, 
+  input Cin,
+  output [SIZE-1:0] S, Cout);
+
+  full_adder fa0(A[0], B[0], Cin, S[0], Cout[0]);
+  
+  for(genvar g = 1; g<SIZE; g++) begin
+    full_adder fa(A[g], B[g], Cout[g-1], S[g], Cout[g]);
+  end
+endmodule
+)");
+
+    Compilation compilation;
+    compilation.addSyntaxTree(tree);
+    compilation.getAllDiagnostics();
+    auto& root = compilation.getRoot();
+
+    TidyConfig config;
+    Registry::setConfig(config);
+    Registry::setSourceManager(compilation.getSourceManager());
+    auto visitor = Registry::create("GenerateNamed");
+    bool result = visitor->check(root);
+    CHECK_FALSE(result);
+}
+
+TEST_CASE("GenerateNamed: Named for block") {
+    auto tree = SyntaxTree::fromText(R"(
+module full_adder(
+  input a, b, cin,
+  output sum, cout
+);
+  
+  assign {sum, cout} = {a^b^cin, ((a & b) | (b & cin) | (a & cin))};
+endmodule
+
+module ripple_carry_adder #(parameter SIZE = 4) (
+  input [SIZE-1:0] A, B, 
+  input Cin,
+  output [SIZE-1:0] S, Cout);
+
+  full_adder fa0(A[0], B[0], Cin, S[0], Cout[0]);
+  
+  for(genvar g = 1; g<SIZE; g++) begin: foo
+    full_adder fa(A[g], B[g], Cout[g-1], S[g], Cout[g]);
+  end
+endmodule
+)");
+
+    Compilation compilation;
+    compilation.addSyntaxTree(tree);
+    compilation.getAllDiagnostics();
+    auto& root = compilation.getRoot();
+
+    TidyConfig config;
+    Registry::setConfig(config);
+    Registry::setSourceManager(compilation.getSourceManager());
+    auto visitor = Registry::create("GenerateNamed");
+    bool result = visitor->check(root);
+    CHECK(result);
+}

--- a/tools/tidy/tests/NoDotVarInPortConnectionTest.cpp
+++ b/tools/tidy/tests/NoDotVarInPortConnectionTest.cpp
@@ -1,0 +1,77 @@
+// SPDX-FileCopyrightText: Michael Popoloski
+// SPDX-License-Identifier: MIT
+
+#include "Test.h"
+#include "TidyFactory.h"
+
+TEST_CASE("NoDotVarInPortConnection: Use of dot var in module port connection") {
+    auto tree = SyntaxTree::fromText(R"(
+module test (input clk, input rst);
+endmodule
+
+module top ();
+    logic clk, rst;
+    test t (.clk(clk), .rst);
+endmodule
+)");
+
+    Compilation compilation;
+    compilation.addSyntaxTree(tree);
+    compilation.getAllDiagnostics();
+    auto& root = compilation.getRoot();
+
+    TidyConfig config;
+    Registry::setConfig(config);
+    Registry::setSourceManager(compilation.getSourceManager());
+    auto visitor = Registry::create("NoDotVarInPortConnection");
+    bool result = visitor->check(root);
+    CHECK_FALSE(result);
+}
+
+TEST_CASE("NoDotVarInPortConnection: Module port connection port by port") {
+    auto tree = SyntaxTree::fromText(R"(
+module test (input clk, input rst);
+endmodule
+
+module top ();
+    logic clk, rst;
+    test t (.clk(clk), .rst(rst));
+endmodule
+)");
+
+    Compilation compilation;
+    compilation.addSyntaxTree(tree);
+    compilation.getAllDiagnostics();
+    auto& root = compilation.getRoot();
+
+    TidyConfig config;
+    Registry::setConfig(config);
+    Registry::setSourceManager(compilation.getSourceManager());
+    auto visitor = Registry::create("NoDotVarInPortConnection");
+    bool result = visitor->check(root);
+    CHECK(result);
+}
+
+TEST_CASE("NoDotVarInPortConnection: Use of dot star in module port connection") {
+    auto tree = SyntaxTree::fromText(R"(
+module test (input clk, input rst);
+endmodule
+
+module top ();
+    logic clk, rst;
+    test t (.*);
+endmodule
+)");
+
+    Compilation compilation;
+    compilation.addSyntaxTree(tree);
+    compilation.getAllDiagnostics();
+    auto& root = compilation.getRoot();
+
+    TidyConfig config;
+    Registry::setConfig(config);
+    Registry::setSourceManager(compilation.getSourceManager());
+    auto visitor = Registry::create("NoDotVarInPortConnection");
+    bool result = visitor->check(root);
+    CHECK(result);
+}

--- a/tools/tidy/tests/NoLegacyGenerateTest.cpp
+++ b/tools/tidy/tests/NoLegacyGenerateTest.cpp
@@ -1,0 +1,128 @@
+// SPDX-FileCopyrightText: Michael Popoloski
+// SPDX-License-Identifier: MIT
+
+#include "Test.h"
+#include "TidyFactory.h"
+
+TEST_CASE("NoLegacyGenerate: For loop inside generate block") {
+    auto tree = SyntaxTree::fromText(R"(
+module eq_n
+	#( parameter N =4)
+	(
+		input logic [N -1:0] a , b ,
+		output logic eq
+	) ;
+	logic [N -1:0] tmp ;
+	generate begin : named_generate
+		genvar i ;
+		for ( i = 0; i < N ; i = i + 1)
+			xnor gen_u ( tmp [ i ] , a [ i ] , b [ i ]) ;
+	end
+	endgenerate
+endmodule
+)");
+
+    Compilation compilation;
+    compilation.addSyntaxTree(tree);
+    compilation.getAllDiagnostics();
+    auto& root = compilation.getRoot();
+
+    TidyConfig config;
+    Registry::setConfig(config);
+    Registry::setSourceManager(compilation.getSourceManager());
+    auto visitor = Registry::create("NoLegacyGenerate");
+    bool result = visitor->check(root);
+    CHECK_FALSE(result);
+}
+
+TEST_CASE("NoLegacyGenerate: For loop inside unnamed generate block") {
+    auto tree = SyntaxTree::fromText(R"(
+module eq_n
+	#( parameter N =4)
+	(
+		input logic [N -1:0] a , b ,
+		output logic eq
+	) ;
+	logic [N -1:0] tmp ;
+	generate
+		genvar i ;
+		for ( i = 0; i < N ; i = i + 1)
+			xnor gen_u ( tmp [ i ] , a [ i ] , b [ i ]) ;
+	endgenerate
+endmodule
+)");
+
+    Compilation compilation;
+    compilation.addSyntaxTree(tree);
+    compilation.getAllDiagnostics();
+    auto& root = compilation.getRoot();
+
+    TidyConfig config;
+    Registry::setConfig(config);
+    Registry::setSourceManager(compilation.getSourceManager());
+    auto visitor = Registry::create("NoLegacyGenerate");
+    bool result = visitor->check(root);
+    CHECK_FALSE(result);
+}
+
+TEST_CASE("NoLegacyGenerate: For loop, no generate block") {
+    auto tree = SyntaxTree::fromText(R"(
+module eq_n
+	#( parameter N =4)
+	(
+		input logic [N -1:0] a , b ,
+		output logic eq
+	) ;
+	logic [N -1:0] tmp ;
+    for (genvar i = 0; i < N ; i = i + 1)
+        xnor gen_u ( tmp [ i ] , a [ i ] , b [ i ]) ;
+endmodule
+)");
+
+    Compilation compilation;
+    compilation.addSyntaxTree(tree);
+    compilation.getAllDiagnostics();
+    auto& root = compilation.getRoot();
+
+    TidyConfig config;
+    Registry::setConfig(config);
+    Registry::setSourceManager(compilation.getSourceManager());
+    auto visitor = Registry::create("NoLegacyGenerate");
+    bool result = visitor->check(root);
+    CHECK(result);
+}
+
+TEST_CASE("NoLegacyGenerate: For loop inside conditional block") {
+    auto tree = SyntaxTree::fromText(R"(
+module eq_n
+	#(
+        parameter N = 4,
+        parameter cond = 0
+    )
+	(
+		input logic [N -1:0] a , b ,
+		output logic eq
+	) ;
+	logic [N -1:0] tmp ;
+    if (cond) begin
+        for (genvar i = 0; i < N ; i = i + 1) begin : foo_name
+            xnor gen_u ( tmp [ i ] , a [ i ] , b [ i ]) ;
+        end
+    end
+
+endmodule
+
+)");
+
+    Compilation compilation;
+    compilation.addSyntaxTree(tree);
+    compilation.getAllDiagnostics();
+    auto& root = compilation.getRoot();
+
+    TidyConfig config;
+    Registry::setConfig(config);
+    Registry::setSourceManager(compilation.getSourceManager());
+    auto visitor = Registry::create("NoLegacyGenerate");
+    bool result = visitor->check(root);
+    CHECK(result);
+}

--- a/tools/tidy/tests/OnlyAssignedOnResetTest.cpp
+++ b/tools/tidy/tests/OnlyAssignedOnResetTest.cpp
@@ -239,3 +239,39 @@ endmodule
     bool result = visitor->check(root);
     CHECK_FALSE(result);
 }
+
+TEST_CASE("OnlyAssignedOnReset: Struct only assigned on reset, reset signal inversed") {
+    auto tree = SyntaxTree::fromText(R"(
+module top;
+    logic clk_i;
+    logic rst_ni;
+    struct {
+        logic a;
+        logic b;
+        logic c;
+    } data;
+
+    always_ff @(posedge clk_i or negedge rst_ni) begin
+        if (rst_ni) begin
+        end
+        else begin
+            data.a <= 1'b0;
+            data.b <= 1'b0;
+            data.c <= 1'b0;
+        end
+    end
+endmodule
+)");
+
+    Compilation compilation;
+    compilation.addSyntaxTree(tree);
+    compilation.getAllDiagnostics();
+    auto& root = compilation.getRoot();
+
+    TidyConfig config;
+    Registry::setConfig(config);
+    Registry::setSourceManager(compilation.getSourceManager());
+    auto visitor = Registry::create("OnlyAssignedOnReset");
+    bool result = visitor->check(root);
+    CHECK_FALSE(result);
+}

--- a/tools/tidy/tests/UnusedSensitiveSignalTest.cpp
+++ b/tools/tidy/tests/UnusedSensitiveSignalTest.cpp
@@ -1,0 +1,92 @@
+// SPDX-FileCopyrightText: Michael Popoloski
+// SPDX-License-Identifier: MIT
+
+#include "Test.h"
+#include "TidyFactory.h"
+
+TEST_CASE("UnusedSensitiveSignal: Unused sensitive signal in always block") {
+    auto tree = SyntaxTree::fromText(R"(
+module d_ff_en
+(
+    input int a_i, b_i, c_i,
+    
+    output int sum_o
+) ;
+always @ (a_i , b_i, c_i ) begin
+    sum_o = a_i + b_i ;
+end
+endmodule
+)");
+
+    Compilation compilation;
+    compilation.addSyntaxTree(tree);
+    compilation.getAllDiagnostics();
+    auto& root = compilation.getRoot();
+
+    TidyConfig config;
+    Registry::setConfig(config);
+    Registry::setSourceManager(compilation.getSourceManager());
+    auto visitor = Registry::create("UnusedSensitiveSignal");
+    bool result = visitor->check(root);
+    CHECK_FALSE(result);
+}
+
+TEST_CASE("UnusedSensitiveSignal: Unused sensitive signal in always_ff block") {
+    auto tree = SyntaxTree::fromText(R"(
+module d_ff_en
+(
+    input logic clk_i, rst_i, en_i, c_i, d_i,
+    
+    output logic q_o
+) ;
+always_ff @ (posedge clk_i, posedge rst_i, c_i) begin
+    if (rst_i)
+        q_o <= '0;
+    else if (en_i)
+        q_o <= d_i;
+    end
+endmodule
+)");
+
+    Compilation compilation;
+    compilation.addSyntaxTree(tree);
+    compilation.getAllDiagnostics();
+    auto& root = compilation.getRoot();
+
+    TidyConfig config;
+    Registry::setConfig(config);
+    Registry::setSourceManager(compilation.getSourceManager());
+    auto visitor = Registry::create("UnusedSensitiveSignal");
+    bool result = visitor->check(root);
+    CHECK_FALSE(result);
+}
+
+TEST_CASE("UnusedSensitiveSignal: All sensitive signal in always_ff block have been used") {
+    auto tree = SyntaxTree::fromText(R"(
+module d_ff_en
+(
+    input logic clk_i, rst_i, en_i, c_i, d_i,
+    
+    output logic q_o
+) ;
+always_ff @ (posedge clk_i, posedge rst_i) begin
+    if (rst_i)
+        q_o <= '0;
+    else if (en_i)
+        q_o <= d_i;
+    end
+endmodule
+)");
+
+    Compilation compilation;
+    compilation.addSyntaxTree(tree);
+    compilation.getAllDiagnostics();
+    auto& root = compilation.getRoot();
+
+    TidyConfig config;
+    Registry::setConfig(config);
+    Registry::setSourceManager(compilation.getSourceManager());
+    auto visitor = Registry::create("UnusedSensitiveSignal");
+    bool result = visitor->check(root);
+    CHECK(result);
+}


### PR DESCRIPTION
This PR adds some new slang-tidy checks, along with some minor fixes to existing ones, mainly aiming to throw the warnings in a more precise location. The new slang-tidy checks added to this PR are the following:

### style checks
* _AlwaysCombNamed_
This check ensures that all always_comb blocks have a name

* _GenerateNamed_
Similar to the previous check, this ensures that all generate blocks are named, including for loops

* _NoDotVarInPortConnection_
A check analogous to _NoDotStarInPortConnection_, enforces that no '.var' is used in port connection, and '.var(var)' should be used instead

* _NoLegacyGenerate_
This check enforces that no generate block is used in the code, since it is an old system verilog syntax

### synthesis checks
* _AlwaysFFAssignmentOutsideConditional_
Check that ensures that if there is a conditional block with reset, all the assignments must be either inside the if or else statements

* _UnusedSensitiveSignal_
This check verifies that every signal inside the sensitivity list of an 'always' or 'always_ff' block is used inside the block statement. The only exception is the clock signal
