### PR TITLE
Pyslang: Implement `.to_dict()` and `.to_json()` methods

### DIFF
--- a/bindings/CMakeLists.txt
+++ b/bindings/CMakeLists.txt
@@ -36,9 +36,9 @@ add_custom_command(
   DEPENDS ${SCRIPTS_DIR}/syntax_gen.py ${SCRIPTS_DIR}/syntax.txt
   COMMENT "Generating syntax bindings")
 
-# Add the pyslang module via pybind11
+# Add the _pyslang module via pybind11
 pybind11_add_module(
-  pyslang
+  _pyslang
   MODULE
   python/ASTBindings.cpp
   python/CompBindings.cpp
@@ -54,13 +54,15 @@ pybind11_add_module(
   ${CMAKE_CURRENT_BINARY_DIR}/PySyntaxBindings1.cpp
   ${CMAKE_CURRENT_BINARY_DIR}/PySyntaxBindings2.cpp
   ${CMAKE_CURRENT_BINARY_DIR}/PySyntaxBindings3.cpp)
-set_source_files_properties(
-  python/pyslang.cpp PROPERTIES COMPILE_DEFINITIONS
+
+set_target_properties(
+  _pyslang PROPERTIES COMPILE_DEFINITIONS
                                 VERSION_INFO=${PROJECT_VERSION})
-target_link_libraries(pyslang PUBLIC slang::slang)
-target_include_directories(pyslang PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/python)
+
+target_link_libraries(_pyslang PUBLIC slang::slang)
+target_include_directories(_pyslang PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/python)
 
 install(
-  TARGETS pyslang
+  TARGETS _pyslang
   COMPONENT pylib
   DESTINATION .)

--- a/bindings/python/pyslang.cpp
+++ b/bindings/python/pyslang.cpp
@@ -19,7 +19,7 @@ void registerSyntaxNodes2(py::module_& m);
 void registerSyntaxNodes3(py::module_& m);
 void registerTypes(py::module_& m);
 
-PYBIND11_MODULE(pyslang, m) {
+PYBIND11_MODULE(_pyslang, m) {
     m.doc() = "Python bindings for slang, the SystemVerilog compiler library";
 
 #ifdef VERSION_INFO

--- a/include/slang/syntax/SyntaxNode.h
+++ b/include/slang/syntax/SyntaxNode.h
@@ -194,7 +194,7 @@ public:
     template<typename TVisitor, typename... Args>
     decltype(auto) visit(TVisitor& visitor, Args&&... args) const;
 
-    /// A base implemention of the method that checks correctness of dynamic casting.
+    /// A base implementation of the method that checks correctness of dynamic casting.
     /// Derived nodes should reimplement this and return true if the provided syntax kind
     /// is compatible with the static type of the object.
     static bool isKind(SyntaxKind) { return true; }

--- a/pyslang/examples/concrete_syntax_tree_to_json.py
+++ b/pyslang/examples/concrete_syntax_tree_to_json.py
@@ -1,0 +1,17 @@
+# SPDX-FileCopyrightText: Michael Popoloski
+# SPDX-License-Identifier: MIT
+
+import sys
+
+import pyslang
+
+
+def main():
+    tree = pyslang.SyntaxTree.fromFile(sys.argv[1])
+
+    json_output = tree.root.to_json()
+    print(json_output)
+
+
+if __name__ == "__main__":
+    main()

--- a/pyslang/pyslang/__init__.py
+++ b/pyslang/pyslang/__init__.py
@@ -1,0 +1,76 @@
+# Import Pybind11 bindings
+from _pyslang import *
+
+import json
+
+# Generic conversion from node to dict
+def node_to_dict(node):
+    if isinstance(node, (int, float, bool, str)):
+        return node
+    
+    if node is None:
+        return None
+    
+    cls_name = type(node).__name__
+    
+    if isinstance(node, SyntaxKind | TokenKind | TriviaKind):
+        return str(node).split('.')[-1]
+    
+    if isinstance(node, SourceLocation):
+        return {
+            "type": cls_name,
+            # "buffer": node.buffer, # TODO: Figure out how to serialize buffer
+            "offset": node.offset,
+        }
+    
+    if isinstance(node, list):
+        return [node_to_dict(item) for item in node]
+    
+    if isinstance(node, dict):
+        return {k: node_to_dict(v) for k, v in node.items()}
+    
+    text = str(node) if hasattr(node, '__str__') else None
+
+    def custom_sort_key(item):
+        # Put start before end, and sort others by name
+        priority = {'kind': -100, 'start': 0, 'end': 1}
+        return (priority.get(item, 20000), item)  # Secondary sort by name
+
+    # Collect non-callable, non-private, non-cyclic attributes.
+    exclude_fields = {'children', 'parent', 'child', 'parents'}
+    properties = {
+        k: node_to_dict(getattr(node, k))
+        for k in sorted(dir(node), key=custom_sort_key)
+        if not k.startswith('_')
+           and not callable(getattr(node, k))
+           and k not in exclude_fields
+    }
+
+    result = {
+        "type": cls_name,
+        **properties
+    }
+
+    if text and not text.startswith("<") and not text.endswith(">"):
+        result["text"] = text
+
+    # Handle iterable children for SyntaxNode-like objects
+    if hasattr(node, '__iter__'):
+        result["children"] = [node_to_dict(child) for child in node]
+
+    return result
+
+# Extend relevant classes with `to_dict` and `to_json`
+def _extend_with_serialization(cls):
+    def to_dict(self):
+        return node_to_dict(self)
+
+    def to_json(self, **kwargs):
+        return json.dumps(self.to_dict(), indent=2, **kwargs)
+
+    cls.to_dict = to_dict
+    cls.to_json = to_json
+
+# Automatically register serialization for known node types
+for cls in [SyntaxNode, Token, Trivia]:
+    _extend_with_serialization(cls)

--- a/pyslang/tests/test_syntax_tree_to_json.py
+++ b/pyslang/tests/test_syntax_tree_to_json.py
@@ -1,0 +1,45 @@
+# SPDX-FileCopyrightText: Michael Popoloski
+# SPDX-License-Identifier: MIT
+
+import pyslang
+
+testfile = """
+module gray_counter (
+    out    , // counter out
+    clk    , //! clock
+    clk1   , //! clock sample
+    rst      //! **active high reset**
+);
+
+    input clk, clk1, rst;
+    output [7:0] out;
+    wire [7:0] out;
+    reg [7:0] count;
+
+    assign out = count;
+    always @(posedge clk or posedge rst) begin
+        if (rst) begin
+            count <= 8'b0;
+        end else begin
+            count <= count + 1;
+        end
+    end
+
+endmodule
+"""
+
+
+def test_to_dict_conversion():
+    tree = pyslang.SyntaxTree.fromText(testfile)
+    assert tree.root.kind == pyslang.SyntaxKind.ModuleDeclaration
+
+    json_output = tree.root.to_dict()
+    assert isinstance(json_output, dict)
+
+
+def test_to_json_conversion():
+    tree = pyslang.SyntaxTree.fromText(testfile)
+    assert tree.root.kind == pyslang.SyntaxKind.ModuleDeclaration
+
+    json_output = tree.root.to_json()
+    assert isinstance(json_output, str)


### PR DESCRIPTION
* Changed the pybind11 module name to `_pyslang`, as recommended in https://github.com/pybind/pybind11/issues/1004
* Implemented rudimetary node_to_str function, which seems to work effectively on many/most node types
* Monkey-patched that in as a method in Python

I'm curious to see how the docs build goes with this (esp. with the `_pyslang` existence now); fingers crossed.