### PR TITLE
[slang] Fix PATHPULSE limit values

### DIFF
--- a/scripts/diagnostics.txt
+++ b/scripts/diagnostics.txt
@@ -262,7 +262,6 @@ error WrongSpecifyDelayCount "expected one, two, three, six, or twelve delay val
 error IfNoneEdgeSensitive "ifnone specify path cannot be an edge-sensitive path"
 error PulseControlSpecifyParent "pulse control specparams can only be declared in specify blocks"
 error PulseControlPATHPULSE "pulse control specparam names must start with 'PATHPULSE$'"
-error PulseControlTwoValues "pulse control specparams must be assigned two values (reject limit and error limit)"
 error TooManyEdgeDescriptors "cannot have more than six pairs of edge transitions in list"
 error EdgeDescWrongKeyword "edge descriptor list cannot be used after '{}'"
 error BindDirectiveInvalidName "bind target name must be a simple module or interface identifier when a list of instances is provided"

--- a/source/parsing/Parser_members.cpp
+++ b/source/parsing/Parser_members.cpp
@@ -3223,13 +3223,10 @@ SpecparamDeclaratorSyntax& Parser::parseSpecparamDeclarator(SyntaxKind parentKin
         closeParen = expect(TokenKind::CloseParenthesis);
 
     if (!name.isMissing()) {
-        if (isPathPulse) {
-            if (parentKind != SyntaxKind::SpecifyBlock)
-                addDiag(diag::PulseControlSpecifyParent, name.range());
-            else if (!expr2)
-                expr2 = &expr1;
-        }
-        else if (expr2) {
+        if (isPathPulse && parentKind != SyntaxKind::SpecifyBlock)
+            addDiag(diag::PulseControlSpecifyParent, name.range());
+
+        if (!isPathPulse && expr2) {
             auto last = expr2->getLastToken();
             SourceRange range(expr1.getFirstToken().location(),
                               last.location() + last.rawText().length());

--- a/source/parsing/Parser_members.cpp
+++ b/source/parsing/Parser_members.cpp
@@ -3227,7 +3227,7 @@ SpecparamDeclaratorSyntax& Parser::parseSpecparamDeclarator(SyntaxKind parentKin
             if (parentKind != SyntaxKind::SpecifyBlock)
                 addDiag(diag::PulseControlSpecifyParent, name.range());
             else if (!expr2)
-                addDiag(diag::PulseControlTwoValues, expr1.sourceRange()) << name.range();
+                expr2 = &expr1;
         }
         else if (expr2) {
             auto last = expr2->getLastToken();

--- a/tests/unittests/parsing/MemberParsingTests.cpp
+++ b/tests/unittests/parsing/MemberParsingTests.cpp
@@ -691,6 +691,20 @@ module m;
         specparam PATHPULSE$a$b = (1:2:3, 4:5:6);
     endspecify
 endmodule
+
+module m1;
+    specify
+        specparam PATHPULSE$ = 1;
+        specparam PATHPULSE$a$b = 1;
+    endspecify
+endmodule
+
+module m2;
+    specify
+        specparam PATHPULSE$ = (1);
+        specparam PATHPULSE$a$b = (1);
+    endspecify
+endmodule
 )";
 
     parseCompilationUnit(text);
@@ -710,10 +724,9 @@ endmodule
 
     parseCompilationUnit(text);
 
-    REQUIRE(diagnostics.size() == 3);
+    REQUIRE(diagnostics.size() == 2);
     CHECK(diagnostics[0].code == diag::PulseControlSpecifyParent);
-    CHECK(diagnostics[1].code == diag::PulseControlTwoValues);
-    CHECK(diagnostics[2].code == diag::PulseControlPATHPULSE);
+    CHECK(diagnostics[1].code == diag::PulseControlPATHPULSE);
 }
 
 TEST_CASE("Invalid package decls") {


### PR DESCRIPTION
In order to `SystemVerilog` LRM grammar it is legal to specialize only 1 value for both `PATHPULSE$` reject and error limits.

According to 30.7.1 section:

```
pulse_control_specparam ::=
          PATHPULSE$ = ( reject_limit_value [ , error_limit_value ] )
       | PATHPULSE$specify_input_terminal_descriptor$specify_output_terminal_descriptor
= ( reject_limit_value [ , error_limit_value ] )
```

At the text below LRM says:

"The path (data=>q) is not explicitly defined in any of the PATHPULSE$ declarations; therefore, it acquires reject and error limit of 3, as defined by the last PATHPULSE$ declaration." for such example:

```verilog
specify
...
    (data => q) = 10;
...
    specparam
    ...
        PATHPULSE$ = 3;
endspecify
```