### PR TITLE
Added slang-tidy check for port prefix

### DIFF
--- a/tools/tidy/CMakeLists.txt
+++ b/tools/tidy/CMakeLists.txt
@@ -10,6 +10,7 @@ add_library(
   src/ASTHelperVisitors.cpp
   src/synthesis/OnlyAssignedOnReset.cpp
   src/synthesis/RegisterHasNoReset.cpp
+  src/style/EnforcePortPrefix.cpp
   src/style/EnforcePortSuffix.cpp
   src/synthesis/NoLatchesOnDesign.cpp
   src/style/NoOldAlwaysSyntax.cpp

--- a/tools/tidy/README.md
+++ b/tools/tidy/README.md
@@ -65,6 +65,9 @@ The available options are:
 |     **outputPortSuffix**      | [string] |       [_o]         |
 |      **inoutPortSuffix**      | [string] |       [_io]        |
 | **moduleInstantiationPrefix** |  string  |        i_          |
+|      **inputPortPrefix**      | [string] |       []           |
+|     **outputPortPrefix**      | [string] |       []           |
+|      **inoutPortPrefix**      | [string] |       []           |
 
 An example of a possible configuration file:
 

--- a/tools/tidy/include/TidyConfig.h
+++ b/tools/tidy/include/TidyConfig.h
@@ -32,6 +32,9 @@ public:
         std::vector<std::string> outputPortSuffix;
         std::vector<std::string> inoutPortSuffix;
         std::string moduleInstantiationPrefix;
+        std::vector<std::string> inputPortPrefix;
+        std::vector<std::string> outputPortPrefix;
+        std::vector<std::string> inoutPortPrefix;
     };
 
     /// Default TidyConfig constructor which will set the default check's configuration values
@@ -120,6 +123,18 @@ private:
         }
         else if (configName == "moduleInstantiationPrefix") {
             visit(checkConfigs.moduleInstantiationPrefix);
+            return;
+        }
+        else if (configName == "inputPortPrefix") {
+            visit(checkConfigs.inputPortPrefix);
+            return;
+        }
+        else if (configName == "outputPortPrefix") {
+            visit(checkConfigs.outputPortPrefix);
+            return;
+        }
+        else if (configName == "inoutPortPrefix") {
+            visit(checkConfigs.inoutPortPrefix);
             return;
         }
         SLANG_THROW(std::invalid_argument(fmt::format("The check: {} does not exist", configName)));

--- a/tools/tidy/include/TidyDiags.h
+++ b/tools/tidy/include/TidyDiags.h
@@ -30,5 +30,6 @@ inline constexpr DiagCode NoDotVarInPortConnection(DiagSubsystem::Tidy, 15);
 inline constexpr DiagCode NoLegacyGenerate(DiagSubsystem::Tidy, 16);
 inline constexpr DiagCode AlwaysFFAssignmentOutsideConditional(DiagSubsystem::Tidy, 17);
 inline constexpr DiagCode UnusedSensitiveSignal(DiagSubsystem::Tidy, 18);
+inline constexpr DiagCode EnforcePortPrefix(DiagSubsystem::Tidy, 19);
 
 } // namespace slang::diag

--- a/tools/tidy/src/TidyConfig.cpp
+++ b/tools/tidy/src/TidyConfig.cpp
@@ -18,10 +18,14 @@ TidyConfig::TidyConfig() {
     checkConfigs.outputPortSuffix = {"_o"};
     checkConfigs.inoutPortSuffix = {"_io"};
     checkConfigs.moduleInstantiationPrefix = "i_";
+    checkConfigs.inputPortPrefix = {""};
+    checkConfigs.outputPortPrefix = {""};
+    checkConfigs.inoutPortPrefix = {""};
 
     auto styleChecks = std::unordered_map<std::string, CheckStatus>();
     styleChecks.emplace("AlwaysCombNonBlocking", CheckStatus::ENABLED);
     styleChecks.emplace("AlwaysFFBlocking", CheckStatus::ENABLED);
+    styleChecks.emplace("EnforcePortPrefix", CheckStatus::ENABLED);
     styleChecks.emplace("EnforcePortSuffix", CheckStatus::ENABLED);
     styleChecks.emplace("NoOldAlwaysSyntax", CheckStatus::ENABLED);
     styleChecks.emplace("EnforceModuleInstantiationPrefix", CheckStatus::ENABLED);

--- a/tools/tidy/src/style/EnforcePortPrefix.cpp
+++ b/tools/tidy/src/style/EnforcePortPrefix.cpp
@@ -1,0 +1,84 @@
+// SPDX-FileCopyrightText: Jonathan Drolet
+// SPDX-License-Identifier: MIT
+
+#include "ASTHelperVisitors.h"
+#include "TidyDiags.h"
+#include "fmt/color.h"
+#include "fmt/ranges.h"
+
+#include "slang/syntax/AllSyntax.h"
+
+using namespace slang;
+using namespace slang::ast;
+
+namespace enforce_port_prefix {
+struct MainVisitor : public TidyVisitor, ASTVisitor<MainVisitor, true, false> {
+    explicit MainVisitor(Diagnostics& diagnostics) : TidyVisitor(diagnostics) {}
+
+    void handle(const PortSymbol& port) {
+        NEEDS_SKIP_SYMBOL(port)
+
+        const auto& checkConfig = config.getCheckConfigs();
+        if (port.isNullPort)
+            return;
+
+        if (port.name == checkConfig.clkName || port.name == checkConfig.resetName)
+            return;
+
+        std::vector<std::string> const* prefixes;
+
+        if (port.direction == slang::ast::ArgumentDirection::In)
+            prefixes = &checkConfig.inputPortPrefix;
+        else if (port.direction == slang::ast::ArgumentDirection::Out)
+            prefixes = &checkConfig.outputPortPrefix;
+        else
+            prefixes = &checkConfig.inoutPortPrefix;
+
+        bool matched = prefixes->empty(); // no error is thrown without a prefix
+        for (auto& prefix : *prefixes) {
+            matched |= port.name.starts_with(prefix);
+        }
+        if (!matched) {
+            auto& diag = diags.add(diag::EnforcePortPrefix, port.location) << port.name;
+            if (prefixes->size() == 1) {
+                diag << fmt::format("\"{}\"", prefixes->front());
+            }
+            else {
+                diag << fmt::format("{}", *prefixes);
+            }
+        }
+    }
+};
+} // namespace enforce_port_prefix
+
+using namespace enforce_port_prefix;
+class EnforcePortPrefix : public TidyCheck {
+public:
+    [[maybe_unused]] explicit EnforcePortPrefix(TidyKind kind) : TidyCheck(kind) {}
+
+    bool check(const ast::RootSymbol& root) override {
+        MainVisitor visitor(diagnostics);
+        root.visit(visitor);
+        return diagnostics.empty();
+    }
+
+    DiagCode diagCode() const override { return diag::EnforcePortPrefix; }
+    DiagnosticSeverity diagSeverity() const override { return DiagnosticSeverity::Warning; }
+    std::string diagString() const override {
+        return "port '{}' is not correctly prefixed with prefix: {}";
+    }
+    std::string name() const override { return "EnforcePortPrefix"; }
+    std::string description() const override {
+        return "Enforces that all ports in the design follow the code guidelines provided in the "
+               "configuration file by the configs " +
+               fmt::format(fmt::emphasis::italic, "inputPortPrefix") + " , " +
+               fmt::format(fmt::emphasis::italic, "outputPortPrefix") + " , " +
+               fmt::format(fmt::emphasis::italic, "inoutPortPrefix") + '\n';
+    }
+    std::string shortDescription() const override {
+        return "Enforces that all ports in the design follows the code guidelines provided in the "
+               "configuration file";
+    }
+};
+
+REGISTER(EnforcePortPrefix, EnforcePortPrefix, TidyKind::Style)

--- a/tools/tidy/tests/CMakeLists.txt
+++ b/tools/tidy/tests/CMakeLists.txt
@@ -11,6 +11,7 @@ add_executable(
   OnlyAssignedOnResetTest.cpp
   RegisterHasNoResetTest.cpp
   NoLatchesOnDesignTest.cpp
+  EnforcePortPrefixTest.cpp
   EnforcePortSuffixTest.cpp
   NoOldAlwaysSyntaxTest.cpp
   AlwaysCombNonBlockingTest.cpp

--- a/tools/tidy/tests/EnforcePortPrefixTest.cpp
+++ b/tools/tidy/tests/EnforcePortPrefixTest.cpp
@@ -1,0 +1,252 @@
+// SPDX-FileCopyrightText: Jonathan Drolet
+// SPDX-License-Identifier: MIT
+
+#include "Test.h"
+#include "TidyFactory.h"
+
+static TidyConfig getTidyPrefixConfig() {
+    TidyConfig config;
+    config.getCheckConfigs().inputPortPrefix = {"i_"};
+    config.getCheckConfigs().outputPortPrefix = {"o_"};
+    config.getCheckConfigs().inoutPortPrefix = {"io_"};
+
+    return config;
+}
+
+TEST_CASE("EnforcePortPrefix: Incorrect input prefix") {
+    auto tree = SyntaxTree::fromText(R"(
+module top (
+    input logic i_clk,
+    input logic i_rst_n,
+
+    input logic a
+);
+endmodule
+)");
+
+    Compilation compilation;
+    compilation.addSyntaxTree(tree);
+    compilation.getAllDiagnostics();
+    auto& root = compilation.getRoot();
+
+    auto config = getTidyPrefixConfig();
+    Registry::setConfig(config);
+    Registry::setSourceManager(compilation.getSourceManager());
+    auto visitor = Registry::create("EnforcePortPrefix");
+    bool result = visitor->check(root);
+    CHECK_FALSE(result);
+}
+
+TEST_CASE("EnforcePortPrefix: Correct input prefix") {
+    auto tree = SyntaxTree::fromText(R"(
+module top (
+    input logic i_clk,
+    input logic i_rst_n,
+
+    input logic i_a
+);
+endmodule
+)");
+
+    Compilation compilation;
+    compilation.addSyntaxTree(tree);
+    compilation.getAllDiagnostics();
+    auto& root = compilation.getRoot();
+
+    auto config = getTidyPrefixConfig();
+    Registry::setConfig(config);
+    Registry::setSourceManager(compilation.getSourceManager());
+    auto visitor = Registry::create("EnforcePortPrefix");
+    bool result = visitor->check(root);
+    CHECK(result);
+}
+
+TEST_CASE("EnforcePortPrefix: Incorrect output prefix") {
+    auto tree = SyntaxTree::fromText(R"(
+module top (
+    input logic i_clk,
+    input logic i_rst_n,
+
+    output logic a
+);
+endmodule
+)");
+
+    Compilation compilation;
+    compilation.addSyntaxTree(tree);
+    compilation.getAllDiagnostics();
+    auto& root = compilation.getRoot();
+
+    auto config = getTidyPrefixConfig();
+    Registry::setConfig(config);
+    Registry::setSourceManager(compilation.getSourceManager());
+    auto visitor = Registry::create("EnforcePortPrefix");
+    bool result = visitor->check(root);
+    CHECK_FALSE(result);
+}
+
+TEST_CASE("EnforcePortPrefix: Correct output prefix") {
+    auto tree = SyntaxTree::fromText(R"(
+module top (
+    input logic i_clk,
+    input logic i_rst_n,
+
+    output logic o_a
+);
+endmodule
+)");
+
+    Compilation compilation;
+    compilation.addSyntaxTree(tree);
+    compilation.getAllDiagnostics();
+    auto& root = compilation.getRoot();
+
+    auto config = getTidyPrefixConfig();
+    Registry::setConfig(config);
+    Registry::setSourceManager(compilation.getSourceManager());
+    auto visitor = Registry::create("EnforcePortPrefix");
+    bool result = visitor->check(root);
+    CHECK(result);
+}
+
+TEST_CASE("EnforcePortPrefix: Incorrect inout prefix") {
+    auto tree = SyntaxTree::fromText(R"(
+module top (
+    input logic i_clk,
+    input logic i_rst_n,
+
+    inout logic a
+);
+endmodule
+)");
+
+    Compilation compilation;
+    compilation.addSyntaxTree(tree);
+    compilation.getAllDiagnostics();
+    auto& root = compilation.getRoot();
+
+    auto config = getTidyPrefixConfig();
+    Registry::setConfig(config);
+    Registry::setSourceManager(compilation.getSourceManager());
+    auto visitor = Registry::create("EnforcePortPrefix");
+    bool result = visitor->check(root);
+    CHECK_FALSE(result);
+}
+
+TEST_CASE("EnforcePortPrefix: Correct inout prefix") {
+    auto tree = SyntaxTree::fromText(R"(
+module top (
+    input logic i_clk,
+    input logic i_rst_n,
+
+    inout logic io_a
+);
+endmodule
+)");
+
+    Compilation compilation;
+    compilation.addSyntaxTree(tree);
+    compilation.getAllDiagnostics();
+    auto& root = compilation.getRoot();
+
+    auto config = getTidyPrefixConfig();
+    Registry::setConfig(config);
+    Registry::setSourceManager(compilation.getSourceManager());
+    auto visitor = Registry::create("EnforcePortPrefix");
+    bool result = visitor->check(root);
+    CHECK(result);
+}
+
+TEST_CASE("EnforcePortPrefix: Multiple prefixes for input port") {
+    auto tree = SyntaxTree::fromText(R"(
+module top (
+    input logic a_in,
+    input logic b_in,
+    input logic c_in
+);
+endmodule
+)");
+
+    Compilation compilation;
+    compilation.addSyntaxTree(tree);
+    compilation.getAllDiagnostics();
+    auto& root = compilation.getRoot();
+
+    auto config = getTidyPrefixConfig();
+    config.getCheckConfigs().inputPortPrefix = {"a_", "b_", "c_"};
+    Registry::setConfig(config);
+    Registry::setSourceManager(compilation.getSourceManager());
+    auto visitor = Registry::create("EnforcePortPrefix");
+    bool result = visitor->check(root);
+    CHECK(result);
+}
+
+TEST_CASE("EnforcePortPrefix: Ignore some port prefixes") {
+    auto tree = SyntaxTree::fromText(R"(
+module top (
+    input logic abc,
+    output logic bcd
+);
+endmodule
+)");
+
+    Compilation compilation;
+    compilation.addSyntaxTree(tree);
+    compilation.getAllDiagnostics();
+    auto& root = compilation.getRoot();
+
+    auto config = getTidyPrefixConfig();
+    config.getCheckConfigs().inputPortPrefix = {};
+    config.getCheckConfigs().outputPortPrefix = {""};
+    Registry::setConfig(config);
+    Registry::setSourceManager(compilation.getSourceManager());
+    auto visitor = Registry::create("EnforcePortPrefix");
+    bool result = visitor->check(root);
+    CHECK(result);
+}
+
+TEST_CASE("EnforcePortPrefix: Explicit ports") {
+    auto tree = SyntaxTree::fromText(R"(
+module top (
+    input .i_data({a1, b1}),
+    output .o_data({a2, b2})
+);
+    logic a1, a1, a2, b2;
+endmodule
+)");
+
+    Compilation compilation;
+    compilation.addSyntaxTree(tree);
+    compilation.getAllDiagnostics();
+    auto& root = compilation.getRoot();
+
+    auto config = getTidyPrefixConfig();
+    Registry::setConfig(config);
+    Registry::setSourceManager(compilation.getSourceManager());
+    auto visitor = Registry::create("EnforcePortPrefix");
+    bool result = visitor->check(root);
+    CHECK(result);
+}
+
+TEST_CASE("EnforcePortPrefix: Explicit port with incorrect prefix") {
+    auto tree = SyntaxTree::fromText(R"(
+module top (
+    input .i_data({a1, b1}),
+    input .o_data({a2, b2})
+);
+    logic a1, a1, a2, b2;
+endmodule
+)");
+
+    Compilation compilation;
+    compilation.addSyntaxTree(tree);
+    compilation.getAllDiagnostics();
+    auto& root = compilation.getRoot();
+
+    auto config = getTidyPrefixConfig();
+    Registry::setConfig(config);
+    Registry::setSourceManager(compilation.getSourceManager());
+    auto visitor = Registry::create("EnforcePortPrefix");
+    bool result = visitor->check(root);
+    CHECK_FALSE(result);
+}


### PR DESCRIPTION
This adds tidy checks for port prefix. This is pretty much a cut-and-paste of the current port suffix checks.

The default config set theses prefixes to empty string, which result in no check.