### PR TITLE
[slang] Fix recursive property bug

### DIFF
--- a/source/ast/expressions/MiscExpressions.cpp
+++ b/source/ast/expressions/MiscExpressions.cpp
@@ -987,7 +987,8 @@ Expression& AssertionInstanceExpression::fromLookup(const Symbol& symbol,
     ASTContext bodyContext(*symbolScope, LookupLocation::max);
     bodyContext.assertionInstance = &instance;
     // Propagate previously founded time advance specs
-    bodyContext.flags |= ASTFlags::PropertyTimeAdvance;
+    if (context.flags.has(ASTFlags::PropertyTimeAdvance))
+        bodyContext.flags |= ASTFlags::PropertyTimeAdvance;
 
     // Let declarations expand directly to an expression.
     if (symbol.kind == SymbolKind::LetDecl)

--- a/source/ast/expressions/MiscExpressions.cpp
+++ b/source/ast/expressions/MiscExpressions.cpp
@@ -986,6 +986,8 @@ Expression& AssertionInstanceExpression::fromLookup(const Symbol& symbol,
 
     ASTContext bodyContext(*symbolScope, LookupLocation::max);
     bodyContext.assertionInstance = &instance;
+    // Propagate previously founded time advance specs
+    bodyContext.flags |= ASTFlags::PropertyTimeAdvance;
 
     // Let declarations expand directly to an expression.
     if (symbol.kind == SymbolKind::LetDecl)

--- a/tests/unittests/ast/AssertionTests.cpp
+++ b/tests/unittests/ast/AssertionTests.cpp
@@ -606,8 +606,21 @@ property check_write_data_beat(
     );
 endproperty
 
+property prop(p, bit b, abort);
+  (p and (1'b1 |=> recProp(p, b, abort)));
+endproperty
+
+property recProp(p, bit b, abort);
+  accept_on(b) reject_on(abort) prop(p, b, abort);
+endproperty
+
 module m;
     assert property (check_write);
+
+    logic p;
+    bit b;
+    logic abort;
+    assert property(prop(p, b, abort));
 endmodule
 )");
 


### PR DESCRIPTION
An LRM example which fails on `slang`:

```verilog
property p3(p, bit b, abort);
    (p and (1'b1 |=> p4(p, b, abort)));
endproperty

property p4(p, bit b, abort);
    accept_on(b) reject_on(abort) p3(p, b, abort);
endproperty
````

It is legal because `p4` invoked as rhs of non-overlap implication.