### PR TITLE
Fix a case of false type equivalency

### DIFF
--- a/source/ast/types/Type.cpp
+++ b/source/ast/types/Type.cpp
@@ -426,8 +426,8 @@ bool Type::isMatching(const Type& rhs) const {
     if (l == r)
         return true;
 
-    if (l->getSyntax() && l->getSyntax() == r->getSyntax() &&
-        l->getParentScope() && l->getParentScope() == r->getParentScope())
+    if (l->getSyntax() && l->getSyntax() == r->getSyntax() && l->getParentScope() &&
+        l->getParentScope() == r->getParentScope())
         return true;
 
     // Special casing for type synonyms: real/realtime

--- a/source/ast/types/Type.cpp
+++ b/source/ast/types/Type.cpp
@@ -427,9 +427,8 @@ bool Type::isMatching(const Type& rhs) const {
         return true;
 
     if (l->getSyntax() && l->getSyntax() == r->getSyntax() &&
-        l->getParentScope() == r->getParentScope()) {
+        l->getParentScope() && l->getParentScope() == r->getParentScope())
         return true;
-    }
 
     // Special casing for type synonyms: real/realtime
     if (l->isFloating() && r->isFloating()) {

--- a/tests/unittests/ast/TypeTests.cpp
+++ b/tests/unittests/ast/TypeTests.cpp
@@ -2263,10 +2263,12 @@ TEST_CASE("Hierarchy-dependent type equivalence") {
     Compilation compilation;
     compilation.addSyntaxTree(tree);
     NO_COMPILATION_ERRORS;
-    
-    const InstanceBodySymbol &top = compilation.getRoot().lookupName<InstanceSymbol>("top").body;
-    const Type *type1 = &top.lookupName<InstanceSymbol>("if1").body.lookupName<VariableSymbol>("ready").getType();
-    const Type *type2 = &top.lookupName<InstanceSymbol>("if2").body.lookupName<VariableSymbol>("ready").getType();
+
+    const InstanceBodySymbol& top = compilation.getRoot().lookupName<InstanceSymbol>("top").body;
+    const Type* type1 =
+        &top.lookupName<InstanceSymbol>("if1").body.lookupName<VariableSymbol>("ready").getType();
+    const Type* type2 =
+        &top.lookupName<InstanceSymbol>("if2").body.lookupName<VariableSymbol>("ready").getType();
 
     CHECK(!type1->isEquivalent(*type2));
 }


### PR DESCRIPTION
Please see the included test to understand the issue. For both types `->getParentScope()` is null, maybe there's a deeper issue which causes the missing scope, but I have been able to resolve some AST inconsistencies with this fix.