### PR TITLE
[slang] Fix deffered assertion function call check

### DIFF
--- a/include/slang/ast/ASTContext.h
+++ b/include/slang/ast/ASTContext.h
@@ -194,11 +194,8 @@ enum class SLANG_EXPORT ASTFlags : uint64_t {
 
     /// AST binding is for a bind instantiation (port connection or param value).
     BindInstantiation = 1ull << 45,
-
-    /// The expression is inside sequence.
-    InsideSequence = 1ull << 46
 };
-SLANG_BITMASK(ASTFlags, InsideSequence)
+SLANG_BITMASK(ASTFlags, BindInstantiation)
 
 // clang-format off
 #define DK(x) \

--- a/include/slang/ast/ASTContext.h
+++ b/include/slang/ast/ASTContext.h
@@ -193,9 +193,12 @@ enum class SLANG_EXPORT ASTFlags : uint64_t {
     DisallowUDNT = 1ull << 44,
 
     /// AST binding is for a bind instantiation (port connection or param value).
-    BindInstantiation = 1ull << 45
+    BindInstantiation = 1ull << 45,
+
+    /// The expression is inside sequence.
+    InsideSequence = 1ull << 46
 };
-SLANG_BITMASK(ASTFlags, BindInstantiation)
+SLANG_BITMASK(ASTFlags, InsideSequence)
 
 // clang-format off
 #define DK(x) \

--- a/include/slang/ast/expressions/AssertionExpr.h
+++ b/include/slang/ast/expressions/AssertionExpr.h
@@ -164,7 +164,7 @@ public:
 
     static bool checkAssertionCall(const CallExpression& call, const ASTContext& context,
                                    DiagCode outArgCode, DiagCode refArgCode, DiagCode nonVoidCode,
-                                   SourceRange range);
+                                   SourceRange range, bool isInsideSequence = false);
 
     static void checkSampledValueExpr(const Expression& expr, const ASTContext& context,
                                       bool isFutureGlobal, DiagCode localVarCode,

--- a/source/ast/expressions/AssertionExpr.cpp
+++ b/source/ast/expressions/AssertionExpr.cpp
@@ -812,9 +812,9 @@ static std::span<const Expression* const> bindMatchItems(const SequenceMatchList
                 break;
             }
             case ExpressionKind::Call: {
-                ASTContext ctx = context;
-                ctx.flags |= ASTFlags::InsideSequence;
-                AssertionExpr::checkAssertionCall(expr.as<CallExpression>(), ctx,
+                ASTContext insideSeqCtx = context;
+                insideSeqCtx.flags |= ASTFlags::InsideSequence;
+                AssertionExpr::checkAssertionCall(expr.as<CallExpression>(), insideSeqCtx,
                                                   diag::SubroutineMatchOutArg,
                                                   diag::SubroutineMatchAutoRefArg,
                                                   diag::SubroutineMatchNonVoid, expr.sourceRange);

--- a/source/ast/expressions/AssertionExpr.cpp
+++ b/source/ast/expressions/AssertionExpr.cpp
@@ -284,8 +284,9 @@ AssertionExpr& AssertionExpr::badExpr(Compilation& compilation, const AssertionE
 
 bool AssertionExpr::checkAssertionCall(const CallExpression& call, const ASTContext& context,
                                        DiagCode outArgCode, DiagCode refArgCode,
-                                       DiagCode nonVoidCode, SourceRange range) {
-    if (context.flags.has(ASTFlags::InsideSequence) || call.isSystemCall()) {
+                                       DiagCode nonVoidCode, SourceRange range,
+                                       bool isInsideSequence) {
+    if (isInsideSequence || call.isSystemCall()) {
         if (call.getSubroutineKind() == SubroutineKind::Function && !call.type->isVoid() &&
             !call.type->isError()) {
             context.addDiag(nonVoidCode, range) << call.getSubroutineName();
@@ -813,11 +814,11 @@ static std::span<const Expression* const> bindMatchItems(const SequenceMatchList
             }
             case ExpressionKind::Call: {
                 ASTContext insideSeqCtx = context;
-                insideSeqCtx.flags |= ASTFlags::InsideSequence;
                 AssertionExpr::checkAssertionCall(expr.as<CallExpression>(), insideSeqCtx,
                                                   diag::SubroutineMatchOutArg,
                                                   diag::SubroutineMatchAutoRefArg,
-                                                  diag::SubroutineMatchNonVoid, expr.sourceRange);
+                                                  diag::SubroutineMatchNonVoid, expr.sourceRange,
+                                                  /*isInsideSequence =*/true);
                 break;
             }
             case ExpressionKind::Invalid:

--- a/tests/unittests/ast/StatementTests.cpp
+++ b/tests/unittests/ast/StatementTests.cpp
@@ -10,7 +10,6 @@
 #include "slang/ast/symbols/ParameterSymbols.h"
 #include "slang/ast/symbols/VariableSymbols.h"
 #include "slang/ast/types/Type.h"
-#include "slang/diagnostics/StatementsDiags.h"
 
 TEST_CASE("For loop statements") {
     auto tree = SyntaxTree::fromText(R"(

--- a/tests/unittests/ast/StatementTests.cpp
+++ b/tests/unittests/ast/StatementTests.cpp
@@ -10,6 +10,7 @@
 #include "slang/ast/symbols/ParameterSymbols.h"
 #include "slang/ast/symbols/VariableSymbols.h"
 #include "slang/ast/types/Type.h"
+#include "slang/diagnostics/StatementsDiags.h"
 
 TEST_CASE("For loop statements") {
     auto tree = SyntaxTree::fromText(R"(
@@ -429,6 +430,7 @@ module m;
     function void f1; endfunction
     function void f2(int i, output int o); endfunction
     function automatic void f3(int i, ref r); endfunction
+    function int error_code(); return (0); endfunction
 
     int i;
     string s;
@@ -439,6 +441,8 @@ module m;
         assert #0 (i < 0) f2(i, i);
         assert #0 (i < 0) f3(i, r);
         assert #0 (i < 0) $swrite(s, "%d", i);
+        assert #0 (i < 0) error_code();
+        assert #0 (i < 0) void'(error_code());
     end
 endmodule
 )");
@@ -447,12 +451,13 @@ endmodule
     compilation.addSyntaxTree(tree);
 
     auto& diags = compilation.getAllDiagnostics();
-    REQUIRE(diags.size() == 5);
+    REQUIRE(diags.size() == 6);
     CHECK(diags[0].code == diag::InvalidDeferredAssertAction);
     CHECK(diags[1].code == diag::DeferredAssertNonVoid);
     CHECK(diags[2].code == diag::DeferredAssertOutArg);
     CHECK(diags[3].code == diag::DeferredAssertAutoRefArg);
     CHECK(diags[4].code == diag::DeferredAssertOutArg);
+    CHECK(diags[5].code == diag::UnusedResult);
 }
 
 TEST_CASE("Break statement check -- regression") {


### PR DESCRIPTION
There is an example from LRM which not marked as `illegal`:

```verilog
function int error_type (int opcode);
    func_assert: assert (opcode < 64) else $display("Opcode error.");
    if (opcode < 32)
        return (0);
    else
        return (1);
endfunction

always_comb begin : b1
    a1: assert #0 (my_cond) else
        $error("Error on operation of type %d\n", error_type(opcode));
    a2: assert #0 (my_cond) else
        error_type(opcode); // returns non-void
...
end
```

`error_type` is not system call and returns non-void value.

I suppose that is valid case when non-void function can be used inside deferred assertions.

In confirmation of my words, a comment was left in the `slang` (`source/ast/Statements.cpp`) that only the type of system calls is checked:

```cpp
    // The subroutine being called has some restrictions:
    // - No output or inout arguments
    // - If a system call, must be a task or void returning
    // - Any ref arguments cannot reference automatic or dynamic variables
    auto& call = stmt.as<ExpressionStatement>().expr.as<CallExpression>();
    AssertionExpr::checkAssertionCall(call, context, diag::DeferredAssertOutArg,
                                      diag::DeferredAssertAutoRefArg, diag::DeferredAssertNonVoid,
                                      stmt.sourceRange);
```