### PR TITLE
Tidy: display config keys in list of checks

### DIFF
--- a/tools/tidy/include/TidyConfigParser.h
+++ b/tools/tidy/include/TidyConfigParser.h
@@ -22,9 +22,9 @@ public:
 
     [[nodiscard]] TidyConfig getConfig() const { return config; };
 
-    /// Translate from config file name format (lower case with hyphens) to the registered name 
+    /// Translate from config file name format (lower case with hyphens) to the registered name
     /// format (camel case).
-    static std::string unformatCheckName(const std::string &name);
+    static std::string unformatCheckName(const std::string& name);
 
 private:
     /// Reserved keywords of the tidy config parser language

--- a/tools/tidy/include/TidyConfigParser.h
+++ b/tools/tidy/include/TidyConfigParser.h
@@ -22,6 +22,10 @@ public:
 
     [[nodiscard]] TidyConfig getConfig() const { return config; };
 
+    /// Translate from config file name format (lower case with hyphens) to the registered name 
+    /// format (camel case).
+    static std::string unformatCheckName(const std::string &name);
+
 private:
     /// Reserved keywords of the tidy config parser language
     enum class Keywords { ChecksKeyword, CheckConfigs };

--- a/tools/tidy/src/TidyConfigParser.cpp
+++ b/tools/tidy/src/TidyConfigParser.cpp
@@ -478,3 +478,21 @@ std::string TidyConfigParser::formatCheckName(const std::string& checkName) {
     name.append(capitalizedName.substr(currentPos));
     return name;
 }
+
+std::string TidyConfigParser::unformatCheckName(const std::string &name) {
+  std::string result;
+
+    for (char ch : name) {
+        if (std::isupper(ch)) {
+            if (!result.empty()) {
+                result += '-';
+            }
+            result += std::tolower(ch);
+        } else {
+            result += ch;
+        }
+    }
+
+    return result;
+}
+

--- a/tools/tidy/src/TidyConfigParser.cpp
+++ b/tools/tidy/src/TidyConfigParser.cpp
@@ -479,8 +479,8 @@ std::string TidyConfigParser::formatCheckName(const std::string& checkName) {
     return name;
 }
 
-std::string TidyConfigParser::unformatCheckName(const std::string &name) {
-  std::string result;
+std::string TidyConfigParser::unformatCheckName(const std::string& name) {
+    std::string result;
 
     for (char ch : name) {
         if (std::isupper(ch)) {
@@ -488,11 +488,11 @@ std::string TidyConfigParser::unformatCheckName(const std::string &name) {
                 result += '-';
             }
             result += std::tolower(ch);
-        } else {
+        }
+        else {
             result += ch;
         }
     }
 
     return result;
 }
-

--- a/tools/tidy/src/tidy.cpp
+++ b/tools/tidy/src/tidy.cpp
@@ -8,8 +8,10 @@
 
 #include "TidyConfigParser.h"
 #include "TidyFactory.h"
+#include "TidyKind.h"
 #include "fmt/color.h"
 #include "fmt/format.h"
+#include <algorithm>
 #include <filesystem>
 #include <unordered_set>
 
@@ -21,6 +23,13 @@
 /// tries on the parent directory until the root.
 std::optional<std::filesystem::path> project_slang_tidy_config();
 using namespace slang;
+
+std::string toLower(const std::string_view input) {
+    std::string result(input);
+    std::transform(result.begin(), result.end(), result.begin(),
+                   [](unsigned char c) { return std::tolower(c); });
+    return result;
+}
 
 int main(int argc, char** argv) {
     OS::setupConsole();
@@ -129,11 +138,13 @@ int main(int argc, char** argv) {
                 first = false;
             else
                 OS::print("\n");
-            OS::print(fmt::format(fmt::emphasis::bold, "[{}]\n", check->name()));
+            OS::print(fmt::format(fmt::emphasis::bold, "[{}]\n\n", check->name()));
+            OS::print(fmt::format("Config key: {}-{}\n\n", toLower(toString(check->getKind())),
+                  TidyConfigParser::unformatCheckName(check->name())));
             if (printDescriptions)
-                OS::print(fmt::format("{}", check->description()));
+                OS::print(fmt::format("{}\n", check->description()));
             else
-                OS::print(fmt::format("{}\n", check->shortDescription()));
+                OS::print(fmt::format("{}\n\n", check->shortDescription()));
         }
         return 0;
     }

--- a/tools/tidy/src/tidy.cpp
+++ b/tools/tidy/src/tidy.cpp
@@ -140,7 +140,7 @@ int main(int argc, char** argv) {
                 OS::print("\n");
             OS::print(fmt::format(fmt::emphasis::bold, "[{}]\n\n", check->name()));
             OS::print(fmt::format("Config key: {}-{}\n\n", toLower(toString(check->getKind())),
-                  TidyConfigParser::unformatCheckName(check->name())));
+                                  TidyConfigParser::unformatCheckName(check->name())));
             if (printDescriptions)
                 OS::print(fmt::format("{}\n", check->description()));
             else


### PR DESCRIPTION
New output, eg:
```
$ slang-tidy --print-descriptions
[AlwaysFFAssignmentOutsideConditional]

Config key: synthesis-always-f-f-assignment-outside-conditional

A register in an always_ff with an assignment outside a conditional block with a reset signal on its sensitivity list

[UnusedSensitiveSignal]

Config key: synthesis-unused-sensitive-signal

A signal inside the sensitivity list is never used in the statement of the procedural block.
...
```
Related to #1365 