### PR TITLE
[slang][port] Fix bugs

### DIFF
--- a/source/ast/symbols/PortSymbols.cpp
+++ b/source/ast/symbols/PortSymbols.cpp
@@ -1981,10 +1981,8 @@ void PortConnection::checkSimulatedNetTypes() const {
             }
         }
 
-        if (in == internal.end() || ex == external.end()) {
-            SLANG_ASSERT(in == internal.end() && ex == external.end());
+        if (in == internal.end() || ex == external.end())
             break;
-        }
 
         currBit += width;
     }
@@ -2069,7 +2067,7 @@ void PortConnection::makeConnections(
 }
 
 void PortConnection::serializeTo(ASTSerializer& serializer) const {
-    serializer.writeLink("port", port);
+    serializer.write("port", port);
     if (port.kind == SymbolKind::InterfacePort) {
         if (connectedSymbol)
             serializer.writeLink("ifaceInstance", *connectedSymbol);


### PR DESCRIPTION
Hello! 
1) This code is not serializing to json correctly. So I fixed PortConnection::serializeTo.

```verilog
module top;
    wire[1:0] net1;
    m loc({net1});
endmodule

module m({net1, net2});
    input wire net1, net2;
endmodule
```

serialization before:
```json
"connections": [
  {
    "port": "2199025177616 ",
    "expr": {
      "kind": "Concatenation",
      "type": "logic[1:0]",
      "operands": [
        {
          "kind": "NamedValue",
          "type": "logic[1:0]",
          "symbol": "2199025173856 net1"
        }
      ]
```

serialization now 
```json 
"connections": [
  {
    "port": {
      "name": "",
      "kind": "MultiPort",
      "addr": 2199025177616,
      "type": "logic[1:0]",
      "direction": "In",
      "ports": [
        {
          "type": "logic",
          "direction": "In",
          "internalSymbol": "2199025175320 net1"
        },
        {
          "type": "logic",
          "direction": "In",
          "internalSymbol": "2199025175720 net2"
        }
      ]


```
2)  When running a debug build on this code:  

```verilog
module top;
    wire net1;
    m loc({net1});
endmodule

module m({net1, net2});
    input wire net1, net2;
endmodule
```
``` 
 internal compiler error: Assertion 'in == internal.end() && ex == external.end()' failed
  in file /etc/slang/source/ast/symbols/PortSymbols.cpp, line 1982
  function: void slang::ast::PortConnection::checkSimulatedNetTypes() const
```

Slang was crashing with an assert. I couldn't understand why this assert was needed. I think it should just be removed from the code.