### PR TITLE
[slang-tidy] Fix XilinxDoNotCareValues checker

### DIFF
--- a/tools/tidy/src/synthesis/XilinxDoNotCareValues.cpp
+++ b/tools/tidy/src/synthesis/XilinxDoNotCareValues.cpp
@@ -7,9 +7,11 @@
 #include "fmt/color.h"
 
 #include "slang/syntax/AllSyntax.h"
+#include "slang/syntax/SyntaxPrinter.h"
 
 using namespace slang;
 using namespace slang::ast;
+using namespace slang::syntax;
 
 namespace xilinx_do_not_care_values {
 struct MainVisitor : public TidyVisitor, ASTVisitor<MainVisitor, true, true> {
@@ -17,8 +19,9 @@ struct MainVisitor : public TidyVisitor, ASTVisitor<MainVisitor, true, true> {
 
     void handle(const IntegerLiteral& expr) {
         if (auto syntax = expr.syntax; syntax) {
-            bool hasDoNotCare = syntax->toString().find('?') != std::string::npos;
-            bool hasDecimal = syntax->toString().find('d') != std::string::npos;
+            auto strSyntax = SyntaxPrinter().setIncludeTrivia(false).print(*syntax).str();
+            bool hasDoNotCare = strSyntax.find('?') != std::string::npos;
+            bool hasDecimal = strSyntax.find('d') != std::string::npos;
 
             if (hasDoNotCare && hasDecimal)
                 diags.add(diag::XilinxDoNotCareValues, syntax->sourceRange());

--- a/tools/tidy/tests/XilinxDoNotCareValuesTest.cpp
+++ b/tools/tidy/tests/XilinxDoNotCareValuesTest.cpp
@@ -63,3 +63,24 @@ endmodule
     bool result = visitor->check(root);
     CHECK(result);
 }
+
+TEST_CASE("XilinxDoNotCareValues: No do-not-care values but with comment") {
+    auto tree = SyntaxTree::fromText(R"(
+module top;
+    logic [3:0] a =
+       /*'d?*/4'd10;
+endmodule
+)");
+
+    Compilation compilation;
+    compilation.addSyntaxTree(tree);
+    compilation.getAllDiagnostics();
+    auto& root = compilation.getRoot();
+
+    TidyConfig config;
+    Registry::setConfig(config);
+    Registry::setSourceManager(compilation.getSourceManager());
+    auto visitor = Registry::create("XilinxDoNotCareValues");
+    bool result = visitor->check(root);
+    CHECK(result);
+}


### PR DESCRIPTION
Following checker have a false positives because it is does not take into account the use of `questions` inside a comments.