### PR TITLE
Make SyntaxRewriter call Derived::visit() rather SyntaxVisitor::visit()

### DIFF
--- a/include/slang/syntax/SyntaxVisitor.h
+++ b/include/slang/syntax/SyntaxVisitor.h
@@ -115,7 +115,7 @@ public:
         commits.clear();
         tempTrees.clear();
 
-        tree->root().visit(*this);
+        tree->root().visit(*DERIVED);
 
         if (commits.empty())
             return tree;


### PR DESCRIPTION
Problem: SyntaxRewriter::transform() launches `SyntaxVisitor::visit()` rather than `Derived::visit()` preventing reliable reimplementation of that method.