### PR TITLE
build arm64 python packages

### DIFF
--- a/.github/workflows/python-dist.yml
+++ b/.github/workflows/python-dist.yml
@@ -32,7 +32,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest, ubuntu-24.04-arm, macos-latest, windows-latest]
     steps:
     - uses: actions/checkout@v4
       with:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,6 +59,7 @@ SLANG_INCLUDE_PYLIB = "ON"
 [tool.cibuildwheel]
 archs = ["auto64"]
 manylinux-x86_64-image = "manylinux_2_28"
+manylinux-aarch64-image = "manylinux_2_28"
 skip = ["pp*", "cp36-*", "*musllinux*"]
 build-verbosity = 1
 test-command = "pytest {project}/pyslang/tests"


### PR DESCRIPTION
Adds:
- building of arm64 python packages to the python-dist flow, this will ensure users on arm based linux distributions will be able to use the python packaged slang.

Successful build: https://github.com/gadfort/slang/actions/runs/12835956579

I can also PR this in the pyslang repo, but it appears that, that repo is migrating to this repo. Just let me know.