### PR TITLE
[fix] Fix sequence methods and sampled value functions inside disable condition explicit clock checking

### DIFF
--- a/source/analysis/AnalyzedAssertion.cpp
+++ b/source/analysis/AnalyzedAssertion.cpp
@@ -415,7 +415,7 @@ struct ClockVisitor {
         // Our current clock doesn't flow into the disable iff condition,
         // so check it separately for explicit clocking of sequence instances
         // and calls to sampled value functions.
-        NonProceduralExprVisitor visitor(context, parentSymbol);
+        NonProceduralExprVisitor visitor(context, parentSymbol, /*isDisableCondition =*/true);
         expr.condition.visit(visitor);
 
         return expr.expr.visit(*this, outerClock, flags);

--- a/source/analysis/NonProceduralExprVisitor.h
+++ b/source/analysis/NonProceduralExprVisitor.h
@@ -21,8 +21,10 @@ struct NonProceduralExprVisitor {
     AnalysisContext& context;
     const Symbol& containingSymbol;
 
-    NonProceduralExprVisitor(AnalysisContext& context, const Symbol& containingSymbol) :
-        context(context), containingSymbol(containingSymbol) {}
+    NonProceduralExprVisitor(AnalysisContext& context, const Symbol& containingSymbol,
+                             bool isDisableCondition = false) :
+        context(context), containingSymbol(containingSymbol),
+        isDisableCondition(isDisableCondition) {}
 
     template<typename T>
     void visit(const T& expr) {
@@ -46,7 +48,12 @@ struct NonProceduralExprVisitor {
     }
 
 private:
+    bool isDisableCondition;
+
     const TimingControl* getDefaultClocking() const {
+        if (isDisableCondition)
+            return nullptr;
+
         auto scope = containingSymbol.getParentScope();
         SLANG_ASSERT(scope);
 

--- a/tests/unittests/analysis/AssertionAnalysisTests.cpp
+++ b/tests/unittests/analysis/AssertionAnalysisTests.cpp
@@ -1982,3 +1982,40 @@ endmodule
     REQUIRE(diags.size() == 1);
     CHECK(diags[0].code == diag::GFSVMatchItems);
 }
+
+TEST_CASE("Sequence methods and sample functions inside disable condition") {
+    auto& text = R"(
+module mod_sva_checks;
+
+   logic a, b, c, d;
+   logic clk_a, clk_d, clk_e1, clk_e2;
+   logic clk_c, clk_p;
+
+   clocking cb_prog @(posedge clk_p); endclocking
+
+   clocking cb_checker @(posedge clk_c); endclocking
+
+   default clocking cb @(posedge clk_d); endclocking
+
+   sequence e4;
+     $rose(b) ##1 c;
+   endsequence
+   a5_illegal: assert property (
+      @(posedge clk_a) disable iff (e4.triggered) a |=> b);
+   a6_illegal: assert property (
+      @(posedge clk_a) disable iff ($rose(a)) a |=> b);
+
+    assert property(e4.triggered);
+    assert property($rose(a));
+endmodule : mod_sva_checks
+)";
+
+    Compilation compilation;
+    AnalysisManager analysisManager;
+
+    auto [diags, design] = analyze(text, compilation, analysisManager);
+    REQUIRE(diags.size() == 3);
+    CHECK(diags[0].code == diag::SampledValueFuncClock);
+    CHECK(diags[1].code == diag::AssertionNoClock);
+    CHECK(diags[2].code == diag::SampledValueFuncClock);
+}


### PR DESCRIPTION
Hi, all!

There are some tests which are not compliant by the SystemVerilog LRM related to explicit clock requirements inside `disable iff` condition for sequence methods and sample value functions.

Citation from LRM section 16.13.6 -- "Sequence methods":

> The sequence on which a method is applied shall either be clocked or infer the clock from the context where
> it is used. The same rules are used to infer the clocking event as specified in 16.9.3 for sampled value
> functions.

And also from 16.9.3 "Sampled value functions" section:

> Otherwise, if called in a disable condition or a clock expression in an assertion, sequence, or
> property, it shall be explicitly clocked.

Inferring the `default clocking` block clock signal is only allowed outside an assertions by this

> Otherwise, if called outside an assertion, default clocking (see 14.12) is used.

So I checked a test below using some proprietary tools with linters like `Questa`/ `VCS`  and `Cadence Xcelium` and most of it are warned on these cases:

```verilog
module mod_sva_checks;

   logic a, b, c, d;
   logic clk_a, clk_d, clk_e1, clk_e2;
   logic clk_c, clk_p;

   clocking cb_prog @(posedge clk_p); endclocking

   clocking cb_checker @(posedge clk_c); endclocking

   default clocking cb @(posedge clk_d); endclocking

   sequence e4;
     $rose(b) ##1 c;
   endsequence
   a5_illegal: assert property (
      @(posedge clk_a) disable iff (e4.triggered) a |=> b);  // Xcelium warns
   a6_illegal: assert property (
     @(posedge clk_a) disable iff ($rose(a)) a |=> b); // Xcelium, VCS and Questa warns

    assert property(e4.triggered);
    assert property($rose(a));
endmodule : mod_sva_checks
```

So I suppose that `slang` should have the more close to LRM specification behaviour