### PR TITLE
[slang] Add a check for local variables same as formal args declaration

### DIFF
--- a/scripts/diagnostics.txt
+++ b/scripts/diagnostics.txt
@@ -739,7 +739,6 @@ error VoidAssignment "expression of type 'void' cannot be used in assignments"
 error VirtualIfaceDefparam "interface instance cannot be assigned to a virtual interface because it is the target of a defparam or bind directive"
 error MultipleDefaultDistWeight "'default' cannot be used more than once in dist item list"
 error DistRealRangeWeight "'dist' for a range of real values must include an explicit weight and must use the ':/' operator"
-error SequenceLocalVarFormalArg "it is illegal to declare the local variable when it is a formal argument"
 warning ignored-slice IgnoredSlice "slice size ignored for left-to-right streaming operator"
 warning unsized-concat UnsizedInConcat "unsized integer in concat; using a width of {}"
 warning width-expand WidthExpand "implicit conversion expands from {} to {} bits"
@@ -770,7 +769,6 @@ warning arith-op-mismatch ArithOpMismatch "arithmetic between operands of differ
 warning bitwise-op-mismatch BitwiseOpMismatch "bitwise operation between operands of different types ({} and {})"
 warning comparison-mismatch ComparisonMismatch "comparison between operands of different types ({} and {})"
 warning sign-compare SignCompare "comparison of differently signed types ({} and {})"
-note NoteSequenceFormalArg "sequence formal argument '{}' specified here"
 
 subsystem Statements
 error ReturnNotInSubroutine "return statement is only valid inside task and function blocks"

--- a/scripts/diagnostics.txt
+++ b/scripts/diagnostics.txt
@@ -739,6 +739,7 @@ error VoidAssignment "expression of type 'void' cannot be used in assignments"
 error VirtualIfaceDefparam "interface instance cannot be assigned to a virtual interface because it is the target of a defparam or bind directive"
 error MultipleDefaultDistWeight "'default' cannot be used more than once in dist item list"
 error DistRealRangeWeight "'dist' for a range of real values must include an explicit weight and must use the ':/' operator"
+error SequenceLocalVarFormalArg "it is illegal to declare the local variable when it is a formal argument"
 warning ignored-slice IgnoredSlice "slice size ignored for left-to-right streaming operator"
 warning unsized-concat UnsizedInConcat "unsized integer in concat; using a width of {}"
 warning width-expand WidthExpand "implicit conversion expands from {} to {} bits"
@@ -769,6 +770,7 @@ warning arith-op-mismatch ArithOpMismatch "arithmetic between operands of differ
 warning bitwise-op-mismatch BitwiseOpMismatch "bitwise operation between operands of different types ({} and {})"
 warning comparison-mismatch ComparisonMismatch "comparison between operands of different types ({} and {})"
 warning sign-compare SignCompare "comparison of differently signed types ({} and {})"
+note NoteSequenceFormalArg "sequence formal argument '{}' specified here"
 
 subsystem Statements
 error ReturnNotInSubroutine "return statement is only valid inside task and function blocks"

--- a/source/ast/expressions/MiscExpressions.cpp
+++ b/source/ast/expressions/MiscExpressions.cpp
@@ -1120,9 +1120,6 @@ Expression& AssertionInstanceExpression::makeDefault(const Symbol& symbol) {
     auto result = comp.emplace<AssertionInstanceExpression>(*type, symbol, body,
                                                             /* isRecursiveProperty */ false, range);
     result->localVars = localVars.copy(comp);
-    // Check LRM 16.10 section restriction:
-    // > It's illegal to declare a local variable if it is a formal argument of a sequence
-    // declaration.
     return *result;
 }
 

--- a/tests/unittests/ast/AssertionTests.cpp
+++ b/tests/unittests/ast/AssertionTests.cpp
@@ -2655,5 +2655,5 @@ endmodule
 
     auto& diags = compilation.getAllDiagnostics();
     REQUIRE(diags.size() == 2);
-    CHECK(diags[0].code == diag::SequenceLocalVarFormalArg);
+    CHECK(diags[0].code == diag::Redefinition);
 }

--- a/tests/unittests/ast/AssertionTests.cpp
+++ b/tests/unittests/ast/AssertionTests.cpp
@@ -2628,3 +2628,32 @@ endmodule
     compilation.addSyntaxTree(tree);
     NO_COMPILATION_ERRORS;
 }
+
+TEST_CASE("Sequence local variable same as formal argument declaration") {
+    auto tree = SyntaxTree::fromText(R"(
+logic a, b, c, d;
+
+sequence sub_seq(lv);
+int lv;
+(a ##1 !a, lv = 1) ##1 !b[*0:$] ##1 b && (1 == lv);
+endsequence
+
+sequence seq;
+int v1;
+c ##1 sub_seq(v1)
+##1 (d == v1);
+endsequence
+
+module m;
+    int m;
+    assert property(seq);
+endmodule
+)");
+
+    Compilation compilation;
+    compilation.addSyntaxTree(tree);
+
+    auto& diags = compilation.getAllDiagnostics();
+    REQUIRE(diags.size() == 2);
+    CHECK(diags[0].code == diag::SequenceLocalVarFormalArg);
+}


### PR DESCRIPTION
Implement a check for restriction from LRM 16.10 section:

> When a local variable is a formal argument of a sequence declaration, it is illegal to declare the variable, as
> shown in the following example:
> ```verilog
> sequence sub_seq3(lv);
> int lv; // illegal because lv is a formal argument
> (a ##1 !a, lv = data_in) ##1 !b[*0:$] ##1 b && (data_out == lv);
> endsequence
> ```