### PR TITLE
Add `std::hash<SourceRange>`

### DIFF
--- a/include/slang/text/SourceLocation.h
+++ b/include/slang/text/SourceLocation.h
@@ -237,4 +237,14 @@ struct hash<slang::SourceLocation> {
     }
 };
 
+template<>
+struct hash<slang::SourceRange> {
+    size_t operator()(const slang::SourceRange& obj) const {
+        size_t seed = 0;
+        slang::hash_combine(seed, obj.start());
+        slang::hash_combine(seed, obj.end());
+        return seed;
+    }
+};
+
 } // namespace std


### PR DESCRIPTION
Add `std::hash<SourceRange>` so `SourceRange` can be stored in a hash map.