### PR TITLE
[slang] Make string simple type

### DIFF
--- a/source/ast/types/Type.cpp
+++ b/source/ast/types/Type.cpp
@@ -317,6 +317,7 @@ bool Type::isSimpleType() const {
         case SymbolKind::FloatingType:
         case SymbolKind::TypeAlias:
         case SymbolKind::ClassType:
+        case SymbolKind::StringType:
             return true;
         default:
             return false;

--- a/tests/unittests/ast/MemberTests.cpp
+++ b/tests/unittests/ast/MemberTests.cpp
@@ -2756,3 +2756,25 @@ endmodule
   ]
 })");
 }
+
+TEST_CASE("IEEE 1800 Section 10.9.2 - structure assignment patterns") {
+    auto tree = SyntaxTree::fromText(R"(
+module top;
+   typedef struct {
+      logic [7:0] a;
+      bit b;
+      bit signed [31:0] c;
+      string s;
+   } sa;
+
+   sa s2;
+   initial s2 = '{int:1, default:0, string:""}; // set all to 0 except the
+                                                // array of bits to 1 and
+                                                // string to ""
+endmodule
+)");
+
+    Compilation compilation;
+    compilation.addSyntaxTree(tree);
+    NO_COMPILATION_ERRORS;
+}


### PR DESCRIPTION
To support such sample from SystemVerilog LRM section 10.9.2:

```verilog
module top;
   typedef struct {
      logic [7:0] a;
      bit b;
      bit signed [31:0] c;
      string s;
   } sa;
   
   sa s2;
   initial s2 = '{int:1, default:0, string:""}; // set all to 0 except the
                                                // array of bits to 1 and
                                                // string to ""
endmodule
```