### PR TITLE
[bug][slang] Fix recursive property negation check bug

### DIFF
--- a/source/ast/expressions/MiscExpressions.cpp
+++ b/source/ast/expressions/MiscExpressions.cpp
@@ -1005,9 +1005,11 @@ Expression& AssertionInstanceExpression::fromLookup(const Symbol& symbol,
 
     ASTContext bodyContext(*symbolScope, LookupLocation::max);
     bodyContext.assertionInstance = &instance;
-    // Propagate previously founded time advance specs
+    // Propagate previously founded time advance specs and negation operators
     if (context.flags.has(ASTFlags::PropertyTimeAdvance))
         bodyContext.flags |= ASTFlags::PropertyTimeAdvance;
+    if (context.flags.has(ASTFlags::PropertyNegation))
+        bodyContext.flags |= ASTFlags::PropertyNegation;
 
     // Let declarations expand directly to an expression.
     if (symbol.kind == SymbolKind::LetDecl)

--- a/tests/unittests/ast/AssertionTests.cpp
+++ b/tests/unittests/ast/AssertionTests.cpp
@@ -1119,13 +1119,14 @@ endmodule
     compilation.addSyntaxTree(tree);
 
     auto& diags = compilation.getAllDiagnostics();
-    REQUIRE(diags.size() == 6);
+    REQUIRE(diags.size() == 7);
     CHECK(diags[0].code == diag::RecursivePropNegation);
-    CHECK(diags[1].code == diag::RecursivePropDisableIff);
-    CHECK(diags[2].code == diag::RecursivePropTimeAdvance);
-    CHECK(diags[3].code == diag::RecursivePropArgExpr);
+    CHECK(diags[1].code == diag::RecursivePropNegation);
+    CHECK(diags[2].code == diag::RecursivePropDisableIff);
+    CHECK(diags[3].code == diag::RecursivePropTimeAdvance);
     CHECK(diags[4].code == diag::RecursivePropArgExpr);
     CHECK(diags[5].code == diag::RecursivePropArgExpr);
+    CHECK(diags[6].code == diag::RecursivePropArgExpr);
 }
 
 TEST_CASE("Illegal concurrent assertions in action blocks") {


### PR DESCRIPTION
Fix a check of illegal recursive property negation example from LRM which currently are not processed by `slang`:

```verilog
module m;
    property prop_always(p);
        p and (1'b1 |=> prop_always(p));
    endproperty

    property illegal_recursion_1(p);
        not prop_always(not p);
    endproperty

endmodule
```