### PR TITLE
Add stub generation to `python-dist.yml` release workflow

### DIFF
--- a/.github/workflows/python-dist.yml
+++ b/.github/workflows/python-dist.yml
@@ -1,4 +1,6 @@
 name: "Python Dist"
+description: "Build and upload Python distributions to PyPI"
+
 on:
   workflow_dispatch:
   release:
@@ -13,6 +15,25 @@ jobs:
     - uses: actions/checkout@v4
       with:
         fetch-depth: 0
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: "3.x"
+    - name: Install dependencies
+      run: |
+        python -m venv venv/
+        ./venv/bin/python -m pip install --upgrade pip
+        ./venv/bin/python -m pip install build twine pybind11-stubgen
+    - name: Build and install pyslang (for stub generation)
+      run: |
+        ./venv/bin/python -m pip install .
+    - name: Generate Python stubs
+      run: |
+        mkdir pyslang/pyslang/
+        ./venv/bin/python -m pybind11_stubgen pyslang -o pyslang/ --root-suffix ''
+    - name: Verify that stub file was generated
+      run: |
+        test -f pyslang/pyslang/__init__.pyi
     - name: Build SDist
       run: pipx run build --sdist
     - name: Check metadata
@@ -33,6 +54,25 @@ jobs:
     - uses: actions/checkout@v4
       with:
         fetch-depth: 0
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: "3.x"
+    - name: Install dependencies
+      run: |
+        python -m venv venv/
+        ./venv/bin/python -m pip install --upgrade pip
+        ./venv/bin/python -m pip install build twine pybind11-stubgen
+    - name: Build and install pyslang (for stub generation)
+      run: |
+        ./venv/bin/python -m pip install .
+    - name: Generate Python stubs
+      run: |
+        mkdir pyslang/pyslang/
+        ./venv/bin/python -m pybind11_stubgen pyslang -o pyslang/ --root-suffix ''
+    - name: Verify that stub file was generated
+      run: |
+        test -f pyslang/pyslang/__init__.pyi
     - uses: maxim-lobanov/setup-xcode@v1
       if: matrix.os == 'macos-latest'
       with:


### PR DESCRIPTION
Fixes #1216 

With this, it'd be awesome to publish a new release to PyPI soon! Lots of good work going on in the Python project lately, and it'd be good to sync up the release imo.

Another reason to release is that the links on PyPI (stored in the pyproject.toml file) are out-of-date and still point to the old now-archived pyslang repo.