### PR TITLE
[bug][slang] Fix case selector huge bitwidth segmentation fault

### DIFF
--- a/source/ast/statements/ConditionalStatements.cpp
+++ b/source/ast/statements/ConditionalStatements.cpp
@@ -239,21 +239,22 @@ public:
         if (auto result = find(value, 0, expr, wildcardX))
             return result;
 
-        CaseTrie* curr = this;
+        Node curr;
+        curr.trie = this;
         const auto width = value.getBitWidth();
         for (uint32_t i = 0; i < width; i++) {
             const auto bit = value[(int32_t)i];
             const bool isWildcard = wildcardX ? bit.isUnknown() : bit.value == logic_t::Z_VALUE;
             const auto valueIndex = isWildcard ? 3 : bit.isUnknown() ? 2 : bit.value;
 
-            auto& elem = curr->nodes[valueIndex];
+            auto& elem = curr.trie->nodes[valueIndex];
             if (i == width - 1) {
                 elem.expr = &expr;
             }
             else {
                 if (!elem.trie)
                     elem.trie = alloc.emplace<CaseTrie>();
-                curr = elem.trie;
+                curr = elem;
             }
         }
 
@@ -284,9 +285,9 @@ private:
         return nullptr;
     }
 
-    union Node {
-        CaseTrie* trie;
-        const Expression* expr;
+    struct Node {
+        CaseTrie* trie = nullptr;
+        const Expression* expr = nullptr;
     };
     Node nodes[4] = {};
 };

--- a/tests/unittests/ast/WarningTests.cpp
+++ b/tests/unittests/ast/WarningTests.cpp
@@ -1261,6 +1261,30 @@ endmodule
     CHECK(diags[6].code == diag::CaseOverlap);
 }
 
+TEST_CASE("Case statement with huge bit width selector") {
+    auto tree = SyntaxTree::fromText(R"(
+module test9(
+  input reg [100:0] sel_i,
+  input reg trg_i,
+  output reg [1:0] reg_o
+);
+  always @(posedge trg_i) begin
+    casex (sel_i)
+      -12'b00zzzzz00001,
+      12'b11: reg_o = 2'b01;
+    endcase
+  end
+endmodule
+)");
+
+    Compilation compilation;
+    compilation.addSyntaxTree(tree);
+
+    auto& diags = compilation.getAllDiagnostics();
+    REQUIRE(diags.size() == 1);
+    CHECK(diags[0].code == diag::CaseDefault);
+}
+
 TEST_CASE("Case items with unknowns that are not wildcards") {
     auto tree = SyntaxTree::fromText(R"(
 module m;


### PR DESCRIPTION
Hi @MikePopoloski!

There are a two examples of `casex` which works incorrect with slang:

```verilog
// This one is segfaults on release and debug builds

module test9(
  input reg [100:0] sel_i,
  input reg trg_i,
  output reg [1:0] reg_o
);
  always @(posedge trg_i) begin
    casex (sel_i)
      -12'b00zzzzz00001,
      12'b11: reg_o = 2'b01;
    endcase
  end
endmodule
```

and

```verilog
// This one produce the strange error on debug build:
// internal compiler error: Assertion 'noteLocation' failed
// in file /home/yan/projects/slang/source/diagnostics/Diagnostics.cpp, line 30
//  function: slang::Diagnostic& slang::Diagnostic::addNote(slang::DiagCode, slang::SourceLocation)

module test9(
  input reg [100:0] sel_i,
  input reg trg_i,
  output reg [1:0] reg_o
);
  always @(posedge trg_i) begin
    casex (sel_i)
      12'sb00xxxxx00001,
      -12'b00zzzzz00001,
      12'b11: reg_o = 2'b01;
    endcase
  end
endmodule
```

I think the whole point is that it is dangerous to use `unions` (for example - [here](https://github.com/MikePopoloski/slang/blob/master/source/ast/statements/ConditionalStatements.cpp#L287)), especially since it is impossible to check which [type](https://github.com/MikePopoloski/slang/blob/master/source/ast/statements/ConditionalStatements.cpp#L277) was actually written to the tree node. This can also happen because of different bit lengths of labels (in one case - for the first label `value.getBitWidth()` returns 12 (leading zeros in front), and in the other 101).