### PR TITLE
Add preprocessor option to interpret translate_on/off pragmas

### DIFF
--- a/include/slang/parsing/Preprocessor.h
+++ b/include/slang/parsing/Preprocessor.h
@@ -8,6 +8,7 @@
 #pragma once
 
 #include <memory>
+#include <regex>
 
 #include "slang/parsing/Lexer.h"
 #include "slang/parsing/NumberParser.h"
@@ -57,6 +58,16 @@ struct SLANG_EXPORT PreprocessorOptions {
 
     /// A set of preprocessor directives to be ignored.
     flat_hash_set<std::string_view> ignoreDirectives;
+
+    /// A flag to enable the interpretation of non-standard line comment
+    /// pragmas within the preprocessor.
+    bool enableCompatPragmas = false;
+
+    /// A pair of regexes to match on the on/off pragmas in line comments.
+    /// The off pragma instructs the preprocessor to ignore all tokens until
+    /// the occurence of the on pragma.
+    std::regex compatOffPragma;
+    std::regex compatOnPragma;
 };
 
 /// Preprocessor - Interface between lexer and parser
@@ -153,6 +164,7 @@ private:
 
     // Internal methods to grab and handle the next token
     Token nextProcessed();
+    Token nextMasked();
     Token nextRaw();
     void popSource();
 

--- a/source/parsing/Preprocessor.cpp
+++ b/source/parsing/Preprocessor.cpp
@@ -225,29 +225,28 @@ Token Preprocessor::nextMasked() {
     while (true) {
         for (const Trivia& trivia : token.trivia()) {
             switch (trivia.kind) {
-            case TriviaKind::LineComment:
-                {
+                case TriviaKind::LineComment: {
                     auto text = trivia.getRawText();
 
                     if (disabledByPragma) {
                         if (std::regex_match(text.begin(), text.end(), options.compatOnPragma))
                             disabledByPragma = false;
-                    } else {
+                    }
+                    else {
                         if (std::regex_match(text.begin(), text.end(), options.compatOffPragma))
                             disabledByPragma = true;
                     }
-                }
-                break;
+                } break;
 
-            case TriviaKind::Directive:
-            case TriviaKind::SkippedSyntax:
-            case TriviaKind::SkippedTokens:
-                // These kinds of trivia shouldn't be possible on a raw token. They imply
-                // the possibility of nested trivia, which we have no handling for in this
-                // loop, so make sure we are not encountering them.
-                SLANG_UNREACHABLE;
+                case TriviaKind::Directive:
+                case TriviaKind::SkippedSyntax:
+                case TriviaKind::SkippedTokens:
+                    // These kinds of trivia shouldn't be possible on a raw token. They imply
+                    // the possibility of nested trivia, which we have no handling for in this
+                    // loop, so make sure we are not encountering them.
+                    SLANG_UNREACHABLE;
 
-            default:
+                default:
             }
         }
 
@@ -258,7 +257,8 @@ Token Preprocessor::nextMasked() {
             skippedTokens.push_back(token);
             token = nextRaw();
             SLANG_ASSERT(!inMacroBody);
-        } else {
+        }
+        else {
             // Exit the loop, but make sure all the skipped tokens get prepended
             // to the next token as trivia.
             if (!skippedTokens.empty()) {

--- a/source/parsing/Preprocessor.cpp
+++ b/source/parsing/Preprocessor.cpp
@@ -247,6 +247,7 @@ Token Preprocessor::nextMasked() {
                     SLANG_UNREACHABLE;
 
                 default:
+                    break;
             }
         }
 

--- a/tests/unittests/parsing/PreprocessorTests.cpp
+++ b/tests/unittests/parsing/PreprocessorTests.cpp
@@ -2694,7 +2694,7 @@ b
 
     diagnostics.clear();
     Bag options;
-    auto &ppOptions = options.insertOrGet<PreprocessorOptions>();
+    auto& ppOptions = options.insertOrGet<PreprocessorOptions>();
     ppOptions.enableCompatPragmas = true;
     ppOptions.compatOnPragma = "\\/\\/.*pragma.+translate_on.*";
     ppOptions.compatOffPragma = "\\/\\/.*pragma.+translate_off.*";


### PR DESCRIPTION
For synthesis tools based on slang, add a preprocessor option to interpret pragmas like

```
    // pragma translate_off
    assert(...); // meant to be ignored in synthesis
    // pragma translate_on
```

Given the non-standard nature of the pragmas, make the exact regex a preprocessor option.

Related: povik/yosys-slang#28