### PR TITLE
Change all.sv test methodology

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,4 @@ CMakeUserPresets.json
 .idea/
 .vs/
 *.code-workspace
+.claude

--- a/tests/regression/all.sv
+++ b/tests/regression/all.sv
@@ -3,6 +3,8 @@ timeprecision 1ps;
 
 (* foo = 1 *) package static p;
     timeunit 1ns;
+    parameter int x = 1;
+    parameter type y = logic[x:0];
     program; endprogram
     export *::*;
 endpackage


### PR DESCRIPTION
Rather than counting syntaxes, change to count the unique nodes seen of each type.