### PR TITLE
[slang] Add virtual interface declaration checks

### DIFF
--- a/scripts/diagnostics.txt
+++ b/scripts/diagnostics.txt
@@ -489,6 +489,7 @@ error TimingCheckEventEdgeRequired "'{}' event argument requires an edge trigger
 error NoChangeEdgeRequired "trigger for first argument to '$nochange' must be posedge or negedge only"
 error PathPulseInvalidPathName "PATHPULSE$ path '{}' must be of the form 'source$dest'"
 error VirtualInterfaceIfaceMember "virtual interfaces cannot be used as the type for interface items"
+error VirtualInterfaceHierRef "Declaration of virtual interface should not contain hierarchical references to objects outside its body"
 error DefparamBadHierarchy "defparam in a hierarchy in or under a generate block, array of instances, or bind instantiation cannot change a parameter value outside that hierarchy"
 error BindTargetPrimitive "cannot bind a primitive"
 error BindUnderBind "cannot bind an instance underneath the scope of another bind instance"

--- a/scripts/diagnostics.txt
+++ b/scripts/diagnostics.txt
@@ -490,6 +490,7 @@ error NoChangeEdgeRequired "trigger for first argument to '$nochange' must be po
 error PathPulseInvalidPathName "PATHPULSE$ path '{}' must be of the form 'source$dest'"
 error VirtualInterfaceIfaceMember "virtual interfaces cannot be used as the type for interface items"
 error VirtualInterfaceHierRef "Declaration of virtual interface should not contain hierarchical references to objects outside its body"
+error VirtualInterfaceIfacePort "Declaration of virtual interface should not contain ports that reference other interfaces"
 error DefparamBadHierarchy "defparam in a hierarchy in or under a generate block, array of instances, or bind instantiation cannot change a parameter value outside that hierarchy"
 error BindTargetPrimitive "cannot bind a primitive"
 error BindUnderBind "cannot bind an instance underneath the scope of another bind instance"

--- a/source/ast/symbols/InstanceSymbols.cpp
+++ b/source/ast/symbols/InstanceSymbols.cpp
@@ -1130,7 +1130,7 @@ class InstanceBodySymbol::HierIdentsVisitor : public ASTVisitor<HierIdentsVisito
 public:
     SmallVector<SourceRange, 4> hierIdentsSR;
 
-    HierIdentsVisitor(const InstanceBodySymbol& ifaceBody) : ifaceBody(ifaceBody){};
+    HierIdentsVisitor(const InstanceBodySymbol& ifaceBody) : ifaceBody(ifaceBody) {};
 
     void handle(const HierarchicalValueExpression& hVE) {
         processHierIdent(hVE, ifaceBody, hierIdentsSR);

--- a/source/ast/symbols/InstanceSymbols.cpp
+++ b/source/ast/symbols/InstanceSymbols.cpp
@@ -1126,6 +1126,28 @@ bool InstanceBodySymbol::hasSameType(const InstanceBodySymbol& other) const {
     return true;
 }
 
+class InstanceBodySymbol::HierIdentsVisitor : public ASTVisitor<HierIdentsVisitor, true, true> {
+public:
+    SmallVector<SourceRange, 4> hierIdentsSR;
+
+    HierIdentsVisitor(const InstanceBodySymbol& ifaceBody) : ifaceBody(ifaceBody){};
+
+    void handle(const HierarchicalValueExpression& hVE) {
+        processHierIdent(hVE, ifaceBody, hierIdentsSR);
+    }
+
+private:
+    const InstanceBodySymbol& ifaceBody;
+};
+
+void InstanceBodySymbol::collectHierIdents(Compilation& comp) const {
+    if (!hierIdentifiers.has_value()) {
+        HierIdentsVisitor hIdentsVisitor(*this);
+        hIdentsVisitor.visit(*this);
+        hierIdentifiers = hIdentsVisitor.hierIdentsSR.copy(comp);
+    }
+}
+
 void InstanceBodySymbol::serializeTo(ASTSerializer& serializer) const {
     serializer.writeLink("definition", definition);
 }

--- a/source/ast/types/AllTypes.cpp
+++ b/source/ast/types/AllTypes.cpp
@@ -1129,8 +1129,7 @@ const Type& VirtualInterfaceType::fromSyntax(const ASTContext& context,
 
     auto loc = syntax.name.location();
     auto& defSym = def->as<DefinitionSymbol>();
-    auto& iface = InstanceSymbol::createVirtual(context, loc, defSym,
-                                                syntax.parameters);
+    auto& iface = InstanceSymbol::createVirtual(context, loc, defSym, syntax.parameters);
 
     // To control duplicates
     SmallSet<const DefinitionSymbol*, 4> visited;


### PR DESCRIPTION
In this PR i add some virtual interface checks such as:
 - hierarchical references usage
 - interface ports usage

That checks related to part of https://github.com/MikePopoloski/slang/issues/522

> Although an interface may contain hierarchical references to objects outside its body or ports that reference
other interfaces, it shall be illegal to use an interface containing those references in the declaration of a
virtual interface.