### PR TITLE
hermetic builds

### DIFF
--- a/bindings/CMakeLists.txt
+++ b/bindings/CMakeLists.txt
@@ -25,8 +25,10 @@ endif()
 
 # Generate bindings for syntax node types
 add_custom_command(
-  COMMAND ${Python_EXECUTABLE} ${SCRIPTS_DIR}/syntax_gen.py --dir
-          ${CMAKE_CURRENT_BINARY_DIR} --python-bindings
+  COMMAND
+    ${Python_EXECUTABLE} ${SCRIPTS_DIR}/syntax_gen.py --dir
+    ${CMAKE_CURRENT_BINARY_DIR} --python-bindings --syntax
+    ${SCRIPTS_DIR}/syntax.txt
   OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/PySyntaxBindings0.cpp
          ${CMAKE_CURRENT_BINARY_DIR}/PySyntaxBindings1.cpp
          ${CMAKE_CURRENT_BINARY_DIR}/PySyntaxBindings2.cpp

--- a/docs/CMakeLists.txt
+++ b/docs/CMakeLists.txt
@@ -36,6 +36,7 @@ add_custom_command(
   COMMAND
     ${Python_EXECUTABLE} ${SCRIPTS_DIR}/diagnostic_gen.py --outDir
     ${CMAKE_CURRENT_BINARY_DIR} --docs --slangBin $<TARGET_FILE:slang::driver>
+    --diagnostics ${SCRIPTS_DIR}/diagnostics.txt
   OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/warnings.dox
   DEPENDS ${SCRIPTS_DIR}/diagnostic_gen.py ${SCRIPTS_DIR}/diagnostics.txt
           ${SCRIPTS_DIR}/warning_docs.txt

--- a/include/slang/diagnostics/DiagArgFormatter.h
+++ b/include/slang/diagnostics/DiagArgFormatter.h
@@ -8,6 +8,9 @@
 #pragma once
 
 #include <any>
+#include <string>
+
+#include "slang/slang_export.h"
 
 namespace slang {
 

--- a/include/slang/util/BumpAllocator.h
+++ b/include/slang/util/BumpAllocator.h
@@ -10,6 +10,7 @@
 #include <cstring>
 #include <new>
 #include <span>
+#include <type_traits>
 
 #include "slang/util/Util.h"
 

--- a/include/slang/util/CopyPtr.h
+++ b/include/slang/util/CopyPtr.h
@@ -7,6 +7,10 @@
 //------------------------------------------------------------------------------
 #pragma once
 
+#include <cstddef>
+#include <ostream>
+#include <utility>
+
 namespace slang {
 
 /// A smart pointer that allocates its pointee on the heap and provides value copy

--- a/include/slang/util/Function.h
+++ b/include/slang/util/Function.h
@@ -7,7 +7,9 @@
 //------------------------------------------------------------------------------
 #pragma once
 
+#include <cstddef>
 #include <cstdint>
+#include <type_traits>
 
 namespace slang {
 

--- a/include/slang/util/Random.h
+++ b/include/slang/util/Random.h
@@ -7,6 +7,7 @@
 //------------------------------------------------------------------------------
 #pragma once
 
+#include <algorithm>
 #include <array>
 #include <functional>
 #include <random>

--- a/include/slang/util/SmallVector.h
+++ b/include/slang/util/SmallVector.h
@@ -8,6 +8,7 @@
 #pragma once
 
 #include <algorithm>
+#include <iterator>
 #include <limits>
 #include <memory>
 #include <span>

--- a/scripts/diagnostic_gen.py
+++ b/scripts/diagnostic_gen.py
@@ -42,7 +42,8 @@ def main():
     try:
         os.makedirs(headerdir, exist_ok=True)
     except OSError as err:
-        print("Directory '%s' can not be created" % headerdir)
+        print(err)
+        print("Directory '%s' can not be created: %s" % headerdir)
         sys.exit(1)
 
     diags = {}

--- a/scripts/diagnostic_gen.py
+++ b/scripts/diagnostic_gen.py
@@ -12,10 +12,12 @@ import sys
 
 
 def writefile(path, contents):
-    existing = None
-    if os.path.exists(path):
+    try:
         with open(path, "r") as f:
             existing = f.read()
+    except OSError:
+        existing = ""
+
     if existing != contents:
         with open(path, "w") as f:
             f.write(contents)
@@ -31,20 +33,9 @@ def main():
     parser.add_argument("--slangBin")
     args = parser.parse_args()
 
-    inf = None
-    try:
-        inf = open(args.diagnostics)
-    except Exception:
-        print("failed to open", args.diagnostics)
-        sys.exit(1)
-
+    inf = open(args.diagnostics)
     headerdir = os.path.join(args.outDir, "slang", "diagnostics")
-    try:
-        os.makedirs(headerdir, exist_ok=True)
-    except OSError as err:
-        print(err)
-        print("Directory '%s' can not be created: %s" % headerdir)
-        sys.exit(1)
+    os.makedirs(headerdir, exist_ok=True)
 
     diags = {}
     groups = []
@@ -316,7 +307,7 @@ def createdocs(outDir, inpath, slangBin, diags, groups):
                 curropt[1] += " "
             curropt[1] += line
 
-    if len(curropt[0]) > 0:
+    if curropt[0]:
         exampleMap[curropt[0]] = curropt
 
     for k, v in exampleMap.items():

--- a/scripts/diagnostic_gen.py
+++ b/scripts/diagnostic_gen.py
@@ -14,7 +14,7 @@ import sys
 def writefile(path, contents):
     existing = None
     if os.path.exists(path):
-        with open(path, 'r') as f:
+        with open(path, "r") as f:
             existing = f.read()
     if existing != contents:
         with open(path, "w") as f:
@@ -285,7 +285,7 @@ def createallheader(path, diags):
 
 def createdocs(outDir, inpath, slangBin, diags, groups):
     inf = open(inpath)
-    curropt = [ None, None, None, None, None ]
+    curropt = [None, None, None, None, None]
     inexample = False
     exampleMap = {}
 

--- a/scripts/syntax_gen.py
+++ b/scripts/syntax_gen.py
@@ -48,17 +48,18 @@ def main():
     parser = argparse.ArgumentParser(description="Diagnostic source generator")
     parser.add_argument("--dir", default=os.getcwd(), help="Output directory")
     parser.add_argument("--python-bindings", action="store_true")
+    parser.add_argument("--syntax", help="full path to syntax file")
     args = parser.parse_args()
 
-    ourdir = os.path.dirname(os.path.realpath(__file__))
-    alltypes, kindmap = loadalltypes(ourdir)
+    inputdir = os.path.dirname(args.syntax)
+    alltypes, kindmap = loadalltypes(inputdir)
 
     if args.python_bindings:
         generatePyBindings(args.dir, alltypes)
     else:
         generateSyntaxClone(args.dir, alltypes, kindmap)
         generateSyntax(args.dir, alltypes, kindmap)
-        generateTokenKinds(ourdir, args.dir)
+        generateTokenKinds(inputdir, args.dir)
 
 
 def loadalltypes(ourdir):
@@ -764,6 +765,9 @@ const std::type_info* typeFromSyntaxKind(SyntaxKind kind) {
 // SPDX-License-Identifier: MIT
 //------------------------------------------------------------------------------
 #pragma once
+
+#include <ostream>
+#include "slang/slang_export.h"
 
 namespace std { class type_info; }
 

--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -10,7 +10,7 @@ add_custom_command(
   COMMAND
     ${Python_EXECUTABLE} ${SCRIPTS_DIR}/diagnostic_gen.py --outDir
     ${CMAKE_CURRENT_BINARY_DIR} --srcDir ${CMAKE_CURRENT_SOURCE_DIR} --incDir
-    ${CMAKE_CURRENT_SOURCE_DIR}/../include/slang
+    ${CMAKE_CURRENT_SOURCE_DIR}/../include/slang --diagnostics ${SCRIPTS_DIR}/diagnostics.txt
   OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/slang/diagnostics/AllDiags.h
          ${CMAKE_CURRENT_BINARY_DIR}/slang/diagnostics/CompilationDiags.h
          ${CMAKE_CURRENT_BINARY_DIR}/slang/diagnostics/ConstEvalDiags.h
@@ -33,7 +33,7 @@ add_custom_command(
 # Generate syntax headers and sources
 add_custom_command(
   COMMAND ${Python_EXECUTABLE} ${SCRIPTS_DIR}/syntax_gen.py --dir
-          ${CMAKE_CURRENT_BINARY_DIR}
+          ${CMAKE_CURRENT_BINARY_DIR} --syntax ${SCRIPTS_DIR}/syntax.txt
   OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/slang/syntax/AllSyntax.h
          ${CMAKE_CURRENT_BINARY_DIR}/AllSyntax.cpp
          ${CMAKE_CURRENT_BINARY_DIR}/SyntaxClone.cpp

--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -10,7 +10,8 @@ add_custom_command(
   COMMAND
     ${Python_EXECUTABLE} ${SCRIPTS_DIR}/diagnostic_gen.py --outDir
     ${CMAKE_CURRENT_BINARY_DIR} --srcDir ${CMAKE_CURRENT_SOURCE_DIR} --incDir
-    ${CMAKE_CURRENT_SOURCE_DIR}/../include/slang --diagnostics ${SCRIPTS_DIR}/diagnostics.txt
+    ${CMAKE_CURRENT_SOURCE_DIR}/../include/slang --diagnostics
+    ${SCRIPTS_DIR}/diagnostics.txt
   OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/slang/diagnostics/AllDiags.h
          ${CMAKE_CURRENT_BINARY_DIR}/slang/diagnostics/CompilationDiags.h
          ${CMAKE_CURRENT_BINARY_DIR}/slang/diagnostics/ConstEvalDiags.h

--- a/tools/netlist/include/DirectedGraph.h
+++ b/tools/netlist/include/DirectedGraph.h
@@ -79,7 +79,7 @@ public:
         return *this;
     }
     Node<NodeType, EdgeType>& operator=(Node<NodeType, EdgeType>&& node) noexcept {
-        edges = std::move(node.Edges);
+        edges = std::move(node.edges);
         return *this;
     }
 


### PR DESCRIPTION
Adds explicit arguments to the generator scripts to point to the input
such that they can be used in a hermetic build where the scripts do
not run from the source directory. Remaining inputs are assume to be
in the same directory.

Adds missing includes.

Fixes #1155 