### PR TITLE
Rename all `Enum.None` to `Enum.None_`

### DIFF
--- a/bindings/python/ASTBindings.cpp
+++ b/bindings/python/ASTBindings.cpp
@@ -28,7 +28,7 @@ void registerAST(py::module_& m) {
         .value("Interrupt", VisitAction::Interrupt);
 
     py::enum_<EvalFlags>(m, "EvalFlags")
-        .value("None", EvalFlags::None)
+        .value("None_", EvalFlags::None)
         .value("IsScript", EvalFlags::IsScript)
         .value("CacheResults", EvalFlags::CacheResults)
         .value("SpecparamsAllowed", EvalFlags::SpecparamsAllowed)
@@ -75,7 +75,7 @@ void registerAST(py::module_& m) {
         .def("store", &LValue::store, "value"_a);
 
     py::enum_<ASTFlags>(m, "ASTFlags")
-        .value("None", ASTFlags::None)
+        .value("None_", ASTFlags::None)
         .value("InsideConcatenation", ASTFlags::InsideConcatenation)
         .value("UnevaluatedBranch", ASTFlags::UnevaluatedBranch)
         .value("AllowDataType", ASTFlags::AllowDataType)

--- a/bindings/python/CompBindings.cpp
+++ b/bindings/python/CompBindings.cpp
@@ -41,7 +41,7 @@ void registerCompilation(py::module_& m) {
         .value("Max", MinTypMax::Max);
 
     py::enum_<CompilationFlags>(m, "CompilationFlags")
-        .value("None", CompilationFlags::None)
+        .value("None_", CompilationFlags::None)
         .value("AllowHierarchicalConst", CompilationFlags::AllowHierarchicalConst)
         .value("RelaxEnumConversions", CompilationFlags::RelaxEnumConversions)
         .value("AllowUseBeforeDeclare", CompilationFlags::AllowUseBeforeDeclare)
@@ -287,7 +287,7 @@ void registerCompilation(py::module_& m) {
         .def("__repr__", [](const SystemSubroutine& self) { return self.name; });
 
     py::enum_<SystemSubroutine::WithClauseMode>(systemSub, "WithClauseMode")
-        .value("None", SystemSubroutine::WithClauseMode::None)
+        .value("None_", SystemSubroutine::WithClauseMode::None)
         .value("Iterator", SystemSubroutine::WithClauseMode::Iterator)
         .value("Randomize", SystemSubroutine::WithClauseMode::Randomize);
 

--- a/bindings/python/SymbolBindings.cpp
+++ b/bindings/python/SymbolBindings.cpp
@@ -23,7 +23,7 @@ void registerSymbols(py::module_& m) {
     EXPOSE_ENUM(m, SystemTimingCheckKind);
 
     py::enum_<LookupFlags>(m, "LookupFlags")
-        .value("None", LookupFlags::None)
+        .value("None_", LookupFlags::None)
         .value("Type", LookupFlags::Type)
         .value("AllowDeclaredAfter", LookupFlags::AllowDeclaredAfter)
         .value("DisallowWildcardImport", LookupFlags::DisallowWildcardImport)
@@ -42,7 +42,7 @@ void registerSymbols(py::module_& m) {
         .value("DisallowUnitReferences", LookupFlags::DisallowUnitReferences);
 
     py::enum_<LookupResultFlags>(m, "LookupResultFlags")
-        .value("None", LookupResultFlags::None)
+        .value("None_", LookupResultFlags::None)
         .value("WasImported", LookupResultFlags::WasImported)
         .value("IsHierarchical", LookupResultFlags::IsHierarchical)
         .value("SuppressUndeclared", LookupResultFlags::SuppressUndeclared)
@@ -272,7 +272,7 @@ void registerSymbols(py::module_& m) {
         .def_property_readonly("pathDest", &SpecparamSymbol::getPathDest);
 
     py::enum_<VariableFlags>(m, "VariableFlags")
-        .value("None", VariableFlags::None)
+        .value("None_", VariableFlags::None)
         .value("Const", VariableFlags::Const)
         .value("CompilerGenerated", VariableFlags::CompilerGenerated)
         .value("ImmutableCoverageOption", VariableFlags::ImmutableCoverageOption)
@@ -302,7 +302,7 @@ void registerSymbols(py::module_& m) {
         .def_property_readonly("driveStrength", &NetSymbol::getDriveStrength);
 
     py::enum_<NetSymbol::ExpansionHint>(netSymbol, "ExpansionHint")
-        .value("None", NetSymbol::None)
+        .value("None_", NetSymbol::None)
         .value("Vectored", NetSymbol::Vectored)
         .value("Scalared", NetSymbol::Scalared)
         .export_values();
@@ -327,7 +327,7 @@ void registerSymbols(py::module_& m) {
         .def_readonly("randMode", &ClassPropertySymbol::randMode);
 
     py::enum_<MethodFlags>(m, "MethodFlags")
-        .value("None", MethodFlags::None)
+        .value("None_", MethodFlags::None)
         .value("Virtual", MethodFlags::Virtual)
         .value("Pure", MethodFlags::Pure)
         .value("Static", MethodFlags::Static)
@@ -700,7 +700,7 @@ void registerSymbols(py::module_& m) {
         .def_readonly("repeatKind", &CoverageBinSymbol::TransRangeList::repeatKind);
 
     py::enum_<CoverageBinSymbol::TransRangeList::RepeatKind>(transRangeList, "RepeatKind")
-        .value("None", CoverageBinSymbol::TransRangeList::None)
+        .value("None_", CoverageBinSymbol::TransRangeList::None)
         .value("Consecutive", CoverageBinSymbol::TransRangeList::Consecutive)
         .value("Nonconsecutive", CoverageBinSymbol::TransRangeList::Nonconsecutive)
         .value("GoTo", CoverageBinSymbol::TransRangeList::GoTo)

--- a/bindings/python/TypeBindings.cpp
+++ b/bindings/python/TypeBindings.cpp
@@ -290,7 +290,7 @@ void registerTypes(py::module_& m) {
         .def_property_readonly("firstForwardDecl", &GenericClassDefSymbol::getFirstForwardDecl);
 
     py::enum_<ConstraintBlockFlags>(m, "ConstraintBlockFlags")
-        .value("None", ConstraintBlockFlags::None)
+        .value("None_", ConstraintBlockFlags::None)
         .value("Pure", ConstraintBlockFlags::Pure)
         .value("Static", ConstraintBlockFlags::Static)
         .value("Extern", ConstraintBlockFlags::Extern)


### PR DESCRIPTION
Here is an example of what the type stubs look like without this change:

```python
# File: pyslang.pyi - sample

import enum

class ConstraintBlockFlags(enum.Enum):
    None = 0
    Pure = 2
    Static = 4
    Extern = 8
    ExplicitExtern = 16
    Initial = 32
    Extends = 64
    Final = 128
```

Unfortunately, in Python, `None` is a protected keyword that cannot be assigned to like above. As a workaround, this PR finds-and-replaces all `.value("None"` with `.value("None_"`, thus changing the enum element name binding as it appears in Python.

This is a prerequisite for https://github.com/MikePopoloski/pyslang/issues/312.

Discussion on how it may technically be possible to avoid this change, but why it's a horrible idea to hack a workaround - https://stackoverflow.com/questions/38773832/is-it-possible-to-add-a-value-named-none-to-enum-type