### PR TITLE
Implements getFullyOriginalRange

### DIFF
--- a/include/slang/text/SourceManager.h
+++ b/include/slang/text/SourceManager.h
@@ -120,6 +120,11 @@ public:
     /// inside a macro. Otherwise just returns the location itself.
     SourceLocation getFullyOriginalLoc(SourceLocation location) const;
 
+    /// Build the original location range where source is written.
+    /// If there is a mismatch between resulting start and end files,
+    /// returns the original range instead.
+    SourceRange getFullyOriginalRange(SourceRange range) const;
+
     /// If the given location is a macro location, fully expands it out to its actual
     /// file expansion location. Otherwise just returns the location itself.
     SourceLocation getFullyExpandedLoc(SourceLocation location) const;

--- a/source/text/SourceManager.cpp
+++ b/source/text/SourceManager.cpp
@@ -199,6 +199,15 @@ SourceLocation SourceManager::getFullyOriginalLoc(SourceLocation location) const
     return location;
 }
 
+SourceRange SourceManager::getFullyOriginalRange(SourceRange range) const {
+    SourceLocation start(getFullyOriginalLoc(range.start()));
+    SourceLocation end(getFullyOriginalLoc(range.end()));
+
+    if (getFileName(start) != getFileName(end))
+        return range;
+    return SourceRange(start, end);
+}
+
 SourceLocation SourceManager::getFullyExpandedLoc(SourceLocation location) const {
     std::shared_lock lock(mutex);
     return getFullyExpandedLocImpl(location, lock);

--- a/source/text/SourceManager.cpp
+++ b/source/text/SourceManager.cpp
@@ -202,9 +202,6 @@ SourceLocation SourceManager::getFullyOriginalLoc(SourceLocation location) const
 SourceRange SourceManager::getFullyOriginalRange(SourceRange range) const {
     SourceLocation start(getFullyOriginalLoc(range.start()));
     SourceLocation end(getFullyOriginalLoc(range.end()));
-
-    if (getFileName(start) != getFileName(end))
-        return range;
     return SourceRange(start, end);
 }
 


### PR DESCRIPTION
Equivalent as getFullyOriginalLoc but directly for ranges

Simply generate a range for which `getFullyOriginalLoc` has been applied to both start() and end().
Return the original range if the resulting files mismatch.

Please let me know if there is a need to add tests for this. 