### PR TITLE
[slang] Do visit cached body

### DIFF
--- a/include/slang/ast/ASTVisitor.h
+++ b/include/slang/ast/ASTVisitor.h
@@ -64,7 +64,8 @@ concept HasVisitExprs = requires(const T& t, TVisitor&& visitor) { t.visitExprs(
 /// visited -- you can include that behavior by invoking @a visitDefault
 /// in your handler.
 ///
-template<typename TDerived, bool VisitStatements, bool VisitExpressions, bool VisitBad = false>
+template<typename TDerived, bool VisitStatements, bool VisitExpressions, bool VisitBad = false,
+         bool VisitCanonical = false>
 class ASTVisitor {
 #define DERIVED *static_cast<TDerived*>(this)
 public:
@@ -114,8 +115,13 @@ public:
         }
 
         if constexpr (std::is_same_v<InstanceSymbol, T>) {
-            const auto& body = t.getCanonicalBody() ? *t.getCanonicalBody() : t.body;
-            body.visit(DERIVED);
+            if constexpr (VisitCanonical) {
+                const auto& body = t.getCanonicalBody() ? *t.getCanonicalBody() : t.body;
+                body.visit(DERIVED);
+            }
+            else {
+                t.body.visit(DERIVED);
+            }
         }
 
         if constexpr (std::is_same_v<CheckerInstanceSymbol, T>) {

--- a/include/slang/ast/ASTVisitor.h
+++ b/include/slang/ast/ASTVisitor.h
@@ -113,8 +113,12 @@ public:
                 member.visit(DERIVED);
         }
 
-        if constexpr (std::is_same_v<InstanceSymbol, T> ||
-                      std::is_same_v<CheckerInstanceSymbol, T>) {
+        if constexpr (std::is_same_v<InstanceSymbol, T>) {
+            const auto& body = t.getCanonicalBody() ? *t.getCanonicalBody() : t.body;
+            body.visit(DERIVED);
+        }
+
+        if constexpr (std::is_same_v<CheckerInstanceSymbol, T>) {
             t.body.visit(DERIVED);
         }
     }


### PR DESCRIPTION
After adding instance bodies caching support (which is enabled by default) some old `instance` body usage patterns are stay untoched.

`ASTVisitor` is common interface for most of `slang` project tools. For example it widely used by `slang-tidy` checkers.

I think `ASTVisitor` interface should visit instance cached bodies if it presents. 

Otherwise, if `ASTVisitor` starts to visit the `body` of `instance` with previously cached body, it will elaborate it (for example in terms of `tidy` checker implementation this is odd implicit behaviour to do that, since elaboration should only be the `slang` compiler task).  