### PR TITLE
Add "has issued errors" method on a compilation

### DIFF
--- a/include/slang/ast/Compilation.h
+++ b/include/slang/ast/Compilation.h
@@ -708,6 +708,9 @@ public:
     /// Creates an empty ImplicitTypeSyntax object.
     const syntax::ImplicitTypeSyntax& createEmptyTypeSyntax(SourceLocation loc);
 
+    /// Queries if any errors have been issued on any scope within this compilation.
+    bool hasIssuedErrors() const { return numErrors > 0; };
+
     /// @{
 
 private:


### PR DESCRIPTION
`Compilation::getSemanticDiagnostics()` caches its result and is meant to be called on a finished compilation for which no more diagnostics will be issued.

For use cases where user code using slang as a library wants to issue its own diagnostics, but doesn't want to deal with an AST which failed elaboration, provide a `hasIssuedErrors()` method to find out early if the elaboration failed.