### PR TITLE
BumpAllocator constructor compile issue fix

### DIFF
--- a/include/slang/util/BumpAllocator.h
+++ b/include/slang/util/BumpAllocator.h
@@ -38,7 +38,7 @@ public:
     template<typename T, typename... Args>
     T* emplace(Args&&... args) {
         static_assert(std::is_trivially_destructible_v<T>);
-        return new (allocate(sizeof(T), alignof(T))) T(std::forward<Args>(args)...);
+        return new (allocate(sizeof(T), alignof(T))) T{std::forward<Args>(args)...};
     }
 
     /// Allocate @a size bytes of memory with the given @a alignment.
@@ -134,7 +134,7 @@ public:
     /// Construct a new item using the allocator.
     template<typename... Args>
     T* emplace(Args&&... args) {
-        return new (allocate(sizeof(T), alignof(T))) T(std::forward<Args>(args)...);
+        return new (allocate(sizeof(T), alignof(T))) T{std::forward<Args>(args)...};
     }
 };
 


### PR DESCRIPTION
**Is your bug report related to the C++ slang project or the pyslang Python bindings?**
C++ slang

**Describe the bug**
When building on a M3 Macbook Pro running MacOS Sequoia 15.3.1 with the macos-release cmake configuration (and any other configuration I tried), the build errored out with this error:

```
[ 67%] Building CXX object source/CMakeFiles/slang_slang.dir/ast/SystemSubroutine.cpp.o
[ 68%] Building CXX object source/CMakeFiles/slang_slang.dir/ast/TimingControl.cpp.o
In file included from /Users/nick/Projects/Rust/slang/source/ast/Compilation.cpp:8:
In file included from /Users/nick/Projects/Rust/slang/source/../include/slang/ast/Compilation.h:12:
In file included from /Users/nick/Projects/Rust/slang/source/../include/slang/ast/ASTDiagMap.h:13:
In file included from /Users/nick/Projects/Rust/slang/source/../include/slang/diagnostics/Diagnostics.h:17:
In file included from /Users/nick/Projects/Rust/slang/source/../include/slang/numeric/ConstantValue.h:16:
In file included from /Users/nick/Projects/Rust/slang/source/../include/slang/numeric/SVInt.h:16:
In file included from /Users/nick/Projects/Rust/slang/source/../include/slang/util/SmallVector.h:18:
/Users/nick/Projects/Rust/slang/source/../include/slang/util/BumpAllocator.h:41:54: error: no matching constructor for initialization of 'slang::ast::Compilation::NetAlias'
        return new (allocate(sizeof(T), alignof(T))) T(std::forward<Args>(args)...);
```

**To Reproduce**
Described above.

**Additional context**
I was able to fix the compile issue with a small edit to bump allocator as seem in this commit [here](https://github.com/nickrallison/slang/commit/f401323991e4c2887e269850c15ff2291707173d).