### PR TITLE
chore: Add `__init__.pyi` file to `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ __pycache__/
 *.pyo
 *.pyd
 _version.py
+__init__.pyi
 
 # C and CMake ignores.
 build/


### PR DESCRIPTION
Helpful to have this file ignored in the case that someone generates it locally for developing tests/examples in their local dev install.