### PR TITLE
slang: Add AST Matchers

### DIFF
--- a/include/slang/matchers/MatchFinder.h
+++ b/include/slang/matchers/MatchFinder.h
@@ -1,0 +1,76 @@
+//------------------------------------------------------------------------------
+//! @file MatchFinder.h
+//! @brief Class that tries to find the nodes that matches the rules provided
+//
+// SPDX-FileCopyrightText: Michael Popoloski
+// SPDX-License-Identifier: MIT
+//------------------------------------------------------------------------------
+#pragma once
+
+#include "MatchersInternal.h"
+
+namespace slang::ast::matchers {
+
+class MatchResult {
+public:
+    explicit MatchResult(const BoundNodesMap& boundNodes, ASTContext& context) :
+        boundNodes(boundNodes), context(context) {}
+
+    template<typename T>
+    std::optional<const T*> getNodeAs(const std::string& id) const {
+        if (const auto it = boundNodes.find(id); it != boundNodes.end()) {
+            return it->second->as<const T>();
+        }
+        return {};
+    }
+
+private:
+    const BoundNodesMap& boundNodes;
+    ASTContext& context;
+};
+
+class MatcherCallback {
+public:
+    virtual ~MatcherCallback() = default;
+    virtual void run(const MatchResult& result) = 0;
+};
+
+class MatchFinder : public ASTVisitor<MatchFinder, true, true> {
+    struct MatcherEntry {
+        internal::BindableMatcher matcher;
+        MatcherCallback* callback;
+    };
+    std::vector<MatcherEntry> matchers;
+    ASTContext context; // Our simple context
+
+    void innerMatch(const Symbol& symbol, const Symbol* parent = nullptr) {
+        for (const auto& [matcher, callback] : matchers) {
+            BoundNodesMap boundNodes;
+
+            if (matcher.matches(symbol, context, boundNodes)) {
+                MatchResult result(boundNodes, context);
+                callback->run(result);
+            }
+        }
+    }
+
+public:
+    explicit MatchFinder(const ASTContext& context) : context(context) {}
+
+    void addMatcher(const internal::BindableMatcher& matcher, MatcherCallback* callback) {
+        matchers.push_back({matcher, callback});
+    }
+
+    template<typename T>
+    void match(const T& rootNode, const Symbol* parent = nullptr) {
+        visit(rootNode);
+    }
+
+    template<typename T>
+    void visit(const T& t) {
+        if constexpr (std::is_base_of_v<Symbol, T>)
+            innerMatch(t, nullptr);
+        visitDefault(t);
+    }
+};
+} // namespace slang::ast::matchers

--- a/include/slang/matchers/Matchers.h
+++ b/include/slang/matchers/Matchers.h
@@ -1,0 +1,53 @@
+//------------------------------------------------------------------------------
+//! @file Matchers.h
+//! @brief AST Matchers
+//
+// SPDX-FileCopyrightText: Michael Popoloski
+// SPDX-License-Identifier: MIT
+//------------------------------------------------------------------------------
+
+#pragma once
+
+#include "slang/ast/Symbol.h"
+#include "slang/ast/symbols/VariableSymbols.h"
+
+#include "MatchersInternal.h"
+
+namespace slang::ast::matchers {
+
+template<typename NodeType>
+class GenericMatcher final : public internal::Matcher<NodeType> {
+public:
+    bool matches(const Symbol& node, ASTContext&, BoundNodesMap&) const override {
+        return node.as_if<NodeType>() != nullptr;
+    }
+};
+
+class VarDeclMatcher final : public internal::ComposableMatcher<VariableSymbol> {
+public:
+    VarDeclMatcher() = default;
+
+    template<typename... MatcherArgs>
+    explicit VarDeclMatcher(MatcherArgs... matchers) : ComposableMatcher(matchers...) {}
+
+    bool matches(const VariableSymbol& varDecl, ASTContext& context,
+                 BoundNodesMap& boundNodes) const override {
+        for (const auto& matcher : matchers) {
+            if (!matcher.matches(varDecl, context, boundNodes)) {
+                return false;
+            }
+        }
+        return true;
+    }
+};
+
+inline internal::BindableMatcher varDecl() {
+    return internal::BindableMatcher(VarDeclMatcher());
+}
+
+template<typename... MatcherArgs>
+internal::BindableMatcher varDecl(MatcherArgs... innerMatchers) {
+    return internal::BindableMatcher(VarDeclMatcher(innerMatchers...));
+}
+
+} // namespace slang::ast::matchers

--- a/include/slang/matchers/MatchersInternal.h
+++ b/include/slang/matchers/MatchersInternal.h
@@ -1,0 +1,90 @@
+//------------------------------------------------------------------------------
+//! @file Matchers.h
+//! @brief AST Matchers
+//
+// SPDX-FileCopyrightText: Michael Popoloski
+// SPDX-License-Identifier: MIT
+//------------------------------------------------------------------------------
+#pragma once
+
+#include "MatchersUtils.h"
+#include <map>
+#include <string>
+
+#include "slang/ast/ASTVisitor.h"
+#include "slang/ast/Symbol.h"
+
+namespace slang::ast::matchers {
+
+using BoundNodesMap = std::map<std::string, const Symbol*>;
+
+namespace internal {
+
+/**
+ * Base matcher class, all matcher shall derive from it
+ * @tparam NodeType AST Node the matcher is matching against
+ */
+template<typename NodeType>
+class Matcher {
+public:
+    virtual ~Matcher() = default;
+
+    virtual bool matches(const NodeType& node, ASTContext& context,
+                         BoundNodesMap& boundNodes) const = 0;
+};
+
+/**
+ * Base matcher class, that allows to `bind()` the result of the match to an ID
+ */
+class BindableMatcher {
+public:
+    template<typename MatcherImp>
+    explicit BindableMatcher(const MatcherImp& matcher) {
+        using NodeType = typename ExtractNodeType<MatcherImp>::type;
+
+        static_assert(std::is_base_of_v<Matcher<NodeType>, MatcherImp>,
+                      "MatherImp must be derived from Matcher");
+
+        auto matcherCopy = std::make_shared<MatcherImp>(matcher);
+        matcherFunc = [matcherCopy](const Symbol& node, ASTContext& context,
+                                    BoundNodesMap& boundNodes) {
+            if (const NodeType* specificNode = node.as_if<NodeType>()) {
+                return matcherCopy->matches(*specificNode, context, boundNodes);
+            }
+            return false;
+        };
+    }
+
+    BindableMatcher(std::function<bool(const Symbol&, ASTContext&, BoundNodesMap&)>&& func,
+                    const std::string&& id) : matcherFunc(func), boundId(id) {}
+
+    bool matches(const Symbol& symbol, ASTContext& context, BoundNodesMap& boundNodes) const {
+        const bool match = matcherFunc(symbol, context, boundNodes);
+        if (match && !boundId.empty()) {
+            boundNodes[boundId] = &symbol;
+        }
+        return match;
+    }
+
+    BindableMatcher bind(const std::string&& id) {
+        return BindableMatcher(std::move(matcherFunc), std::forward<const std::string>(id));
+    }
+
+private:
+    std::function<bool(const Symbol&, ASTContext&, BoundNodesMap&)> matcherFunc;
+    const std::string boundId;
+};
+
+template<typename NodeType>
+class ComposableMatcher : public Matcher<NodeType> {
+public:
+    template<typename... Matchers>
+    explicit ComposableMatcher(Matchers... matchers) : matchers({BindableMatcher(matchers)...}) {}
+
+protected:
+    std::vector<BindableMatcher> matchers;
+};
+
+} // namespace internal
+
+} // namespace slang::ast::matchers

--- a/include/slang/matchers/MatchersUtils.h
+++ b/include/slang/matchers/MatchersUtils.h
@@ -1,0 +1,36 @@
+//------------------------------------------------------------------------------
+//! @file Matchers.h
+//! @brief AST Matchers
+//
+// SPDX-FileCopyrightText: Michael Popoloski
+// SPDX-License-Identifier: MIT
+//------------------------------------------------------------------------------
+#pragma once
+#include <type_traits>
+
+namespace slang::ast::matchers::internal {
+namespace detail {
+
+template<typename T>
+struct MemberFunctionArgumentHelper;
+
+// For non-const member functions
+template<typename R, typename C, typename Arg0, typename... Args>
+struct MemberFunctionArgumentHelper<R (C::*)(Arg0, Args...)> {
+    using FirstArgType = Arg0;
+};
+
+// For const member functions
+template<typename R, typename C, typename Arg0, typename... Args>
+struct MemberFunctionArgumentHelper<R (C::*)(Arg0, Args...) const> {
+    using FirstArgType = Arg0;
+};
+
+} // namespace detail
+
+template <typename MatcherImp>
+struct ExtractNodeType {
+    using DeducedArgType = typename detail::MemberFunctionArgumentHelper<decltype(&MatcherImp::matches)>::FirstArgType;
+    using type = std::remove_cv_t<std::remove_reference_t<DeducedArgType>>;
+};
+} // namespace slang::ast::matchers::internal

--- a/tests/unittests/CMakeLists.txt
+++ b/tests/unittests/CMakeLists.txt
@@ -28,6 +28,7 @@ add_executable(
   ast/SystemFuncTests.cpp
   ast/TypeTests.cpp
   ast/WarningTests.cpp
+  matchers/MatchersTest.cpp
   parsing/DiagnosticTests.cpp
   parsing/ExpressionParsingTests.cpp
   parsing/LexerTests.cpp

--- a/tests/unittests/matchers/MatchersTest.cpp
+++ b/tests/unittests/matchers/MatchersTest.cpp
@@ -1,0 +1,38 @@
+// SPDX-FileCopyrightText: Michael Popoloski
+// SPDX-License-Identifier: MIT
+
+#include "Test.h"
+#include <iostream>
+
+#include "slang/matchers/MatchFinder.h"
+#include "slang/matchers/Matchers.h"
+
+using namespace slang::ast::matchers;
+
+class Callback : public MatcherCallback {
+public:
+    bool found = false;
+    void run(const MatchResult&) override { found = true; }
+};
+
+TEST_CASE("Match basic") {
+    const auto tree = SyntaxTree::fromText(R"(
+module top();
+    logic a;
+endmodule
+)");
+
+    Compilation compilation;
+    compilation.addSyntaxTree(tree);
+    NO_COMPILATION_ERRORS;
+
+    auto& root = compilation.getRoot();
+
+    const auto context = ASTContext(compilation.createScriptScope(), LookupLocation::max);
+    MatchFinder finder(context);
+    Callback callback;
+    finder.addMatcher(varDecl().bind("var_a"), &callback);
+    finder.match(root);
+
+    CHECK(callback.found);
+}


### PR DESCRIPTION
Add the capability to match the AST Nodes ala clang matchers.

Combining different Matchers and using the MatchFinder, the user will be able to match specific nodes in the AST and execute a callback function to evaluate the matched AST node