### PR TITLE
Fix [*] and ##[*] operator range minimums to be 0

### DIFF
--- a/source/ast/expressions/AssertionExpr.cpp
+++ b/source/ast/expressions/AssertionExpr.cpp
@@ -487,6 +487,10 @@ SequenceRepetition::SequenceRepetition(const SequenceRepetitionSyntax& syntax,
             kind = Consecutive;
             range.min = 1;
             return;
+        case TokenKind::Star:
+            kind = Consecutive;
+            range.min = 0;
+            break;
         default:
             kind = Consecutive;
             break;
@@ -663,6 +667,9 @@ AssertionExpr& SequenceConcatExpr::fromSyntax(const DelayedSequenceExprSyntax& s
         else if (es->range) {
             delay = SequenceRange::fromSyntax(*es->range, context,
                                               /* allowUnbounded */ true);
+        }
+        else if (es->op.kind == TokenKind::Star) {
+            delay.min = 0;
         }
         else if (es->op.kind == TokenKind::Plus) {
             delay.min = 1;


### PR DESCRIPTION
According to the LRM, `[*] is an equivalent representation of [*0:$]` (1800-2023 p411 16.9.1) and `##[*] is used as an equivalent representation of ##[0:$]` (1800-2023 p400 16.7).

With the current master build of slang (170ad7ba), `[*]` and `[*0:$]` produce the following ast json respectively:
```json
"repetition": {
  "kind": "Consecutive",
  "min": 1,
  "max": "$"
}
```
```json
"repetition": {
  "kind": "Consecutive",
  "min": 0,
  "max": "$"
}
```

and `##[*]` and `##[0:$]` produce the following respectively:
```json
{
  "sequence": {
    "kind": "Simple",
    "expr": {
      "kind": "Invalid",
      "type": "<error>"
    }
  },
  "min": 1,
  "max": "$"
}
```
```json
{
  "sequence": {
    "kind": "Simple",
    "expr": {
      "kind": "Invalid",
      "type": "<error>"
    }
  },
  "min": 0,
  "max": "$"
}
```

These should all have the same `min` value of 0, but these cases weren't being handled correctly. This patch adds the special casing needed for these two scenarios, and the output now has `"min": 0` for all cases.

An alternative approach could be to set the default `SequenceRange::min` value to 0, but I wasn't sure if other code relies on it being 1.