### PR TITLE
Add semantic analysis for `celldefine directive

### DIFF
--- a/bindings/python/SymbolBindings.cpp
+++ b/bindings/python/SymbolBindings.cpp
@@ -194,6 +194,7 @@ void registerSymbols(py::module_& m) {
         .def_readonly("definitionKind", &DefinitionSymbol::definitionKind)
         .def_readonly("defaultLifetime", &DefinitionSymbol::defaultLifetime)
         .def_readonly("unconnectedDrive", &DefinitionSymbol::unconnectedDrive)
+        .def_readonly("cellDefine", &DefinitionSymbol::cellDefine)
         .def_readonly("timeScale", &DefinitionSymbol::timeScale)
         .def_property_readonly("defaultNetType",
                                [](const DefinitionSymbol& self) { return &self.defaultNetType; })

--- a/include/slang/ast/Compilation.h
+++ b/include/slang/ast/Compilation.h
@@ -904,6 +904,7 @@ private:
         const NetType* defaultNetType = nullptr;
         std::optional<TimeScale> timeScale;
         UnconnectedDrive unconnectedDrive = UnconnectedDrive::None;
+        bool cellDefine = false;
     };
 
     // Map from syntax nodes to parse-time metadata about them.

--- a/include/slang/ast/symbols/CompilationUnitSymbols.h
+++ b/include/slang/ast/symbols/CompilationUnitSymbols.h
@@ -158,6 +158,9 @@ public:
     /// The drive setting to use for unconnected nets within this definition.
     UnconnectedDrive unconnectedDrive;
 
+    /// Whether this definition is a cell definition.
+    bool cellDefine = false;
+
     /// The timescale specified for this definition, or nullopt if none
     /// is explicitly specified.
     std::optional<TimeScale> timeScale;
@@ -187,7 +190,8 @@ public:
     /// Constructs a new instance of the DefinitionSymbol class.
     DefinitionSymbol(const Scope& scope, LookupLocation lookupLocation,
                      const syntax::ModuleDeclarationSyntax& syntax, const NetType& defaultNetType,
-                     UnconnectedDrive unconnectedDrive, std::optional<TimeScale> directiveTimeScale,
+                     UnconnectedDrive unconnectedDrive, bool cellDefine,
+                     std::optional<TimeScale> directiveTimeScale,
                      const syntax::SyntaxTree* syntaxTree);
 
     /// Returns a string description of the definition kind, such as "module",

--- a/include/slang/parsing/ParserMetadata.h
+++ b/include/slang/parsing/ParserMetadata.h
@@ -22,6 +22,7 @@ struct SLANG_EXPORT ParserMetadata {
     struct Node {
         TokenKind defaultNetType;
         TokenKind unconnectedDrive;
+        bool cellDefine = false;
         std::optional<TimeScale> timeScale;
     };
 

--- a/include/slang/parsing/Preprocessor.h
+++ b/include/slang/parsing/Preprocessor.h
@@ -130,6 +130,10 @@ public:
     /// if any has been set by the user. If none is set, this returns TokenKind::Unknown.
     TokenKind getUnconnectedDrive() const { return unconnectedDrive; }
 
+    /// Gets the currently active kind of module definition, if any has been set by
+    /// the user. If none is set, this returns false.
+    bool getCellDefine() const { return cellDefine; }
+
     /// Gets the currently active keyword version in use by the preprocessor.
     KeywordVersion getCurrentKeywordVersion() const { return keywordVersionStack.back(); }
 
@@ -176,6 +180,8 @@ private:
     Trivia handleEndKeywordsDirective(Token directive);
     Trivia handleUnconnectedDriveDirective(Token directive);
     Trivia handleNoUnconnectedDriveDirective(Token directive);
+    Trivia handleCellDefineDirective(Token directive);
+    Trivia handleEndCellDefineDirective(Token directive);
     Trivia handleDefaultDecayTimeDirective(Token directive);
     Trivia handleDefaultTriregStrengthDirective(Token directive);
     Trivia createSimpleDirective(Token directive);
@@ -421,6 +427,7 @@ private:
     std::optional<TimeScale> activeTimeScale;
     TokenKind defaultNetType = TokenKind::WireKeyword;
     TokenKind unconnectedDrive = TokenKind::Unknown;
+    bool cellDefine = false;
 
     int designElementDepth = 0;
     uint32_t includeDepth = 0;

--- a/source/ast/Compilation.cpp
+++ b/source/ast/Compilation.cpp
@@ -234,6 +234,8 @@ void Compilation::addSyntaxTree(std::shared_ptr<SyntaxTree> tree) {
                 break;
         }
 
+        result.cellDefine = meta.cellDefine;
+
         syntaxMetadata[n] = result;
     }
 
@@ -822,7 +824,7 @@ void Compilation::createDefinition(const Scope& scope, LookupLocation location,
     auto def = definitionMemory
                    .emplace_back(std::make_unique<DefinitionSymbol>(
                        scope, location, syntax, *metadata.defaultNetType, metadata.unconnectedDrive,
-                       metadata.timeScale, metadata.tree))
+                       metadata.cellDefine, metadata.timeScale, metadata.tree))
                    .get();
     definitionFromSyntax[&syntax].push_back(def);
 

--- a/source/ast/symbols/CompilationUnitSymbols.cpp
+++ b/source/ast/symbols/CompilationUnitSymbols.cpp
@@ -255,11 +255,11 @@ static const SourceLibrary& getLibForDef(const Scope& scope, const SyntaxTree* s
 DefinitionSymbol::DefinitionSymbol(const Scope& scope, LookupLocation lookupLocation,
                                    const ModuleDeclarationSyntax& syntax,
                                    const NetType& defaultNetType, UnconnectedDrive unconnectedDrive,
-                                   std::optional<TimeScale> directiveTimeScale,
+                                   bool cellDefine, std::optional<TimeScale> directiveTimeScale,
                                    const SyntaxTree* syntaxTree) :
     Symbol(SymbolKind::Definition, syntax.header->name.valueText(), syntax.header->name.location()),
-    defaultNetType(defaultNetType), unconnectedDrive(unconnectedDrive), syntaxTree(syntaxTree),
-    sourceLibrary(getLibForDef(scope, syntaxTree)) {
+    defaultNetType(defaultNetType), unconnectedDrive(unconnectedDrive), cellDefine(cellDefine),
+    syntaxTree(syntaxTree), sourceLibrary(getLibForDef(scope, syntaxTree)) {
 
     // Extract and save various properties of the definition.
     setParent(scope, lookupLocation.getIndex());
@@ -353,6 +353,7 @@ void DefinitionSymbol::serializeTo(ASTSerializer& serializer) const {
     serializer.write("definitionKind", toString(definitionKind));
     serializer.write("defaultLifetime", toString(defaultLifetime));
     serializer.write("unconnectedDrive", toString(unconnectedDrive));
+    serializer.write("cellDefine", cellDefine);
 
     if (timeScale)
         serializer.write("timeScale", timeScale->toString());

--- a/source/parsing/ParserMetadata.cpp
+++ b/source/parsing/ParserMetadata.cpp
@@ -91,7 +91,7 @@ public:
 
         // Needs to come after we visitDefault because visiting the first token
         // might update our preproc state.
-        meta.nodeMap[&syntax] = {defaultNetType, unconnectedDrive, timeScale};
+        meta.nodeMap[&syntax] = {defaultNetType, unconnectedDrive, cellDefine, timeScale};
     }
 
     void visitToken(Token token) {
@@ -112,6 +112,12 @@ public:
                     case SyntaxKind::NoUnconnectedDriveDirective:
                         unconnectedDrive = TokenKind::Unknown;
                         break;
+                    case SyntaxKind::CellDefineDirective:
+                        cellDefine = true;
+                        break;
+                    case SyntaxKind::EndCellDefineDirective:
+                        cellDefine = false;
+                        break;
                     case SyntaxKind::TimeScaleDirective: {
                         auto& tsd = s->as<TimeScaleDirectiveSyntax>();
                         if (tsd.timeUnit.kind == TokenKind::TimeLiteral &&
@@ -130,6 +136,7 @@ public:
                     case SyntaxKind::ResetAllDirective:
                         defaultNetType = TokenKind::Unknown;
                         unconnectedDrive = TokenKind::Unknown;
+                        cellDefine = false;
                         timeScale = {};
                         break;
                     default:
@@ -143,6 +150,7 @@ private:
     SmallVector<flat_hash_set<std::string_view>, 4> moduleDeclStack;
     TokenKind defaultNetType = TokenKind::Unknown;
     TokenKind unconnectedDrive = TokenKind::Unknown;
+    bool cellDefine = false;
     std::optional<TimeScale> timeScale;
 };
 

--- a/source/parsing/Parser_members.cpp
+++ b/source/parsing/Parser_members.cpp
@@ -75,7 +75,8 @@ MemberSyntax& Parser::parseModule(AttrList attributes, SyntaxKind parentKind,
     }
 
     SyntaxKind declKind = getModuleDeclarationKind(header.moduleKeyword.kind);
-    ParserMetadata::Node node{pp.getDefaultNetType(), pp.getUnconnectedDrive(), pp.getTimeScale()};
+    ParserMetadata::Node node{pp.getDefaultNetType(), pp.getUnconnectedDrive(), pp.getCellDefine(),
+                              pp.getTimeScale()};
 
     auto savedDefinitionKind = currentDefinitionKind;
     currentDefinitionKind = declKind;

--- a/source/parsing/Preprocessor.cpp
+++ b/source/parsing/Preprocessor.cpp
@@ -191,6 +191,7 @@ void Preprocessor::resetAllDirectives() {
     activeTimeScale = std::nullopt;
     defaultNetType = TokenKind::WireKeyword;
     unconnectedDrive = TokenKind::Unknown;
+    cellDefine = false;
     resetProtectState();
 }
 
@@ -356,6 +357,12 @@ Token Preprocessor::handleDirectives(Token token) {
                     case SyntaxKind::NoUnconnectedDriveDirective:
                         trivia.push_back(handleNoUnconnectedDriveDirective(token));
                         break;
+                    case SyntaxKind::CellDefineDirective:
+                        trivia.push_back(handleCellDefineDirective(token));
+                        break;
+                    case SyntaxKind::EndCellDefineDirective:
+                        trivia.push_back(handleEndCellDefineDirective(token));
+                        break;
                     case SyntaxKind::DefaultDecayTimeDirective:
                         trivia.push_back(handleDefaultDecayTimeDirective(token));
                         break;
@@ -369,8 +376,6 @@ Token Preprocessor::handleDirectives(Token token) {
                             trivia.push_back(skipped);
                         break;
                     }
-                    case SyntaxKind::CellDefineDirective:
-                    case SyntaxKind::EndCellDefineDirective:
                     case SyntaxKind::DelayModeDistributedDirective:
                     case SyntaxKind::DelayModePathDirective:
                     case SyntaxKind::DelayModeUnitDirective:
@@ -1088,6 +1093,16 @@ Trivia Preprocessor::handleUnconnectedDriveDirective(Token directive) {
 Trivia Preprocessor::handleNoUnconnectedDriveDirective(Token directive) {
     checkOutsideDesignElement(directive);
     unconnectedDrive = TokenKind::Unknown;
+    return createSimpleDirective(directive);
+}
+
+Trivia Preprocessor::handleCellDefineDirective(Token directive) {
+    cellDefine = true;
+    return createSimpleDirective(directive);
+}
+
+Trivia Preprocessor::handleEndCellDefineDirective(Token directive) {
+    cellDefine = false;
     return createSimpleDirective(directive);
 }
 

--- a/tests/unittests/parsing/PreprocessorTests.cpp
+++ b/tests/unittests/parsing/PreprocessorTests.cpp
@@ -1287,15 +1287,25 @@ TokenKind lexDefaultNetType(std::string_view text) {
 
 TEST_CASE("default_nettype directive") {
     CHECK(lexDefaultNetType("`default_nettype wire") == TokenKind::WireKeyword);
+    CHECK_DIAGNOSTICS_EMPTY;
     CHECK(lexDefaultNetType("`default_nettype uwire") == TokenKind::UWireKeyword);
+    CHECK_DIAGNOSTICS_EMPTY;
     CHECK(lexDefaultNetType("`default_nettype wand") == TokenKind::WAndKeyword);
+    CHECK_DIAGNOSTICS_EMPTY;
     CHECK(lexDefaultNetType("`default_nettype wor") == TokenKind::WOrKeyword);
+    CHECK_DIAGNOSTICS_EMPTY;
     CHECK(lexDefaultNetType("`default_nettype tri") == TokenKind::TriKeyword);
+    CHECK_DIAGNOSTICS_EMPTY;
     CHECK(lexDefaultNetType("`default_nettype tri0") == TokenKind::Tri0Keyword);
+    CHECK_DIAGNOSTICS_EMPTY;
     CHECK(lexDefaultNetType("`default_nettype tri1") == TokenKind::Tri1Keyword);
+    CHECK_DIAGNOSTICS_EMPTY;
     CHECK(lexDefaultNetType("`default_nettype triand") == TokenKind::TriAndKeyword);
+    CHECK_DIAGNOSTICS_EMPTY;
     CHECK(lexDefaultNetType("`default_nettype trior") == TokenKind::TriOrKeyword);
+    CHECK_DIAGNOSTICS_EMPTY;
     CHECK(lexDefaultNetType("`default_nettype trireg") == TokenKind::TriRegKeyword);
+    CHECK_DIAGNOSTICS_EMPTY;
     CHECK(lexDefaultNetType("`default_nettype none") == TokenKind::Unknown);
     CHECK_DIAGNOSTICS_EMPTY;
 
@@ -1318,7 +1328,9 @@ TokenKind lexUnconnectedDrive(std::string_view text) {
 
 TEST_CASE("unconnected_drive directive") {
     CHECK(lexUnconnectedDrive("`unconnected_drive pull0") == TokenKind::Pull0Keyword);
+    CHECK_DIAGNOSTICS_EMPTY;
     CHECK(lexUnconnectedDrive("`unconnected_drive pull1") == TokenKind::Pull1Keyword);
+    CHECK_DIAGNOSTICS_EMPTY;
     CHECK(lexUnconnectedDrive("`nounconnected_drive") == TokenKind::Unknown);
     CHECK_DIAGNOSTICS_EMPTY;
 

--- a/tests/unittests/parsing/PreprocessorTests.cpp
+++ b/tests/unittests/parsing/PreprocessorTests.cpp
@@ -1338,6 +1338,28 @@ TEST_CASE("unconnected_drive directive") {
     CHECK(!diagnostics.empty());
 }
 
+bool lexCellDefine(std::string_view text) {
+    diagnostics.clear();
+
+    Preprocessor preprocessor(getSourceManager(), alloc, diagnostics);
+    preprocessor.pushSource(text);
+
+    Token token = preprocessor.next();
+    REQUIRE(token);
+    return preprocessor.getCellDefine();
+}
+
+TEST_CASE("celldefine directive") {
+    CHECK(lexCellDefine("`celldefine") == true);
+    CHECK_DIAGNOSTICS_EMPTY;
+
+    CHECK(lexCellDefine("`celldefine\n`endcelldefine") == false);
+    CHECK_DIAGNOSTICS_EMPTY;
+
+    CHECK(lexCellDefine("`endcelldefine") == false);
+    CHECK_DIAGNOSTICS_EMPTY;
+}
+
 TEST_CASE("macro-defined include file") {
     auto& text = "`define FILE <include.svh>\n"
                  "`include `FILE";

--- a/tests/unittests/parsing/VisitorTests.cpp
+++ b/tests/unittests/parsing/VisitorTests.cpp
@@ -650,6 +650,7 @@ TEST_CASE("Syntax rewriting with metadata updates") {
     auto tree = SyntaxTree::fromFileInMemory(R"(
 `default_nettype none
 `unconnected_drive pull0
+`celldefine
 `timescale 1ns/1ps
 `define FOO
 
@@ -694,6 +695,7 @@ class C; endclass
     CHECK(SyntaxPrinter::printFile(*newTree) == R"(
 `default_nettype none
 `unconnected_drive pull0
+`celldefine
 `timescale 1ns/1ps
 `define FOO
 
@@ -727,6 +729,7 @@ class C; endclass
         if (key->as<ModuleDeclarationSyntax>().header->name.valueText() == "FooBar") {
             CHECK(node.timeScale->base.unit == TimeUnit::Nanoseconds);
             CHECK(node.unconnectedDrive == TokenKind::Pull0Keyword);
+            CHECK(node.cellDefine == true);
         }
     }
 }


### PR DESCRIPTION
Fixes #1295.

This is my first PR to slang, and I expect that I'll miss some of the finer points of the design. In particular I'm not sure if the transfer of the metadata from the AST to the compilation database is quite right.