### PR TITLE
[slang][analysis] Fix unique_ptr UAF bug

### DIFF
--- a/source/analysis/AnalyzedProcedure.cpp
+++ b/source/analysis/AnalyzedProcedure.cpp
@@ -201,8 +201,8 @@ void AnalyzedProcedure::addFunctionDrivers(AnalysisContext& context, const CallE
     auto analysis = context.manager->getAnalyzedSubroutine(subroutine);
     if (!analysis) {
         analysisMem = std::make_unique<AnalyzedProcedure>(context, subroutine);
-        analysis = analysisMem.get();
         context.manager->addAnalyzedSubroutine(subroutine, std::move(analysisMem));
+        analysis = context.manager->getAnalyzedSubroutine(subroutine);
     }
 
     // For each driver in the function, create a new driver that points to the


### PR DESCRIPTION
Hi, all!

There is a Use-after-free [bug](https://github.com/MikePopoloski/slang/blob/master/source/analysis/AnalyzedProcedure.cpp#L205) when moved `unique_ptr` [used](https://github.com/MikePopoloski/slang/blob/master/source/analysis/AnalyzedProcedure.cpp#L210) lately through raw [ptr](https://github.com/MikePopoloski/slang/blob/master/source/analysis/AnalyzedProcedure.cpp#L204) which had gotten using `get()`.

It's UB exploitation due to standard.

I have't built any minimal example which can help you to reproduce it.

But you can run `slang` directly on [file](https://github.com/olgirard/openmsp430/blob/92c883abb4518dbc35b027e6cad5ffef5b2fbb81/fpga/altera_de0_nano_soc/bench/verilog/altsyncram.v) from this open repo and you will get a segmentation fault on release and debug builds.