### PR TITLE
Fix `BufferID.placeholder` static property, Doxygen docs

### DIFF
--- a/bindings/python/UtilBindings.cpp
+++ b/bindings/python/UtilBindings.cpp
@@ -58,9 +58,8 @@ void registerUtil(py::module_& m) {
         .def(py::init<>())
         .def_property_readonly("id", &BufferID::getId)
         .def_static("getPlaceholder", &BufferID::getPlaceholder)
-        .def_property_readonly_static("placeholder", [](py::object /* self or cls */) {
-            return BufferID::getPlaceholder();
-        })
+        .def_property_readonly_static(
+            "placeholder", [](py::object /* self or cls */) { return BufferID::getPlaceholder(); })
         .def(py::self == py::self)
         .def(py::self != py::self)
         .def(py::self < py::self)

--- a/bindings/python/UtilBindings.cpp
+++ b/bindings/python/UtilBindings.cpp
@@ -57,7 +57,10 @@ void registerUtil(py::module_& m) {
     py::class_<BufferID>(m, "BufferID")
         .def(py::init<>())
         .def_property_readonly("id", &BufferID::getId)
-        .def_property_readonly_static("placeholder", &BufferID::getPlaceholder)
+        .def_static("getPlaceholder", &BufferID::getPlaceholder)
+        .def_property_readonly_static("placeholder", [](py::object /* self or cls */) {
+            return BufferID::getPlaceholder();
+        })
         .def(py::self == py::self)
         .def(py::self != py::self)
         .def(py::self < py::self)

--- a/docs/Doxyfile.in
+++ b/docs/Doxyfile.in
@@ -1,5 +1,9 @@
 # Doxyfile 1.9.5
 
+# Note that this file cloned-and-modified by the settings in CMakeLists.txt.
+# Various placeholders (e.g., `@DOXYGEN_OUTPUT_DIR@`) are replaced with the
+# values of the corresponding CMake variables.
+
 # This file describes the settings to be used by the documentation system
 # doxygen (www.doxygen.org) for a project.
 #


### PR DESCRIPTION
During the M.CSS documentation generation setup, it errored when it got to the following:

```
        .def_property_readonly_static("placeholder", &BufferID::getPlaceholder)
```

The issue is that the static function is actually treated as a `@classmethod` in Python, and the associated C++ function is called with the `cls = type(self)` argument. In the fix, an anonymous function is used to discard the `cls` in the call.

Also added a note about Doxygen.in which I wish was present from the start. 