### PR TITLE
pyslang: Create bindings for SyntaxRewriter

### DIFF
--- a/bindings/python/SyntaxBindings.cpp
+++ b/bindings/python/SyntaxBindings.cpp
@@ -56,61 +56,57 @@ void pySyntaxVisit(const SyntaxNode& sn, py::object f) {
 }
 
 class PySyntaxRewriter : public SyntaxRewriter<PySyntaxRewriter> {
-    public:
-        PySyntaxRewriter(pybind11::function handler) : handler(std::move(handler)) {}
-    
-        void visit(const SyntaxNode& node) {
-            try {
-                handler(pybind11::cast(&node), pybind11::cast(this));
-            } catch (const pybind11::error_already_set& e) {
-                throw;
-            }
-            visitDefault(node);
-        }
-    
-        // --- Expose protected base methods via public wrappers ---
-        void py_remove(const SyntaxNode& node) {
-            this->remove(node);
-        }
+public:
+    PySyntaxRewriter(pybind11::function handler) : handler(std::move(handler)) {}
 
-        void py_replace(const SyntaxNode& oldNode, SyntaxNode& newNode) {
-            this->replace(oldNode, cloneNode(newNode));
+    void visit(const SyntaxNode& node) {
+        try {
+            handler(pybind11::cast(&node), pybind11::cast(this));
         }
-
-        void py_insertBefore(const SyntaxNode& node, SyntaxNode& newNode) {
-            this->insertBefore(node, cloneNode(newNode));
+        catch (const pybind11::error_already_set& e) {
+            throw;
         }
+        visitDefault(node);
+    }
 
-        void py_insertAfter(const SyntaxNode& node, SyntaxNode& newNode) {
-            this->insertAfter(node, cloneNode(newNode));
-        }
+    // --- Expose protected base methods via public wrappers ---
+    void py_remove(const SyntaxNode& node) { this->remove(node); }
 
-        void py_insertAtFront(const SyntaxListBase& list, SyntaxNode& newNode, Token separator = {}) {
-            this->insertAtFront(list, cloneNode(newNode), separator);
-        }
-        
-        void py_insertAtBack(const SyntaxListBase& list, SyntaxNode& newNode, Token separator = {}) {
-            this->insertAtBack(list, cloneNode(newNode), separator);
-        }
+    void py_replace(const SyntaxNode& oldNode, SyntaxNode& newNode) {
+        this->replace(oldNode, cloneNode(newNode));
+    }
 
-        SyntaxFactory& getFactory() { return factory; }
+    void py_insertBefore(const SyntaxNode& node, SyntaxNode& newNode) {
+        this->insertBefore(node, cloneNode(newNode));
+    }
 
-    private:
-        pybind11::function handler;
+    void py_insertAfter(const SyntaxNode& node, SyntaxNode& newNode) {
+        this->insertAfter(node, cloneNode(newNode));
+    }
 
-        SyntaxNode& cloneNode(const SyntaxNode& node) {
-            return *slang::syntax::deepClone(node, this->alloc);
-        }
+    void py_insertAtFront(const SyntaxListBase& list, SyntaxNode& newNode, Token separator = {}) {
+        this->insertAtFront(list, cloneNode(newNode), separator);
+    }
+
+    void py_insertAtBack(const SyntaxListBase& list, SyntaxNode& newNode, Token separator = {}) {
+        this->insertAtBack(list, cloneNode(newNode), separator);
+    }
+
+    SyntaxFactory& getFactory() { return factory; }
+
+private:
+    pybind11::function handler;
+
+    SyntaxNode& cloneNode(const SyntaxNode& node) {
+        return *slang::syntax::deepClone(node, this->alloc);
+    }
 };
 
-std::shared_ptr<SyntaxTree> pySyntaxRewrite(
-    const std::shared_ptr<SyntaxTree>& tree,
-    pybind11::function handler
-) {
+std::shared_ptr<SyntaxTree> pySyntaxRewrite(const std::shared_ptr<SyntaxTree>& tree,
+                                            pybind11::function handler) {
     PySyntaxRewriter rewriter(std::move(handler));
     return rewriter.transform(tree);
 }
-
 
 } // end namespace
 
@@ -363,17 +359,16 @@ void registerSyntax(py::module_& m) {
         .def("str", &SyntaxPrinter::str)
         .def_static("printFile", &SyntaxPrinter::printFile, "tree"_a);
 
-
     py::class_<PySyntaxRewriter>(m, "SyntaxRewriter")
         .def("remove", &PySyntaxRewriter::py_remove)
         .def("replace", &PySyntaxRewriter::py_replace)
         .def("insert_before", &PySyntaxRewriter::py_insertBefore)
         .def("insert_after", &PySyntaxRewriter::py_insertAfter)
-        .def("insert_at_front", &PySyntaxRewriter::py_insertAtFront,
-            py::arg("list"), py::arg("newNode"), py::arg("separator") = Token())
-        .def("insert_at_back", &PySyntaxRewriter::py_insertAtBack,
-                py::arg("list"), py::arg("newNode"), py::arg("separator") = Token())
+        .def("insert_at_front", &PySyntaxRewriter::py_insertAtFront, py::arg("list"),
+             py::arg("newNode"), py::arg("separator") = Token())
+        .def("insert_at_back", &PySyntaxRewriter::py_insertAtBack, py::arg("list"),
+             py::arg("newNode"), py::arg("separator") = Token())
         .def_property_readonly("factory", &PySyntaxRewriter::getFactory);
-    
+
     m.def("rewrite", &pySyntaxRewrite, py::arg("tree"), py::arg("handler"));
 }

--- a/pyslang/tests/test_syntax_rewriter.py
+++ b/pyslang/tests/test_syntax_rewriter.py
@@ -379,8 +379,8 @@ def test_rewriter_nested():
 
                     if token.value == "logic_member_to_stay_untouched":
                         new_decl = pyslang.SyntaxTree.fromText(
-                            "logic logic_member_to_insert;", "new.sv"
-                        ).root
+                            "typedef struct{logic logic_member_to_insert;}t;", "new.sv"
+                        ).root.type.members[0]
 
                         check_func_called["insert_match_count"] += 1
 
@@ -408,7 +408,7 @@ def test_rewriter_nested():
     result_str = clean_whitespace(str(result.root))
     expected_str = clean_whitespace(str(expected.root))
     assert result_str == expected_str
-    # assert result.root.isEquivalentTo(expected.root) is True # FIXME: Can't figure out why this fails.
+    assert result.root.isEquivalentTo(expected.root) is True
 
 
 def test_rewriter_skip():

--- a/pyslang/tests/test_syntax_rewriter.py
+++ b/pyslang/tests/test_syntax_rewriter.py
@@ -1,0 +1,379 @@
+import re
+
+import pytest
+
+import pyslang
+
+
+def test_rewriter_handler_function_called_with_right_args():
+    input_tree = pyslang.SyntaxTree.fromText("""
+        module m;
+            int i;
+            logic l;
+        endmodule
+    """, "test.sv")
+
+    handler_tracker = {"call_count": 0}
+
+    def handler(*args, **kwargs):
+        assert len(args) == 2
+        assert isinstance(args[0], pyslang.SyntaxNode)
+        assert isinstance(args[1], pyslang.SyntaxRewriter)
+        assert len(kwargs) == 0
+
+        handler_tracker["call_count"] += 1
+
+    assert handler_tracker["call_count"] == 0
+    result = pyslang.rewrite(input_tree, handler)
+    assert result is not None
+    assert isinstance(result, pyslang.SyntaxTree)
+
+    assert handler_tracker["call_count"] > 0, "Handler should have been called at least once"
+    assert handler_tracker["call_count"] >= 4, "Handler should have been called at least 4 times"
+
+
+
+def test_rewriter_with_no_changes():
+    input_tree = pyslang.SyntaxTree.fromText("""
+        module m;
+            int i;
+            logic l;
+        endmodule
+    """, "test.sv")
+    expected = pyslang.SyntaxTree.fromText("""
+        module m;
+            int i;
+            logic l;
+        endmodule
+    """, "test.sv")
+    result = pyslang.rewrite(input_tree, lambda _node, _rewriter: None)
+    assert result is not None
+    assert result.root.isEquivalentTo(expected.root) is True
+
+def test_rewriter_remove():
+    input_tree = pyslang.SyntaxTree.fromText("""
+        module m;
+            int i;
+            logic l;
+        endmodule
+    """, "test.sv")
+    expected = pyslang.SyntaxTree.fromText("""
+        module m;
+            logic l;
+        endmodule
+    """, "test.sv")
+
+    check_func_called = {
+        "called": False,
+        "SyntaxList_count": 0,
+        "SyntaxList_subnode_count": 0,
+        "remove_match_count": 0
+    }
+    
+    def remove_int_var(node: pyslang.SyntaxNode, rewriter: pyslang.SyntaxRewriter) -> None:
+        assert isinstance(node, pyslang.SyntaxNode)
+        assert isinstance(rewriter, pyslang.SyntaxRewriter)
+
+        check_func_called["called"] = True
+
+        if node.kind == pyslang.SyntaxKind.DataDeclaration:
+            if node[0].kind == pyslang.SyntaxKind.SyntaxList:
+                check_func_called["SyntaxList_count"] += 1
+            else:
+                return # Go onto the next node.
+            
+            for subnode in node:
+                check_func_called["SyntaxList_subnode_count"] += 1
+                if subnode.kind == pyslang.SyntaxKind.IntType:
+                    check_func_called["remove_match_count"] += 1
+                    rewriter.remove(node)
+
+    assert check_func_called["called"] is False, "Handler should not have been called yet"
+
+    result = pyslang.rewrite(input_tree, remove_int_var)
+    print(result.root)
+    assert check_func_called["called"] is True, "Handler should have been called"
+    assert result is not None
+    assert check_func_called["SyntaxList_count"] == 2
+    assert check_func_called["SyntaxList_subnode_count"] == 10
+    assert check_func_called["remove_match_count"] == 1, "Handler should have removed one match"
+    assert result.root.isEquivalentTo(input_tree.root) is False, "input_tree should be modified"
+    assert result.root.isEquivalentTo(expected.root) is True
+
+
+def test_rewriter_insert_after_with_new_declaration_outside():
+    input_text = """
+        module m;
+            int i;
+        endmodule
+    """
+    input_tree = pyslang.SyntaxTree.fromText(input_text, "input_tree.sv")
+    expected = pyslang.SyntaxTree.fromText("""
+        module m;
+            int i;
+            logic j;
+        endmodule
+    """, "test.sv")
+
+    check_func_called = {
+        "called": False,
+        "SyntaxList_count": 0,
+        "SyntaxList_subnode_count": 0,
+        "insertion_point_match_count": 0
+    }
+
+    # Create new variable declaration to insert.
+    new_decl = pyslang.SyntaxTree.fromText(
+        "logic j;", "new.sv"
+    ).root
+    
+    def insert_logic_var(node: pyslang.SyntaxNode, rewriter: pyslang.SyntaxRewriter):
+        """Insert logic j after int i."""
+        assert isinstance(node, pyslang.SyntaxNode)
+        assert isinstance(rewriter, pyslang.SyntaxRewriter)
+        check_func_called["called"] = True
+
+        if node.kind == pyslang.SyntaxKind.DataDeclaration:
+            if node[0].kind == pyslang.SyntaxKind.SyntaxList:
+                check_func_called["SyntaxList_count"] += 1
+                
+                rewriter.insert_after(node, new_decl)
+                check_func_called["insertion_point_match_count"] += 1
+    
+    result = pyslang.rewrite(input_tree, insert_logic_var)
+    assert result is not None
+    assert check_func_called["called"] is True, "Handler should have been called"
+    assert check_func_called["SyntaxList_count"] == 1
+    assert check_func_called["insertion_point_match_count"] == 1, "Handler should have inserted one match"
+    assert result.root.isEquivalentTo(input_tree.root) is False, "input_tree should be modified"
+    assert result.root.isEquivalentTo(expected.root) is True
+    assert input_tree.root.isEquivalentTo(pyslang.SyntaxTree.fromText(input_text, "input_tree_again.sv").root) is True, "input_tree should not be modified"
+
+
+def test_rewriter_insert_after_with_new_declaration_inside():
+    input_tree = pyslang.SyntaxTree.fromText("""
+        module m;
+            int i;
+        endmodule
+    """, "test.sv")
+    expected = pyslang.SyntaxTree.fromText("""
+        module m;
+            int i;
+            logic j;
+        endmodule
+    """, "test.sv")
+
+    check_func_called = {
+        "called": False,
+        "SyntaxList_count": 0,
+        "SyntaxList_subnode_count": 0,
+        "insertion_point_match_count": 0
+    }
+    
+    def insert_logic_var(node: pyslang.SyntaxNode, rewriter: pyslang.SyntaxRewriter):
+        """Insert logic j after int i."""
+        assert isinstance(node, pyslang.SyntaxNode)
+        assert isinstance(rewriter, pyslang.SyntaxRewriter)
+        check_func_called["called"] = True
+
+        if node.kind == pyslang.SyntaxKind.DataDeclaration:
+            if node[0].kind == pyslang.SyntaxKind.SyntaxList:
+                check_func_called["SyntaxList_count"] += 1
+
+                # Create new variable declaration to insert.
+                # This test is special because `new_decl` is constructed inside this handler function!
+                new_decl = pyslang.SyntaxTree.fromText(
+                    "logic j;", "new.sv"
+                ).root
+                
+                rewriter.insert_after(node, new_decl)
+                check_func_called["insertion_point_match_count"] += 1
+    
+    result = pyslang.rewrite(input_tree, insert_logic_var)
+    assert result is not None
+    assert check_func_called["called"] is True, "Handler should have been called"
+    assert check_func_called["SyntaxList_count"] == 1
+    assert check_func_called["insertion_point_match_count"] == 1, "Handler should have inserted one match"
+    assert result.root.isEquivalentTo(input_tree.root) is False, "input_tree should be modified"
+    assert result.root.isEquivalentTo(expected.root) is True
+
+
+
+def test_rewriter_replace():
+    input_text = """
+        module m;
+            int i;
+            logic l;
+        endmodule
+    """
+    input_tree = pyslang.SyntaxTree.fromText(input_text, "input_tree.sv")
+    expected = pyslang.SyntaxTree.fromText("""
+        module m;
+            logic j;
+            logic l;
+        endmodule
+    """, "test.sv")
+
+    check_func_called = {
+        "called": False,
+        "SyntaxList_count": 0,
+        "SyntaxList_subnode_count": 0,
+        "replacement_point_match_count": 0
+    }
+    
+    def replace_int_var(node: pyslang.SyntaxNode, rewriter: pyslang.SyntaxRewriter) -> None:
+        """Replace int i with logic j."""
+        assert isinstance(node, pyslang.SyntaxNode)
+        assert isinstance(rewriter, pyslang.SyntaxRewriter)
+        check_func_called["called"] = True
+        if node.kind == pyslang.SyntaxKind.DataDeclaration:
+            if node[0].kind == pyslang.SyntaxKind.SyntaxList:
+                check_func_called["SyntaxList_count"] += 1
+
+                for subnode in node:
+                    check_func_called["SyntaxList_subnode_count"] += 1
+                    if subnode.kind == pyslang.SyntaxKind.IntType:
+                        check_func_called["replacement_point_match_count"] += 1
+                        
+                        # Create new variable declaration to insert.
+                        new_decl = pyslang.SyntaxTree.fromText(
+                            "logic j;", "new.sv"
+                        ).root
+                        
+                        rewriter.replace(node, new_decl)
+    
+    result = pyslang.rewrite(input_tree, replace_int_var)
+    assert check_func_called["called"] is True, "Handler should have been called"
+    assert check_func_called["SyntaxList_count"] == 2
+    assert check_func_called["SyntaxList_subnode_count"] == 10
+    assert check_func_called["replacement_point_match_count"] == 1, "Handler should have replaced one match"
+    assert result.root.isEquivalentTo(input_tree.root) is False, "input_tree should be modified"
+    assert result.root.isEquivalentTo(expected.root) is True
+    assert input_tree.root.isEquivalentTo(pyslang.SyntaxTree.fromText(input_text, "input_tree_again.sv").root) is True, "input_tree should not be modified"
+
+def test_rewriter_nested():
+    input_tree = pyslang.SyntaxTree.fromText("""
+        module m;
+            struct {
+                int int_member_to_be_removed;
+                logic logic_member_to_stay_untouched;
+            } s;
+        endmodule
+    """, "test.sv")
+    expected = pyslang.SyntaxTree.fromText("""
+        module m;
+            struct {
+                logic logic_member_to_insert;
+                logic logic_member_to_stay_untouched;
+            } s;
+        endmodule
+    """, "test.sv")
+
+    check_func_called = {
+        "called": False,
+        "remove_match_count": 0,
+        "insert_match_count": 0
+    }
+    
+    def modify_struct(node: pyslang.SyntaxNode, rewriter: pyslang.SyntaxRewriter) -> None:
+        """Modify the struct with several operations.
+        
+        Multiple operations:
+            1. Remove `int int_member_to_be_removed` from the struct.
+            2. Add `logic logic_member_to_insert` within the struct (at the start).
+        """
+        check_func_called["called"] = True
+
+        assert isinstance(node, pyslang.SyntaxNode)
+        assert isinstance(rewriter, pyslang.SyntaxRewriter)
+        
+        # Handle removing `int i;` from inside struct.
+        for subnode in node:
+            if subnode.kind == pyslang.SyntaxKind.IntType:
+                check_func_called["remove_match_count"] += 1
+                rewriter.remove(node)
+                break
+        
+        # Handle adding `logic j` before struct.
+        if node.kind == pyslang.SyntaxKind.StructUnionMember:
+            print(f"StructUnionMember #{check_func_called['insert_match_count']} found: {node}")
+
+            for subnode in node:
+                if subnode.kind == pyslang.SyntaxKind.SeparatedList:
+                    print(f"SeparatedList #{check_func_called['insert_match_count']} found: {list(subnode)}")
+
+                    token = subnode[0][0]
+                    assert isinstance(token, pyslang.Token)
+                    assert token.kind == pyslang.TokenKind.Identifier
+
+                    if token.value == "logic_member_to_stay_untouched":
+                        new_decl = pyslang.SyntaxTree.fromText(
+                            "logic logic_member_to_insert;", "new.sv"
+                        ).root
+
+                        check_func_called["insert_match_count"] += 1
+                        
+                        rewriter.insert_before(node, new_decl)
+    
+    result = pyslang.rewrite(input_tree, modify_struct)
+    assert result is not None
+    assert check_func_called["called"] is True, "Handler should have been called"
+    assert check_func_called["remove_match_count"] == 1, "Handler should have removed one match"
+    assert check_func_called["insert_match_count"] >= 1, "Handler should have inserted one match"
+    assert result.root.isEquivalentTo(input_tree.root) is False, "input_tree should be modified"
+
+    def clean_whitespace(s: str) -> str:
+        s = re.sub(r'\s+', ' ', s).strip()
+        # Remove extra spaces around operators.
+        s = re.sub(r'\s*([{}();,])\s*', r'\1', s)
+        return s
+
+    result_str = clean_whitespace(str(result.root))
+    expected_str = clean_whitespace(str(expected.root))
+    assert result_str == expected_str
+    # assert result.root.isEquivalentTo(expected.root) is True # FIXME: Can't figure out why this fails.
+
+def test_rewriter_skip():
+    input_tree = pyslang.SyntaxTree.fromText("""
+        module m;
+            int i;
+            logic l;
+        endmodule
+    """, "test.sv")
+    expected = pyslang.SyntaxTree.fromText("""
+        module m;
+            int i;
+            logic l;
+        endmodule
+    """, "test.sv")
+    
+    def skip_module_body(node: pyslang.SyntaxNode, rewriter: pyslang.SyntaxRewriter) -> None:
+        # Skip processing the module's body.
+        if node.kind == pyslang.SyntaxKind.ModuleDeclaration:
+            rewriter.remove(node)
+    
+    result = pyslang.rewrite(input_tree, skip_module_body)
+    assert result is not None
+    assert result.root.isEquivalentTo(expected.root) is True
+
+def test_rewriter_handler_errors_are_propagated():
+    input_str = """
+        module m;
+            int i;
+            logic l;
+        endmodule
+    """
+    input_tree = pyslang.SyntaxTree.fromText(input_str, "test.sv")
+
+    def handler_with_error(node: pyslang.SyntaxNode, rewriter: pyslang.SyntaxRewriter) -> None:
+        assert isinstance(node, pyslang.SyntaxNode)
+        assert isinstance(rewriter, pyslang.SyntaxRewriter)
+        
+        # Simulate an error in the handler.
+        raise ValueError("This is a test error.")
+
+    with pytest.raises(ValueError, match="This is a test error."):
+        pyslang.rewrite(input_tree, handler_with_error)
+
+    # Assert that the input_tree is unchanged.
+    assert input_tree.root.isEquivalentTo(pyslang.SyntaxTree.fromText(input_str, "test_again.sv").root) is True

--- a/pyslang/tests/test_syntax_rewriter.py
+++ b/pyslang/tests/test_syntax_rewriter.py
@@ -6,12 +6,15 @@ import pyslang
 
 
 def test_rewriter_handler_function_called_with_right_args():
-    input_tree = pyslang.SyntaxTree.fromText("""
+    input_tree = pyslang.SyntaxTree.fromText(
+        """
         module m;
             int i;
             logic l;
         endmodule
-    """, "test.sv")
+    """,
+        "test.sv",
+    )
 
     handler_tracker = {"call_count": 0}
 
@@ -28,49 +31,67 @@ def test_rewriter_handler_function_called_with_right_args():
     assert result is not None
     assert isinstance(result, pyslang.SyntaxTree)
 
-    assert handler_tracker["call_count"] > 0, "Handler should have been called at least once"
-    assert handler_tracker["call_count"] >= 4, "Handler should have been called at least 4 times"
-
+    assert (
+        handler_tracker["call_count"] > 0
+    ), "Handler should have been called at least once"
+    assert (
+        handler_tracker["call_count"] >= 4
+    ), "Handler should have been called at least 4 times"
 
 
 def test_rewriter_with_no_changes():
-    input_tree = pyslang.SyntaxTree.fromText("""
+    input_tree = pyslang.SyntaxTree.fromText(
+        """
         module m;
             int i;
             logic l;
         endmodule
-    """, "test.sv")
-    expected = pyslang.SyntaxTree.fromText("""
+    """,
+        "test.sv",
+    )
+    expected = pyslang.SyntaxTree.fromText(
+        """
         module m;
             int i;
             logic l;
         endmodule
-    """, "test.sv")
+    """,
+        "test.sv",
+    )
     result = pyslang.rewrite(input_tree, lambda _node, _rewriter: None)
     assert result is not None
     assert result.root.isEquivalentTo(expected.root) is True
 
+
 def test_rewriter_remove():
-    input_tree = pyslang.SyntaxTree.fromText("""
+    input_tree = pyslang.SyntaxTree.fromText(
+        """
         module m;
             int i;
             logic l;
         endmodule
-    """, "test.sv")
-    expected = pyslang.SyntaxTree.fromText("""
+    """,
+        "test.sv",
+    )
+    expected = pyslang.SyntaxTree.fromText(
+        """
         module m;
             logic l;
         endmodule
-    """, "test.sv")
+    """,
+        "test.sv",
+    )
 
     check_func_called = {
         "called": False,
         "SyntaxList_count": 0,
         "SyntaxList_subnode_count": 0,
-        "remove_match_count": 0
+        "remove_match_count": 0,
     }
-    
-    def remove_int_var(node: pyslang.SyntaxNode, rewriter: pyslang.SyntaxRewriter) -> None:
+
+    def remove_int_var(
+        node: pyslang.SyntaxNode, rewriter: pyslang.SyntaxRewriter
+    ) -> None:
         assert isinstance(node, pyslang.SyntaxNode)
         assert isinstance(rewriter, pyslang.SyntaxRewriter)
 
@@ -80,15 +101,17 @@ def test_rewriter_remove():
             if node[0].kind == pyslang.SyntaxKind.SyntaxList:
                 check_func_called["SyntaxList_count"] += 1
             else:
-                return # Go onto the next node.
-            
+                return  # Go onto the next node.
+
             for subnode in node:
                 check_func_called["SyntaxList_subnode_count"] += 1
                 if subnode.kind == pyslang.SyntaxKind.IntType:
                     check_func_called["remove_match_count"] += 1
                     rewriter.remove(node)
 
-    assert check_func_called["called"] is False, "Handler should not have been called yet"
+    assert (
+        check_func_called["called"] is False
+    ), "Handler should not have been called yet"
 
     result = pyslang.rewrite(input_tree, remove_int_var)
     print(result.root)
@@ -96,8 +119,12 @@ def test_rewriter_remove():
     assert result is not None
     assert check_func_called["SyntaxList_count"] == 2
     assert check_func_called["SyntaxList_subnode_count"] == 10
-    assert check_func_called["remove_match_count"] == 1, "Handler should have removed one match"
-    assert result.root.isEquivalentTo(input_tree.root) is False, "input_tree should be modified"
+    assert (
+        check_func_called["remove_match_count"] == 1
+    ), "Handler should have removed one match"
+    assert (
+        result.root.isEquivalentTo(input_tree.root) is False
+    ), "input_tree should be modified"
     assert result.root.isEquivalentTo(expected.root) is True
 
 
@@ -108,25 +135,26 @@ def test_rewriter_insert_after_with_new_declaration_outside():
         endmodule
     """
     input_tree = pyslang.SyntaxTree.fromText(input_text, "input_tree.sv")
-    expected = pyslang.SyntaxTree.fromText("""
+    expected = pyslang.SyntaxTree.fromText(
+        """
         module m;
             int i;
             logic j;
         endmodule
-    """, "test.sv")
+    """,
+        "test.sv",
+    )
 
     check_func_called = {
         "called": False,
         "SyntaxList_count": 0,
         "SyntaxList_subnode_count": 0,
-        "insertion_point_match_count": 0
+        "insertion_point_match_count": 0,
     }
 
     # Create new variable declaration to insert.
-    new_decl = pyslang.SyntaxTree.fromText(
-        "logic j;", "new.sv"
-    ).root
-    
+    new_decl = pyslang.SyntaxTree.fromText("logic j;", "new.sv").root
+
     def insert_logic_var(node: pyslang.SyntaxNode, rewriter: pyslang.SyntaxRewriter):
         """Insert logic j after int i."""
         assert isinstance(node, pyslang.SyntaxNode)
@@ -136,40 +164,55 @@ def test_rewriter_insert_after_with_new_declaration_outside():
         if node.kind == pyslang.SyntaxKind.DataDeclaration:
             if node[0].kind == pyslang.SyntaxKind.SyntaxList:
                 check_func_called["SyntaxList_count"] += 1
-                
+
                 rewriter.insert_after(node, new_decl)
                 check_func_called["insertion_point_match_count"] += 1
-    
+
     result = pyslang.rewrite(input_tree, insert_logic_var)
     assert result is not None
     assert check_func_called["called"] is True, "Handler should have been called"
     assert check_func_called["SyntaxList_count"] == 1
-    assert check_func_called["insertion_point_match_count"] == 1, "Handler should have inserted one match"
-    assert result.root.isEquivalentTo(input_tree.root) is False, "input_tree should be modified"
+    assert (
+        check_func_called["insertion_point_match_count"] == 1
+    ), "Handler should have inserted one match"
+    assert (
+        result.root.isEquivalentTo(input_tree.root) is False
+    ), "input_tree should be modified"
     assert result.root.isEquivalentTo(expected.root) is True
-    assert input_tree.root.isEquivalentTo(pyslang.SyntaxTree.fromText(input_text, "input_tree_again.sv").root) is True, "input_tree should not be modified"
+    assert (
+        input_tree.root.isEquivalentTo(
+            pyslang.SyntaxTree.fromText(input_text, "input_tree_again.sv").root
+        )
+        is True
+    ), "input_tree should not be modified"
 
 
 def test_rewriter_insert_after_with_new_declaration_inside():
-    input_tree = pyslang.SyntaxTree.fromText("""
+    input_tree = pyslang.SyntaxTree.fromText(
+        """
         module m;
             int i;
         endmodule
-    """, "test.sv")
-    expected = pyslang.SyntaxTree.fromText("""
+    """,
+        "test.sv",
+    )
+    expected = pyslang.SyntaxTree.fromText(
+        """
         module m;
             int i;
             logic j;
         endmodule
-    """, "test.sv")
+    """,
+        "test.sv",
+    )
 
     check_func_called = {
         "called": False,
         "SyntaxList_count": 0,
         "SyntaxList_subnode_count": 0,
-        "insertion_point_match_count": 0
+        "insertion_point_match_count": 0,
     }
-    
+
     def insert_logic_var(node: pyslang.SyntaxNode, rewriter: pyslang.SyntaxRewriter):
         """Insert logic j after int i."""
         assert isinstance(node, pyslang.SyntaxNode)
@@ -182,21 +225,22 @@ def test_rewriter_insert_after_with_new_declaration_inside():
 
                 # Create new variable declaration to insert.
                 # This test is special because `new_decl` is constructed inside this handler function!
-                new_decl = pyslang.SyntaxTree.fromText(
-                    "logic j;", "new.sv"
-                ).root
-                
+                new_decl = pyslang.SyntaxTree.fromText("logic j;", "new.sv").root
+
                 rewriter.insert_after(node, new_decl)
                 check_func_called["insertion_point_match_count"] += 1
-    
+
     result = pyslang.rewrite(input_tree, insert_logic_var)
     assert result is not None
     assert check_func_called["called"] is True, "Handler should have been called"
     assert check_func_called["SyntaxList_count"] == 1
-    assert check_func_called["insertion_point_match_count"] == 1, "Handler should have inserted one match"
-    assert result.root.isEquivalentTo(input_tree.root) is False, "input_tree should be modified"
+    assert (
+        check_func_called["insertion_point_match_count"] == 1
+    ), "Handler should have inserted one match"
+    assert (
+        result.root.isEquivalentTo(input_tree.root) is False
+    ), "input_tree should be modified"
     assert result.root.isEquivalentTo(expected.root) is True
-
 
 
 def test_rewriter_replace():
@@ -207,21 +251,26 @@ def test_rewriter_replace():
         endmodule
     """
     input_tree = pyslang.SyntaxTree.fromText(input_text, "input_tree.sv")
-    expected = pyslang.SyntaxTree.fromText("""
+    expected = pyslang.SyntaxTree.fromText(
+        """
         module m;
             logic j;
             logic l;
         endmodule
-    """, "test.sv")
+    """,
+        "test.sv",
+    )
 
     check_func_called = {
         "called": False,
         "SyntaxList_count": 0,
         "SyntaxList_subnode_count": 0,
-        "replacement_point_match_count": 0
+        "replacement_point_match_count": 0,
     }
-    
-    def replace_int_var(node: pyslang.SyntaxNode, rewriter: pyslang.SyntaxRewriter) -> None:
+
+    def replace_int_var(
+        node: pyslang.SyntaxNode, rewriter: pyslang.SyntaxRewriter
+    ) -> None:
         """Replace int i with logic j."""
         assert isinstance(node, pyslang.SyntaxNode)
         assert isinstance(rewriter, pyslang.SyntaxRewriter)
@@ -234,50 +283,68 @@ def test_rewriter_replace():
                     check_func_called["SyntaxList_subnode_count"] += 1
                     if subnode.kind == pyslang.SyntaxKind.IntType:
                         check_func_called["replacement_point_match_count"] += 1
-                        
+
                         # Create new variable declaration to insert.
                         new_decl = pyslang.SyntaxTree.fromText(
                             "logic j;", "new.sv"
                         ).root
-                        
+
                         rewriter.replace(node, new_decl)
-    
+
     result = pyslang.rewrite(input_tree, replace_int_var)
     assert check_func_called["called"] is True, "Handler should have been called"
     assert check_func_called["SyntaxList_count"] == 2
     assert check_func_called["SyntaxList_subnode_count"] == 10
-    assert check_func_called["replacement_point_match_count"] == 1, "Handler should have replaced one match"
-    assert result.root.isEquivalentTo(input_tree.root) is False, "input_tree should be modified"
+    assert (
+        check_func_called["replacement_point_match_count"] == 1
+    ), "Handler should have replaced one match"
+    assert (
+        result.root.isEquivalentTo(input_tree.root) is False
+    ), "input_tree should be modified"
     assert result.root.isEquivalentTo(expected.root) is True
-    assert input_tree.root.isEquivalentTo(pyslang.SyntaxTree.fromText(input_text, "input_tree_again.sv").root) is True, "input_tree should not be modified"
+    assert (
+        input_tree.root.isEquivalentTo(
+            pyslang.SyntaxTree.fromText(input_text, "input_tree_again.sv").root
+        )
+        is True
+    ), "input_tree should not be modified"
+
 
 def test_rewriter_nested():
-    input_tree = pyslang.SyntaxTree.fromText("""
+    input_tree = pyslang.SyntaxTree.fromText(
+        """
         module m;
             struct {
                 int int_member_to_be_removed;
                 logic logic_member_to_stay_untouched;
             } s;
         endmodule
-    """, "test.sv")
-    expected = pyslang.SyntaxTree.fromText("""
+    """,
+        "test.sv",
+    )
+    expected = pyslang.SyntaxTree.fromText(
+        """
         module m;
             struct {
                 logic logic_member_to_insert;
                 logic logic_member_to_stay_untouched;
             } s;
         endmodule
-    """, "test.sv")
+    """,
+        "test.sv",
+    )
 
     check_func_called = {
         "called": False,
         "remove_match_count": 0,
-        "insert_match_count": 0
+        "insert_match_count": 0,
     }
-    
-    def modify_struct(node: pyslang.SyntaxNode, rewriter: pyslang.SyntaxRewriter) -> None:
+
+    def modify_struct(
+        node: pyslang.SyntaxNode, rewriter: pyslang.SyntaxRewriter
+    ) -> None:
         """Modify the struct with several operations.
-        
+
         Multiple operations:
             1. Remove `int int_member_to_be_removed` from the struct.
             2. Add `logic logic_member_to_insert` within the struct (at the start).
@@ -286,21 +353,25 @@ def test_rewriter_nested():
 
         assert isinstance(node, pyslang.SyntaxNode)
         assert isinstance(rewriter, pyslang.SyntaxRewriter)
-        
+
         # Handle removing `int i;` from inside struct.
         for subnode in node:
             if subnode.kind == pyslang.SyntaxKind.IntType:
                 check_func_called["remove_match_count"] += 1
                 rewriter.remove(node)
                 break
-        
+
         # Handle adding `logic j` before struct.
         if node.kind == pyslang.SyntaxKind.StructUnionMember:
-            print(f"StructUnionMember #{check_func_called['insert_match_count']} found: {node}")
+            print(
+                f"StructUnionMember #{check_func_called['insert_match_count']} found: {node}"
+            )
 
             for subnode in node:
                 if subnode.kind == pyslang.SyntaxKind.SeparatedList:
-                    print(f"SeparatedList #{check_func_called['insert_match_count']} found: {list(subnode)}")
+                    print(
+                        f"SeparatedList #{check_func_called['insert_match_count']} found: {list(subnode)}"
+                    )
 
                     token = subnode[0][0]
                     assert isinstance(token, pyslang.Token)
@@ -312,20 +383,26 @@ def test_rewriter_nested():
                         ).root
 
                         check_func_called["insert_match_count"] += 1
-                        
+
                         rewriter.insert_before(node, new_decl)
-    
+
     result = pyslang.rewrite(input_tree, modify_struct)
     assert result is not None
     assert check_func_called["called"] is True, "Handler should have been called"
-    assert check_func_called["remove_match_count"] == 1, "Handler should have removed one match"
-    assert check_func_called["insert_match_count"] >= 1, "Handler should have inserted one match"
-    assert result.root.isEquivalentTo(input_tree.root) is False, "input_tree should be modified"
+    assert (
+        check_func_called["remove_match_count"] == 1
+    ), "Handler should have removed one match"
+    assert (
+        check_func_called["insert_match_count"] >= 1
+    ), "Handler should have inserted one match"
+    assert (
+        result.root.isEquivalentTo(input_tree.root) is False
+    ), "input_tree should be modified"
 
     def clean_whitespace(s: str) -> str:
-        s = re.sub(r'\s+', ' ', s).strip()
+        s = re.sub(r"\s+", " ", s).strip()
         # Remove extra spaces around operators.
-        s = re.sub(r'\s*([{}();,])\s*', r'\1', s)
+        s = re.sub(r"\s*([{}();,])\s*", r"\1", s)
         return s
 
     result_str = clean_whitespace(str(result.root))
@@ -333,28 +410,38 @@ def test_rewriter_nested():
     assert result_str == expected_str
     # assert result.root.isEquivalentTo(expected.root) is True # FIXME: Can't figure out why this fails.
 
+
 def test_rewriter_skip():
-    input_tree = pyslang.SyntaxTree.fromText("""
+    input_tree = pyslang.SyntaxTree.fromText(
+        """
         module m;
             int i;
             logic l;
         endmodule
-    """, "test.sv")
-    expected = pyslang.SyntaxTree.fromText("""
+    """,
+        "test.sv",
+    )
+    expected = pyslang.SyntaxTree.fromText(
+        """
         module m;
             int i;
             logic l;
         endmodule
-    """, "test.sv")
-    
-    def skip_module_body(node: pyslang.SyntaxNode, rewriter: pyslang.SyntaxRewriter) -> None:
+    """,
+        "test.sv",
+    )
+
+    def skip_module_body(
+        node: pyslang.SyntaxNode, rewriter: pyslang.SyntaxRewriter
+    ) -> None:
         # Skip processing the module's body.
         if node.kind == pyslang.SyntaxKind.ModuleDeclaration:
             rewriter.remove(node)
-    
+
     result = pyslang.rewrite(input_tree, skip_module_body)
     assert result is not None
     assert result.root.isEquivalentTo(expected.root) is True
+
 
 def test_rewriter_handler_errors_are_propagated():
     input_str = """
@@ -365,10 +452,12 @@ def test_rewriter_handler_errors_are_propagated():
     """
     input_tree = pyslang.SyntaxTree.fromText(input_str, "test.sv")
 
-    def handler_with_error(node: pyslang.SyntaxNode, rewriter: pyslang.SyntaxRewriter) -> None:
+    def handler_with_error(
+        node: pyslang.SyntaxNode, rewriter: pyslang.SyntaxRewriter
+    ) -> None:
         assert isinstance(node, pyslang.SyntaxNode)
         assert isinstance(rewriter, pyslang.SyntaxRewriter)
-        
+
         # Simulate an error in the handler.
         raise ValueError("This is a test error.")
 
@@ -376,4 +465,9 @@ def test_rewriter_handler_errors_are_propagated():
         pyslang.rewrite(input_tree, handler_with_error)
 
     # Assert that the input_tree is unchanged.
-    assert input_tree.root.isEquivalentTo(pyslang.SyntaxTree.fromText(input_str, "test_again.sv").root) is True
+    assert (
+        input_tree.root.isEquivalentTo(
+            pyslang.SyntaxTree.fromText(input_str, "test_again.sv").root
+        )
+        is True
+    )

--- a/pyslang/tests/test_syntax_tree_equality.py
+++ b/pyslang/tests/test_syntax_tree_equality.py
@@ -105,3 +105,32 @@ def test_verilog_equality() -> None:
     assert st1_stripped.root.isEquivalentTo(st2.root)
     assert st1.root.isEquivalentTo(st2.root)
     assert st1.root.isEquivalentTo(st2_stripped.root)
+
+def test_verilog_equality_with_whitespaces_around_operators() -> None:
+    """Test a specific case with structs."""
+    tree1 = pyslang.SyntaxTree.fromText("""
+        module m;
+            struct {logic logic_signal_to_insert;
+                logic logic_member_to_stay_untouched;
+            } s;
+        endmodule""", "test.sv")
+    
+    tree2 = pyslang.SyntaxTree.fromText("""
+    module m;
+        struct {logic logic_signal_to_insert;
+            logic logic_member_to_stay_untouched;
+        } s;
+    endmodule""", "test.sv")
+
+    assert tree1.root.isEquivalentTo(tree2.root) is True
+
+    tree3 = pyslang.SyntaxTree.fromText("""
+        module m;
+            struct {
+                logic logic_signal_to_insert;
+                logic logic_member_to_stay_untouched;
+            } s;
+        endmodule
+    """, "test.sv")
+    assert tree1.root.isEquivalentTo(tree3.root) is True
+    assert tree2.root.isEquivalentTo(tree3.root) is True

--- a/pyslang/tests/test_syntax_tree_equality.py
+++ b/pyslang/tests/test_syntax_tree_equality.py
@@ -106,31 +106,41 @@ def test_verilog_equality() -> None:
     assert st1.root.isEquivalentTo(st2.root)
     assert st1.root.isEquivalentTo(st2_stripped.root)
 
+
 def test_verilog_equality_with_whitespaces_around_operators() -> None:
     """Test a specific case with structs."""
-    tree1 = pyslang.SyntaxTree.fromText("""
+    tree1 = pyslang.SyntaxTree.fromText(
+        """
         module m;
             struct {logic logic_signal_to_insert;
                 logic logic_member_to_stay_untouched;
             } s;
-        endmodule""", "test.sv")
-    
-    tree2 = pyslang.SyntaxTree.fromText("""
+        endmodule""",
+        "test.sv",
+    )
+
+    tree2 = pyslang.SyntaxTree.fromText(
+        """
     module m;
         struct {logic logic_signal_to_insert;
             logic logic_member_to_stay_untouched;
         } s;
-    endmodule""", "test.sv")
+    endmodule""",
+        "test.sv",
+    )
 
     assert tree1.root.isEquivalentTo(tree2.root) is True
 
-    tree3 = pyslang.SyntaxTree.fromText("""
+    tree3 = pyslang.SyntaxTree.fromText(
+        """
         module m;
             struct {
                 logic logic_signal_to_insert;
                 logic logic_member_to_stay_untouched;
             } s;
         endmodule
-    """, "test.sv")
+    """,
+        "test.sv",
+    )
     assert tree1.root.isEquivalentTo(tree3.root) is True
     assert tree2.root.isEquivalentTo(tree3.root) is True


### PR DESCRIPTION
Massive project - implementing bindings and tests for SyntaxRewriter. Finally done. 

There seems to be one quirk - the check at the end of the `test_rewriter_nested()` test (see the `# FIXME` comment). Would really appreciate it if you could help me take a look at that and see why `assert result.root.isEquivalentTo(expected.root) is True` fails, but checking string equality (neglecting whitespaces) passes. 

Fixes #1271