### PR TITLE
NoDotVarInPortConnection: Fix implicit port connection

### DIFF
--- a/tools/tidy/src/style/NoDotVarInPortConnection.cpp
+++ b/tools/tidy/src/style/NoDotVarInPortConnection.cpp
@@ -15,7 +15,7 @@ namespace no_dot_var_in_port_connection {
 
 struct PortConnectionVisitor : public SyntaxVisitor<PortConnectionVisitor> {
     void handle(const NamedPortConnectionSyntax& port) {
-        if (!port.expr)
+        if (!port.openParen)
             foundPorts.push_back(&port);
     }
 


### PR DESCRIPTION
Previously expr was checked, but this caused false positives for empty output connections. The right way is to check for the opening parenthesis