### PR TITLE
[slang][parser] Fix timeless constraint expression parsing

### DIFF
--- a/source/parsing/Parser_members.cpp
+++ b/source/parsing/Parser_members.cpp
@@ -2206,10 +2206,15 @@ ConstraintItemSyntax* Parser::parseConstraintItem(bool allowBlock, bool isTopLev
     if (!isPossibleExpression(peek().kind) && !allowBlock)
         return nullptr;
 
+    Token curr = peek();
     // at this point we either have an expression with optional distribution or
     // we have an implication constraint
     auto expr =
         &parseSubExpression(ExpressionOptions::ConstraintContext | ExpressionOptions::AllowDist, 0);
+    // checking that tokens were extracted during expression parsing
+    if (curr == peek())
+        return nullptr;
+
     if (peek(TokenKind::MinusArrow)) {
         auto arrow = consume();
         return &factory.implicationConstraint(*expr, arrow, *parseConstraintItem(true, false));

--- a/source/parsing/Parser_statements.cpp
+++ b/source/parsing/Parser_statements.cpp
@@ -762,6 +762,7 @@ RandCaseStatementSyntax& Parser::parseRandCaseStatement(NamedLabelSyntax* label,
     SmallVector<RandCaseItemSyntax*> itemBuffer;
 
     while (isPossibleExpression(peek().kind)) {
+        Token curr = peek();
         auto& expr = parseExpression();
         auto colon = expect(TokenKind::Colon);
         const auto loc = peek().location();
@@ -771,6 +772,9 @@ RandCaseStatementSyntax& Parser::parseRandCaseStatement(NamedLabelSyntax* label,
             skipToken(std::nullopt);
         }
         itemBuffer.push_back(&factory.randCaseItem(expr, colon, stmt));
+        // If there no consumed tokens then expression was not parced
+        if (curr == peek())
+            break;
     }
 
     auto endcase = expect(TokenKind::EndCaseKeyword);
@@ -995,8 +999,13 @@ StatementSyntax& Parser::parseRandSequenceStatement(NamedLabelSyntax* label, Att
     auto closeParen = expect(TokenKind::CloseParenthesis);
 
     SmallVector<ProductionSyntax*> productions;
-    while (isPossibleDataType(peek().kind))
+    while (isPossibleDataType(peek().kind)) {
+        Token curr = peek();
         productions.push_back(&parseProduction());
+        // If there no consumed tokens then production was not parced
+        if (curr == peek())
+            break;
+    }
 
     if (productions.empty())
         addDiag(diag::ExpectedRsRule, peek().location());

--- a/source/parsing/Parser_statements.cpp
+++ b/source/parsing/Parser_statements.cpp
@@ -765,16 +765,12 @@ RandCaseStatementSyntax& Parser::parseRandCaseStatement(NamedLabelSyntax* label,
         Token curr = peek();
         auto& expr = parseExpression();
         auto colon = expect(TokenKind::Colon);
-        const auto loc = peek().location();
         auto& stmt = parseStatement();
-        if (stmt.kind == SyntaxKind::EmptyStatement &&
-            stmt.as<EmptyStatementSyntax>().semicolon.isMissing() && loc == peek().location()) {
-            skipToken(std::nullopt);
-        }
-        itemBuffer.push_back(&factory.randCaseItem(expr, colon, stmt));
-        // If there is no consumed tokens then expression was not parsed
+        // If there is no consumed tokens then expression and statement were not parsed
         if (curr == peek())
-            break;
+            skipToken(std::nullopt);
+
+        itemBuffer.push_back(&factory.randCaseItem(expr, colon, stmt));
     }
 
     auto endcase = expect(TokenKind::EndCaseKeyword);
@@ -1004,7 +1000,7 @@ StatementSyntax& Parser::parseRandSequenceStatement(NamedLabelSyntax* label, Att
         productions.push_back(&parseProduction());
         // If there is no consumed tokens then production was not parsed
         if (curr == peek())
-            break;
+            skipToken(std::nullopt);
     }
 
     if (productions.empty())

--- a/source/parsing/Parser_statements.cpp
+++ b/source/parsing/Parser_statements.cpp
@@ -772,7 +772,7 @@ RandCaseStatementSyntax& Parser::parseRandCaseStatement(NamedLabelSyntax* label,
             skipToken(std::nullopt);
         }
         itemBuffer.push_back(&factory.randCaseItem(expr, colon, stmt));
-        // If there no consumed tokens then expression was not parced
+        // If there is no consumed tokens then expression was not parsed
         if (curr == peek())
             break;
     }
@@ -1002,7 +1002,7 @@ StatementSyntax& Parser::parseRandSequenceStatement(NamedLabelSyntax* label, Att
     while (isPossibleDataType(peek().kind)) {
         Token curr = peek();
         productions.push_back(&parseProduction());
-        // If there no consumed tokens then production was not parced
+        // If there is no consumed tokens then production was not parsed
         if (curr == peek())
             break;
     }

--- a/tests/unittests/parsing/MemberParsingTests.cpp
+++ b/tests/unittests/parsing/MemberParsingTests.cpp
@@ -1493,10 +1493,18 @@ endmodule
 TEST_CASE("Bad top level constraints") {
     auto& text = R"(
 constraint A :: A { &&& }
+
 constraint A :: A { matches }
+
 constraint A :: A { soft *) 0 ; }
+
+program A ; final randsequence ( const ) A : A ; endsequence endprogram
+
+constraint A :: A { foreach ( &&& A [ ] ) 0 ; }
+
+program A ; final randcase 0 : matches A = # 0 0 ; endcase endprogram
 )";
     parseCompilationUnit(text);
 
-    REQUIRE(diagnostics.size() == 4);
+    REQUIRE(diagnostics.size() == 18);
 }

--- a/tests/unittests/parsing/MemberParsingTests.cpp
+++ b/tests/unittests/parsing/MemberParsingTests.cpp
@@ -1506,5 +1506,5 @@ program A ; final randcase 0 : matches A = # 0 0 ; endcase endprogram
 )";
     parseCompilationUnit(text);
 
-    REQUIRE(diagnostics.size() == 18);
+    REQUIRE(diagnostics.size() == 16);
 }

--- a/tests/unittests/parsing/MemberParsingTests.cpp
+++ b/tests/unittests/parsing/MemberParsingTests.cpp
@@ -1489,3 +1489,14 @@ endmodule
     REQUIRE(diagnostics.size() == 1);
     CHECK(diagnostics[0].code == diag::UnexpectedEndDelim);
 }
+
+TEST_CASE("Bad top level constraints") {
+    auto& text = R"(
+constraint A :: A { &&& }
+constraint A :: A { matches }
+constraint A :: A { soft *) 0 ; }
+)";
+    parseCompilationUnit(text);
+
+    REQUIRE(diagnostics.size() == 4);
+}


### PR DESCRIPTION
`slang` fails to parse such constraint block expression types:

```verilog
constraint A :: A { &&& }

//and

constraint A :: A { matches }
```

It tries endlessly to parse the expression and takes all RAM. This is because the expression may start with these tokens. - `TripleAnd` and `Match`.

There is an another variant to fix - forcibly consume token after `left` validation. But I suppose this is not best solution because expression can't start with that tokens as it said in method `isPossibleExpression` commentaries.

