### PR TITLE
Add isChildOptional() method

### DIFF
--- a/include/slang/syntax/SyntaxNode.h
+++ b/include/slang/syntax/SyntaxNode.h
@@ -190,6 +190,10 @@ public:
     /// is compatible with the static type of the object.
     static bool isKind(SyntaxKind) { return true; }
 
+    /// Derived nodes should implement this and return false if child at provided
+    /// index is node wrapped in not_null.
+    static bool isChildOptional(size_t) { return true; }
+
 protected:
     explicit SyntaxNode(SyntaxKind kind) : kind(kind) {}
 
@@ -286,6 +290,8 @@ public:
     virtual void resetAll(BumpAllocator& alloc, std::span<const TokenOrSyntax> children) = 0;
 
     static bool isKind(SyntaxKind kind);
+
+    static bool isChildOptional(size_t index);
 
 protected:
     SyntaxListBase(SyntaxKind kind, size_t childCount) : SyntaxNode(kind), childCount(childCount) {}

--- a/source/syntax/SyntaxNode.cpp
+++ b/source/syntax/SyntaxNode.cpp
@@ -216,4 +216,9 @@ bool SyntaxListBase::isKind(SyntaxKind kind) {
     }
 }
 
+bool SyntaxListBase::isChildOptional(size_t index) {
+    (void)index;
+    return true;
+}
+
 } // namespace slang::syntax


### PR DESCRIPTION
Add method for determining whether child at given index is wrapped in `not_null<>`.

Rationale:
Passing child that is wrapped in `not_null` to `SyntaxRewriter::remove()`, results in failing not_null assertion.
When you remove quite a lot arbitrary nodes it gets cumbersome to avoid this issue "manually".

Thanks to this `isChildOptional()`, one can re-implement `visit`/`visitDefault` methods to pass handler information that node must not be removed.