### PR TITLE
Fix non-ptr children to be marked as non optional

### DIFF
--- a/include/slang/syntax/SyntaxNode.h
+++ b/include/slang/syntax/SyntaxNode.h
@@ -190,8 +190,8 @@ public:
     /// is compatible with the static type of the object.
     static bool isKind(SyntaxKind) { return true; }
 
-    /// Derived nodes should implement this and return false if child at provided
-    /// index is node wrapped in not_null.
+    /// Derived nodes should implement this and return true if child at provided
+    /// index is pointer not wrapped in not_null.
     static bool isChildOptional(size_t) { return true; }
 
 protected:

--- a/scripts/syntax_gen.py
+++ b/scripts/syntax_gen.py
@@ -378,7 +378,7 @@ namespace slang::syntax {
                 )
             )
             docf.write(
-                "    @brief Returns false if child member (token or syntax node) at the provided index within this struct is a syntax node wrapped in not_null<>\n"
+                "    @brief Returns true if child member (token or syntax node) at the provided index within this struct is a nullable pointer\n"
             )
             docf.write(
                 "    @fn TokenOrSyntax slang::syntax::{}::getChild(size_t index)\n".format(
@@ -493,20 +493,20 @@ size_t SyntaxNode::getChildCount() const {
 
         if v.members or v.final != "":
             cppf.write("bool {}::isChildOptional(size_t index) {{\n".format(k))
-            if v.notNullMembers:
+            if v.optionalMembers:
                 cppf.write("    switch (index) {\n")
 
                 index = 0
                 for m in v.combinedMembers:
-                    if m[1] in v.notNullMembers:
-                        cppf.write("        case {}: return false;\n".format(index))
+                    if m[1] in v.optionalMembers:
+                        cppf.write("        case {}: return true;\n".format(index))
                     index += 1
 
-                cppf.write("        default: return true;\n")
+                cppf.write("        default: return false;\n")
                 cppf.write("    }\n")
             else:
                 cppf.write("    (void)index;\n")
-                cppf.write("    return true;\n")
+                cppf.write("    return false;\n")
 
             cppf.write("}\n\n")
 


### PR DESCRIPTION
Previous implementation of `isChildOptional()` (introduced in [#1070](https://github.com/MikePopoloski/slang/commit/928045a4da4e1239831b2d0cbd75f25b63ee07d5)) wrongly marked non-ptr nodes (like
`SyntaxList`s) as optional