### PR TITLE
Do not skip control characters embedded in malformed UTF-8 characters in comments

### DIFF
--- a/include/slang/text/CharInfo.h
+++ b/include/slang/text/CharInfo.h
@@ -197,21 +197,12 @@ constexpr const char* utf8Decode(const char* b, uint32_t* c, int* e, int& comput
     // For normal path, this should not be checked
     if (*e) {
         // if error, trim next pointer so that control char is read as next char
-        switch (len) {
-            case 4:
-                if (uc(b[3]) < 0x20)
-                    next--; // last byte in a 4-byte UTF8 is illegal
-                // fall through because earlier bytes might also be illegal
-                [[fallthrough]];
-            case 3:
-                if (uc(b[2]) < 0x20)
-                    next--;
-                [[fallthrough]];
-            case 2:
-                if (uc(b[1]) < 0x20)
-                    next--;
-                // No need for len==1 check because this would not be a unicode
-        }
+        if ((len > 1) && (uc(b[1]) < 0x20))
+            next = b + 1;
+        else if ((len > 2) && (uc(b[2]) < 0x20))
+            next = b + 2;
+        else if ((len > 3) && (uc(b[3]) < 0x20))
+            next = b + 3;
     }
 
     return next;

--- a/include/slang/text/CharInfo.h
+++ b/include/slang/text/CharInfo.h
@@ -202,9 +202,11 @@ constexpr const char* utf8Decode(const char* b, uint32_t* c, int* e, int& comput
                 if (uc(b[3]) < 0x20)
                     next--; // last byte in a 4-byte UTF8 is illegal
                 // fall through because earlier bytes might also be illegal
+                [[fallthrough]];
             case 3:
                 if (uc(b[2]) < 0x20)
                     next--;
+                [[fallthrough]];
             case 2:
                 if (uc(b[1]) < 0x20)
                     next--;

--- a/include/slang/text/CharInfo.h
+++ b/include/slang/text/CharInfo.h
@@ -194,7 +194,6 @@ constexpr const char* utf8Decode(const char* b, uint32_t* c, int* e, int& comput
     *e |= (uc(b[3])) >> 6;
     *e ^= 0x2a; // top two bits of each tail byte correct?
     *e >>= shifte[len];
-    // For normal path, this should not be checked
 
     return next;
 }

--- a/include/slang/text/CharInfo.h
+++ b/include/slang/text/CharInfo.h
@@ -200,15 +200,15 @@ constexpr const char* utf8Decode(const char* b, uint32_t* c, int* e, int& comput
         switch (len) {
             case 4:
                 if (uc(b[3]) < 0x20)
-                    next--; //last byte in a 4-byte UTF8 is illegal
-                    // fall through because earlier bytes might also be illegal
+                    next--; // last byte in a 4-byte UTF8 is illegal
+                // fall through because earlier bytes might also be illegal
             case 3:
                 if (uc(b[2]) < 0x20)
                     next--;
             case 2:
                 if (uc(b[1]) < 0x20)
                     next--;
-            // No need for len==1 check because this would not be a unicode
+                // No need for len==1 check because this would not be a unicode
         }
     }
 

--- a/include/slang/text/CharInfo.h
+++ b/include/slang/text/CharInfo.h
@@ -194,6 +194,23 @@ constexpr const char* utf8Decode(const char* b, uint32_t* c, int* e, int& comput
     *e |= (uc(b[3])) >> 6;
     *e ^= 0x2a; // top two bits of each tail byte correct?
     *e >>= shifte[len];
+    // For normal path, this should not be checked
+    if (*e) {
+        // if error, trim next pointer so that control char is read as next char
+        switch (len) {
+            case 4:
+                if (uc(b[3]) < 0x20)
+                    next--; //last byte in a 4-byte UTF8 is illegal
+                    // fall through because earlier bytes might also be illegal
+            case 3:
+                if (uc(b[2]) < 0x20)
+                    next--;
+            case 2:
+                if (uc(b[1]) < 0x20)
+                    next--;
+            // No need for len==1 check because this would not be a unicode
+        }
+    }
 
     return next;
 }

--- a/include/slang/text/CharInfo.h
+++ b/include/slang/text/CharInfo.h
@@ -195,15 +195,6 @@ constexpr const char* utf8Decode(const char* b, uint32_t* c, int* e, int& comput
     *e ^= 0x2a; // top two bits of each tail byte correct?
     *e >>= shifte[len];
     // For normal path, this should not be checked
-    if (*e) {
-        // if error, trim next pointer so that control char is read as next char
-        if ((len > 1) && (uc(b[1]) < 0x20))
-            next = b + 1;
-        else if ((len > 2) && (uc(b[2]) < 0x20))
-            next = b + 2;
-        else if ((len > 3) && (uc(b[3]) < 0x20))
-            next = b + 3;
-    }
 
     return next;
 }

--- a/source/parsing/Lexer.cpp
+++ b/source/parsing/Lexer.cpp
@@ -1239,7 +1239,10 @@ void Lexer::scanLineComment() {
             advance();
         }
         else {
-            sawUTF8Error |= !scanUTF8Char(sawUTF8Error);
+            auto error = !scanUTF8Char(sawUTF8Error);
+            sawUTF8Error |= error;
+            if (error)
+                errorCount--; // counter increment in scanUTF8Char()
         }
     }
     addTrivia(TriviaKind::LineComment);
@@ -1276,7 +1279,10 @@ void Lexer::scanBlockComment() {
             }
         }
         else {
-            sawUTF8Error |= !scanUTF8Char(sawUTF8Error);
+            auto error = !scanUTF8Char(sawUTF8Error);
+            sawUTF8Error |= error;
+            if (error)
+                errorCount--; // counter increment in scanUTF8Char()
         }
     }
 

--- a/source/parsing/Lexer.cpp
+++ b/source/parsing/Lexer.cpp
@@ -1306,6 +1306,14 @@ bool Lexer::scanUTF8Char(bool alreadyErrored, uint32_t* code, int& computedLen) 
     }
 
     if (error) {
+        // if error, trim next pointer so that control char is read as next char
+        if ((computedLen > 1) && (curr[1]< 0x20))
+            sourceBuffer = curr + 1;
+        else if ((computedLen > 2) && (curr[2] < 0x20))
+            sourceBuffer = curr + 2;
+        else if ((computedLen > 3) && (curr[3] < 0x20))
+            sourceBuffer = curr + 3;
+
         errorCount++;
         if (!alreadyErrored)
             addDiag(diag::InvalidUTF8Seq, (size_t)(curr - originalBegin));

--- a/source/parsing/Lexer.cpp
+++ b/source/parsing/Lexer.cpp
@@ -1307,7 +1307,7 @@ bool Lexer::scanUTF8Char(bool alreadyErrored, uint32_t* code, int& computedLen) 
 
     if (error) {
         // if error, trim next pointer so that control char is read as next char
-        if ((computedLen > 1) && (curr[1]< 0x20))
+        if ((computedLen > 1) && (curr[1] < 0x20))
             sourceBuffer = curr + 1;
         else if ((computedLen > 2) && (curr[2] < 0x20))
             sourceBuffer = curr + 2;

--- a/source/parsing/Lexer.cpp
+++ b/source/parsing/Lexer.cpp
@@ -1239,10 +1239,7 @@ void Lexer::scanLineComment() {
             advance();
         }
         else {
-            auto error = !scanUTF8Char(sawUTF8Error);
-            sawUTF8Error |= error;
-            if (error)
-                errorCount--; // counter increment in scanUTF8Char()
+            sawUTF8Error |= !scanUTF8Char(sawUTF8Error);
         }
     }
     addTrivia(TriviaKind::LineComment);
@@ -1279,10 +1276,7 @@ void Lexer::scanBlockComment() {
             }
         }
         else {
-            auto error = !scanUTF8Char(sawUTF8Error);
-            sawUTF8Error |= error;
-            if (error)
-                errorCount--; // counter increment in scanUTF8Char()
+            sawUTF8Error |= !scanUTF8Char(sawUTF8Error);
         }
     }
 
@@ -1320,7 +1314,6 @@ bool Lexer::scanUTF8Char(bool alreadyErrored, uint32_t* code, int& computedLen) 
         else if ((computedLen > 3) && (curr[3] < 0x20))
             sourceBuffer = curr + 3;
 
-        errorCount++;
         if (!alreadyErrored)
             addDiag(diag::InvalidUTF8Seq, (size_t)(curr - originalBegin));
         return false;

--- a/tests/unittests/parsing/LexerTests.cpp
+++ b/tests/unittests/parsing/LexerTests.cpp
@@ -149,7 +149,8 @@ TEST_CASE("Embedded control characters in a broken UTF8 comment (2)") {
 }
 
 TEST_CASE("Embedded control characters in a broken UTF8 comment not affecting lexer errorCount") {
-    auto& text = "//\x82\xe8\n//\x82\xe8\n//\x82\xe8\n//\x82\xe8\n//\x82\xe8\n//\x82\xe8\n//\x82\xe8\n//\x82\xe8\nendmodule\n";
+    auto& text = "//\x82\xe8\n//\x82\xe8\n//\x82\xe8\n//\x82\xe8\n//\x82\xe8\n//\x82\xe8\n//"
+                 "\x82\xe8\n//\x82\xe8\nendmodule\n";
 
     LexerOptions options;
     options.maxErrors = 4;
@@ -162,8 +163,8 @@ TEST_CASE("Embedded control characters in a broken UTF8 comment not affecting le
     CHECK(token.kind == TokenKind::EndModuleKeyword);
     CHECK(token.trivia().size() == 16);
     for (int i = 0; i < 8; i++) {
-        CHECK(token.trivia()[2*i].kind == TriviaKind::LineComment);
-        CHECK(token.trivia()[2*i+1].kind == TriviaKind::EndOfLine);
+        CHECK(token.trivia()[2 * i].kind == TriviaKind::LineComment);
+        CHECK(token.trivia()[2 * i + 1].kind == TriviaKind::EndOfLine);
     }
     REQUIRE(diagnostics.size() == 8); // Due to UTF8 intended error
 }

--- a/tests/unittests/parsing/LexerTests.cpp
+++ b/tests/unittests/parsing/LexerTests.cpp
@@ -126,6 +126,17 @@ TEST_CASE("Line Comment (UTF8)") {
     REQUIRE(diagnostics.empty());
 }
 
+TEST_CASE("Embedded control characters in a broken UTF8 comment") {
+    const char text[] = "//\xe0\x80\nendmodule";
+    Token token = lexToken(text);
+
+    CHECK(token.kind == TokenKind::EndModuleKeyword);
+    CHECK(token.trivia().size() == 2);
+    CHECK(token.trivia()[0].kind == TriviaKind::LineComment);
+    CHECK(token.trivia()[1].kind == TriviaKind::EndOfLine);
+    REQUIRE(diagnostics.size() == 1); // Due to UTF8 intended error
+}
+
 TEST_CASE("Block Comment (one line)") {
     auto& text = "/* comment */";
     Token token = lexToken(text);

--- a/tests/unittests/parsing/LexerTests.cpp
+++ b/tests/unittests/parsing/LexerTests.cpp
@@ -137,6 +137,17 @@ TEST_CASE("Embedded control characters in a broken UTF8 comment") {
     REQUIRE(diagnostics.size() == 1); // Due to UTF8 intended error
 }
 
+TEST_CASE("Embedded control characters in a broken UTF8 comment (2)") {
+    const char text[] = "//\x82\xe8\nendmodule";
+    Token token = lexToken(text);
+
+    CHECK(token.kind == TokenKind::EndModuleKeyword);
+    CHECK(token.trivia().size() == 2);
+    CHECK(token.trivia()[0].kind == TriviaKind::LineComment);
+    CHECK(token.trivia()[1].kind == TriviaKind::EndOfLine);
+    REQUIRE(diagnostics.size() == 1); // Due to UTF8 intended error
+}
+
 TEST_CASE("Block Comment (one line)") {
     auto& text = "/* comment */";
     Token token = lexToken(text);


### PR DESCRIPTION
This PR is a partial fix for #1054
Since SystemVerilog files are simple ASCII files, some code bases use international languages in their comments.
Slang expects comments to be in the UTF8 encoding.
If a different coding is used, it is possible that the comment is misinterpreted as an illegal UTF8 string, and effectively skips control characters such as newline.
For this to work, it may be necessary to add the `-Wno-invalid-source-encoding` , since slang will abort any file when the maximum number of lexer errors is encountered (default is 16).

