### PR TITLE
Give type alias symbols a syntax

### DIFF
--- a/include/slang/ast/symbols/ParameterSymbols.h
+++ b/include/slang/ast/symbols/ParameterSymbols.h
@@ -87,13 +87,14 @@ public:
     static bool isKind(SymbolKind kind) { return kind == SymbolKind::TypeParameter; }
 
     const Type& getTypeAlias() const { return *typeAlias; }
+    void setTypeSyntax(const syntax::SyntaxNode& syntax);
     bool isOverridden() const;
     void checkTypeRestriction() const;
 
     void serializeTo(ASTSerializer& serializer) const;
 
 private:
-    const Type* typeAlias;
+    Type* typeAlias;
 };
 
 /// Represents a defparam directive.

--- a/source/ast/symbols/ParameterBuilder.cpp
+++ b/source/ast/symbols/ParameterBuilder.cpp
@@ -169,8 +169,11 @@ const ParameterSymbolBase& ParameterBuilder::createParam(
 
         if (decl.hasSyntax) {
             handlePreviewNodes(*decl.typeSyntax);
-            if (decl.typeDecl && decl.typeDecl->assignment)
-                param->defaultValSyntax = decl.typeDecl->assignment->type;
+            if (decl.typeDecl) {
+                param->setTypeSyntax(*decl.typeDecl);
+                if (decl.typeDecl->assignment)
+                    param->defaultValSyntax = decl.typeDecl->assignment->type;
+            }
         }
 
         auto& tt = param->targetType;

--- a/source/ast/symbols/ParameterSymbols.cpp
+++ b/source/ast/symbols/ParameterSymbols.cpp
@@ -247,6 +247,10 @@ void TypeParameterSymbol::fromSyntax(const Scope& scope,
     }
 }
 
+void TypeParameterSymbol::setTypeSyntax(const syntax::SyntaxNode& syntax) {
+    typeAlias->setSyntax(syntax);
+}
+
 void TypeParameterSymbol::checkTypeRestriction() const {
     if (typeRestriction != ForwardTypeRestriction::None) {
         auto& type = targetType.getType();

--- a/tests/unittests/ast/ParameterTests.cpp
+++ b/tests/unittests/ast/ParameterTests.cpp
@@ -7,6 +7,7 @@
 #include "slang/ast/symbols/CompilationUnitSymbols.h"
 #include "slang/ast/symbols/InstanceSymbols.h"
 #include "slang/ast/symbols/ParameterSymbols.h"
+#include "slang/ast/types/AllTypes.h"
 #include "slang/ast/types/Type.h"
 
 SVInt testParameter(const std::string& text, uint32_t index = 0) {
@@ -146,6 +147,17 @@ endmodule
     Compilation compilation;
     compilation.addSyntaxTree(tree);
     NO_COMPILATION_ERRORS;
+
+    auto sym = compilation.getRoot().lookupName("top.m1.foo_t");
+    auto& typeAlias = sym->as<ast::TypeAliasType>();
+    CHECK(typeAlias.targetType.getType().getSyntax() == nullptr);
+    CHECK(typeAlias.targetType.getTypeSyntax() == nullptr);
+    CHECK(typeAlias.targetType.getInitializerSyntax() == nullptr);
+    CHECK(typeAlias.targetType.getDimensionSyntax() == nullptr);
+    CHECK(typeAlias.getFirstForwardDecl() == nullptr);
+
+    REQUIRE(typeAlias.getSyntax());
+    CHECK(typeAlias.getSyntax()->kind == SyntaxKind::TypeAssignment);
 }
 
 TEST_CASE("Type parameters 3") {

--- a/tests/unittests/ast/ParameterTests.cpp
+++ b/tests/unittests/ast/ParameterTests.cpp
@@ -153,7 +153,6 @@ endmodule
     CHECK(typeAlias.targetType.getType().getSyntax() == nullptr);
     CHECK(typeAlias.targetType.getTypeSyntax() == nullptr);
     CHECK(typeAlias.targetType.getInitializerSyntax() == nullptr);
-    CHECK(typeAlias.targetType.getDimensionSyntax() == nullptr);
     CHECK(typeAlias.getFirstForwardDecl() == nullptr);
 
     REQUIRE(typeAlias.getSyntax() != nullptr);

--- a/tests/unittests/ast/ParameterTests.cpp
+++ b/tests/unittests/ast/ParameterTests.cpp
@@ -156,7 +156,7 @@ endmodule
     CHECK(typeAlias.targetType.getDimensionSyntax() == nullptr);
     CHECK(typeAlias.getFirstForwardDecl() == nullptr);
 
-    REQUIRE(typeAlias.getSyntax());
+    REQUIRE(typeAlias.getSyntax() != nullptr);
     CHECK(typeAlias.getSyntax()->kind == SyntaxKind::TypeAssignment);
 }
 


### PR DESCRIPTION
Looking up a type parameter results in a type alias symbol with no syntax, and there aren't other consistent means of getting that syntax from the symbol.