### PR TITLE
[slang][analysis] Fix getAnalyzedScope specifier

### DIFF
--- a/include/slang/analysis/AnalysisManager.h
+++ b/include/slang/analysis/AnalysisManager.h
@@ -149,7 +149,7 @@ public:
                                               const AnalyzedProcedure* parentProcedure = nullptr);
 
     /// Returns the results of a previous analysis of a scope, if available.
-    const AnalyzedScope* getAnalyzedScope(const ast::Scope& scope);
+    const AnalyzedScope* getAnalyzedScope(const ast::Scope& scope) const;
 
     /// Gets the result of analyzing a subroutine, if available.
     /// Otherwise returns nullptr.

--- a/source/analysis/AnalysisManager.cpp
+++ b/source/analysis/AnalysisManager.cpp
@@ -117,7 +117,7 @@ const AnalyzedScope& AnalysisManager::analyzeScopeBlocking(
     return result;
 }
 
-const AnalyzedScope* AnalysisManager::getAnalyzedScope(const Scope& scope) {
+const AnalyzedScope* AnalysisManager::getAnalyzedScope(const Scope& scope) const {
     const AnalyzedScope* result = nullptr;
     analyzedScopes.cvisit(&scope, [&result](auto& item) {
         if (item.second)


### PR DESCRIPTION
Hi, all!

Added a `const` specifier to `getAnalyzedScope` `analysisManager` method similar to other methods like `getAnalyzedProcedure`.

Because without it there is no chance to extract procedure drivers for symbols directly from `slang-tidy`  checkers.