### PR TITLE
fix: Invalid autogenerated bindings using `None`/`with` fields

### DIFF
--- a/bindings/python/pyslang.h
+++ b/bindings/python/pyslang.h
@@ -29,14 +29,15 @@ using namespace slang::parsing;
 using namespace slang::syntax;
 using namespace slang::ast;
 
-#define EXPOSE_ENUM(handle, name)                                   \
-    do {                                                            \
-        py::enum_<name> e(handle, #name);                           \
-        for (auto member : name##_traits::values) {                 \
-            std::string nameStr = std::string(toString(member));    \
-            if (nameStr == "None") nameStr = "None_";               \
-            e.value(nameStr.c_str(), member);                       \
-        }                                                           \
+#define EXPOSE_ENUM(handle, name)                                \
+    do {                                                         \
+        py::enum_<name> e(handle, #name);                        \
+        for (auto member : name##_traits::values) {              \
+            std::string nameStr = std::string(toString(member)); \
+            if (nameStr == "None")                               \
+                nameStr = "None_";                               \
+            e.value(nameStr.c_str(), member);                    \
+        }                                                        \
     } while (0)
 
 static constexpr auto byref = py::return_value_policy::reference;

--- a/bindings/python/pyslang.h
+++ b/bindings/python/pyslang.h
@@ -33,7 +33,9 @@ using namespace slang::ast;
     do {                                                            \
         py::enum_<name> e(handle, #name);                           \
         for (auto member : name##_traits::values) {                 \
-            e.value(std::string(toString(member)).c_str(), member); \
+            std::string nameStr = std::string(toString(member));    \
+            if (nameStr == "None") nameStr = "None_";               \
+            e.value(nameStr.c_str(), member);                       \
         }                                                           \
     } while (0)
 

--- a/scripts/syntax_gen.py
+++ b/scripts/syntax_gen.py
@@ -1106,14 +1106,20 @@ void registerSyntaxNodes{0}(py::module_& m) {{
         )
 
         idx = i * perfile
-        for k, v in items[idx : idx + perfile]:
-            if k == "SyntaxNode":
+        for class_name, v in items[idx : idx + perfile]:
+            if class_name == "SyntaxNode":
                 continue
 
-            outf.write('    py::class_<{}, {}>(m, "{}")'.format(k, v.base, k))
-            for m in v.members:
+            outf.write(f'    py::class_<{class_name}, {v.base}>(m, "{class_name}")')
+            for member_name in v.members:
+                python_member_name = member_name[1]
+
+                # Validate and rewrite invalid Python attribute names.
+                if python_member_name == "with":
+                    python_member_name = "with_"
+
                 outf.write(
-                    '\n        .def_readwrite("{}", &{}::{})'.format(m[1], k, m[1])
+                    f'\n        .def_readwrite("{python_member_name}", &{class_name}::{member_name[1]})'
                 )
             outf.write(";\n\n")
 


### PR DESCRIPTION
Partial fix for #1269