### PR TITLE
Make specializations of parametrizable classes visitable

### DIFF
--- a/include/slang/ast/ASTVisitor.h
+++ b/include/slang/ast/ASTVisitor.h
@@ -91,6 +91,11 @@ public:
             }
         }
 
+        if constexpr (std::is_base_of_v<GenericClassDefSymbol, T>) {
+            for (auto&& spec : t.specializations())
+                spec.visit(DERIVED);
+        }
+
         if constexpr (std::is_base_of_v<Scope, T>) {
             for (auto& member : t.members())
                 member.visit(DERIVED);


### PR DESCRIPTION
Specializations of parametrizable classes [were dumped in json](https://github.com/MikePopoloski/slang/blob/ef4337b258871dc72afae5992c5a0296c0e365f5/source/ast/symbols/ClassSymbols.cpp#L1039-L1042), but skipped by `ASTVisitor`. This MR fixes it.