### PR TITLE
driver: generate compliant SV identifiers when obfuscating

### DIFF
--- a/source/driver/Driver.cpp
+++ b/source/driver/Driver.cpp
@@ -622,9 +622,8 @@ bool Driver::processOptions() {
 }
 
 template<typename TGenerator>
-static std::string generateRandomAlphanumericString(TGenerator& gen, size_t len) {
-    static constexpr auto chars = "0123456789"
-                                  "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+static std::string generateRandomAlphaString(TGenerator& gen, size_t len) {
+    static constexpr auto chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
                                   "abcdefghijklmnopqrstuvwxyz"sv;
     auto result = std::string(len, '\0');
     std::ranges::generate_n(begin(result), ptrdiff_t(len), [&] {
@@ -677,7 +676,7 @@ bool Driver::runPreprocessor(bool includeComments, bool includeDirectives, bool 
             auto name = std::string(token.valueText());
             auto translation = obfuscationMap.find(name);
             if (translation == obfuscationMap.end()) {
-                auto newName = generateRandomAlphanumericString(*rng, 16);
+                auto newName = generateRandomAlphaString(*rng, 16);
                 translation = obfuscationMap.emplace(name, newName).first;
             }
             token = token.withRawText(alloc, translation->second);

--- a/tests/unittests/DriverTests.cpp
+++ b/tests/unittests/DriverTests.cpp
@@ -179,10 +179,10 @@ TEST_CASE("Driver file preprocess -- obfuscation") {
     auto output = OS::capturedStdout;
     output = std::regex_replace(output, std::regex("\r\n"), "\n");
 
-    CHECK(output.starts_with("\nmodule ykyD0R1TWLDra6jk;\n"
+    CHECK(output.starts_with("\nmodule AOOpUHNpKPjVcKHQ;\n"
                              "    // hello\n"
-                             "    int N65udx39eEabGtIV = 32'haa_bb??e;\n"
-                             "    string TKs9hBr80Qx0xQD8 = "));
+                             "    int LMxOpJDziyYJoPIV = 32'haa_bb??e;\n"
+                             "    string pmOPtNbMAqvklYVm = "));
 
     CHECK(output.ends_with(";\n"
                            "    begin end\n"


### PR DESCRIPTION
SystemVerilog identifiers shall not start with a digit, hence this commit removes the generation of numbers in the random string that replaces the identifiers when obfuscating