### PR TITLE
Add root scope accessor on Compilation

### DIFF
--- a/include/slang/ast/Compilation.h
+++ b/include/slang/ast/Compilation.h
@@ -759,6 +759,9 @@ public:
     /// Creates an empty ImplicitTypeSyntax object.
     const syntax::ImplicitTypeSyntax& createEmptyTypeSyntax(SourceLocation loc);
 
+    /// Get the root scope (c.f. getRoot() this method doesn't trigger finalization)
+    const Scope *getRootScope() const;
+
     /// @}
 
 private:

--- a/include/slang/ast/Compilation.h
+++ b/include/slang/ast/Compilation.h
@@ -760,7 +760,7 @@ public:
     const syntax::ImplicitTypeSyntax& createEmptyTypeSyntax(SourceLocation loc);
 
     /// Get the root scope (c.f. getRoot() this method doesn't trigger finalization)
-    const Scope *getRootScope() const;
+    const Scope* getRootScope() const;
 
     /// @}
 

--- a/source/ast/Compilation.cpp
+++ b/source/ast/Compilation.cpp
@@ -2710,4 +2710,8 @@ Diagnostic* Compilation::errorMissingDef(std::string_view name, const Scope& sco
     return &diag;
 }
 
+const Scope* Compilation::getRootScope() const {
+    return root.get();
+}
+
 } // namespace slang::ast


### PR DESCRIPTION
This is the only outstanding downstream patch in yosys-slang that's critical. Please take a look if adding `getRootScope()` is fine. I use it with `compilation.tryGetDefinition()` to find if there's an existing definition without triggering finalization ([link](https://github.com/povik/yosys-slang/blob/25540d82e35d1478b453670b752001cb1f5b1ef6/src/blackboxes.cc#L59))