### PR TITLE
Don't error on uninstantiated asserts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ CMakeUserPresets.json
 # Editor ignores.
 .vscode/
 !.vscode/settings.json
+!.vscode/extensions.json
 
 .idea/
 .vs/

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,5 @@
+{
+  "recommendations": [
+    "matepek.vscode-catch2-test-adapter",
+  ],
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,4 +2,5 @@
   "python.testing.pytestArgs": [],
   "python.testing.unittestEnabled": false,
   "python.testing.pytestEnabled": true,
+  "testMate.cpp.test.workingDirectory": "${workspaceFolder}",
 }

--- a/source/ast/symbols/MemberSymbols.cpp
+++ b/source/ast/symbols/MemberSymbols.cpp
@@ -715,6 +715,9 @@ void ElabSystemTaskSymbol::issueDiagnostic() const {
     if (!msg)
         return;
 
+    if (scope->isUninstantiated())
+        return;
+
     DiagCode code;
     switch (taskKind) {
         case ElabSystemTaskKind::Fatal:

--- a/tests/unittests/ast/MemberTests.cpp
+++ b/tests/unittests/ast/MemberTests.cpp
@@ -1135,6 +1135,25 @@ source:18:29: note: comparison reduces to (12 < 8)
 )");
 }
 
+TEST_CASE("static_assert ignore uninstantiated") {
+    auto tree = SyntaxTree::fromText(R"(
+module top;
+endmodule
+
+module m;
+    $static_assert(0);
+endmodule
+)");
+
+    CompilationOptions options;
+    options.topModules.insert("top");
+    Compilation compilation(options);
+    compilation.addSyntaxTree(tree);
+
+    auto& diagnostics = compilation.getAllDiagnostics();
+    CHECK(diagnostics.size() == 0);
+}
+
 TEST_CASE("$static_assert with let expression") {
     auto tree = SyntaxTree::fromText(R"(
 module m;


### PR DESCRIPTION
I also added some vscode settings so vscode visual debugging works out of the box with this extension- https://marketplace.visualstudio.com/items?itemName=matepek.vscode-catch2-test-adapter