### PR TITLE
Tidy: add support for user-specified severities

### DIFF
--- a/tools/tidy/README.md
+++ b/tools/tidy/README.md
@@ -16,7 +16,7 @@ config                ::= section+
 section               ::= checks_config_section | checks_section
 checks_section        ::= "Checks:" [EOL] rule+
 rule                  ::= ["-"] ((check_or_all ",")* | check_or_all) END
-check_or_all          ::= "*" | check_group "-" check_name_or_all
+check_or_all          ::= "*" | check_group "-" check_name_or_all ["=" severity_name]
 check_group           ::= identifier
 check_name_or_all     ::= "*" | identifier
 checks_config_section ::= "CheckConfigs:" [EOL] config+
@@ -24,6 +24,7 @@ config                ::= ((config_tuple ",")* | config_tuple) END
 config_tuple          ::= config_name ":" config_value
 config_name           ::= identifier
 config_value          ::= expression | "[" ((expression ",")* expression)? "]"
+severity_name         ::= "ignore" | "info" | "warning" | "error" | "fatal"
 identifier            ::= { A-Z | a-z }+
 expression            ::= { A-Z | a-z | 0-9 | "_" }+
 EOL                   ::= '\n' | '\r' | '\r\n'
@@ -51,6 +52,14 @@ Enable all: *
 
 Disable all: -*
 ```
+
+Each check identifier is composed of a group name, eg `style`, followed by a
+hyphen `-` and the check name in lower case with hyphens. See the output of
+`--print-descriptions` to see the available checks and their config keys.
+
+Additionally, each check or group of checks can specify a severity level that
+diagnostics are reported with. These levels are `ignore`, `info`, `warning`,
+`error` and `fatal`.
 
 The `CheckConfigs` is a dictionary like, `config: value`, comma separated list of options for the different checks.
 The available options are:

--- a/tools/tidy/include/TidyConfig.h
+++ b/tools/tidy/include/TidyConfig.h
@@ -17,6 +17,7 @@
 #include <unordered_map>
 #include <unordered_set>
 #include <vector>
+
 #include "slang/diagnostics/Diagnostics.h"
 
 class TidyConfig {
@@ -89,18 +90,17 @@ public:
     }
 
 private:
-    
     /// Possible status of the checks.
     enum class CheckStatus { ENABLED, DISABLED };
 
     /// Configuration for each check.
     struct CheckOptions {
 
-      // Whether the check is enabled or disabled.
-      CheckStatus status{CheckStatus::ENABLED};
+        // Whether the check is enabled or disabled.
+        CheckStatus status{CheckStatus::ENABLED};
 
-      // Whether there is a user-specified severity.
-      std::optional<slang::DiagnosticSeverity> severity; 
+        // Whether there is a user-specified severity.
+        std::optional<slang::DiagnosticSeverity> severity;
     };
 
     CheckConfigs checkConfigs;
@@ -117,12 +117,14 @@ private:
     void toggleAl(CheckStatus status);
 
     /// Enables or disables all the checks implemented in the TidyKind provided based on status
-    void toggleGroup(slang::TidyKind kind, CheckStatus status, std::optional<slang::DiagnosticSeverity> severity);
+    void toggleGroup(slang::TidyKind kind, CheckStatus status,
+                     std::optional<slang::DiagnosticSeverity> severity);
 
     /// Disables or enables a particular check implemented in the TidyKind provided based on status.
     /// It will return false if the check do not exist.
     [[nodiscard]] bool toggleCheck(slang::TidyKind kind, const std::string& checkName,
-                                   CheckStatus status, std::optional<slang::DiagnosticSeverity> severity);
+                                   CheckStatus status,
+                                   std::optional<slang::DiagnosticSeverity> severity);
 
     /// Visits the value of a check config. Will throw an invalid_argument exception
     /// if the configName is unknown

--- a/tools/tidy/include/TidyConfig.h
+++ b/tools/tidy/include/TidyConfig.h
@@ -17,12 +17,13 @@
 #include <unordered_map>
 #include <unordered_set>
 #include <vector>
+#include "slang/diagnostics/Diagnostics.h"
 
 class TidyConfig {
     friend class TidyConfigParser;
 
 public:
-    /// Configuration values of checks
+    /// Configuration values across all checks.
     struct CheckConfigs {
         std::string clkName;
         std::string clkNameRegexString;
@@ -43,6 +44,10 @@ public:
 
     /// Returns whether a check is enabled or not
     [[nodiscard]] bool isCheckEnabled(slang::TidyKind kind, const std::string& checkName) const;
+
+    /// Returns the user-specified severity of the check
+    [[nodiscard]] auto getCheckSeverity(slang::TidyKind kind, const std::string& checkName) const
+        -> std::optional<slang::DiagnosticSeverity>;
 
     /// Returns the check config object
     inline const CheckConfigs& getCheckConfigs() const { return checkConfigs; }
@@ -84,12 +89,23 @@ public:
     }
 
 private:
-    CheckConfigs checkConfigs;
-
-    /// Possible status of the checks
+    
+    /// Possible status of the checks.
     enum class CheckStatus { ENABLED, DISABLED };
 
-    std::unordered_map<slang::TidyKind, std::unordered_map<std::string, CheckStatus>> checkKinds;
+    /// Configuration for each check.
+    struct CheckOptions {
+
+      // Whether the check is enabled or disabled.
+      CheckStatus status{CheckStatus::ENABLED};
+
+      // Whether there is a user-specified severity.
+      std::optional<slang::DiagnosticSeverity> severity; 
+    };
+
+    CheckConfigs checkConfigs;
+
+    std::unordered_map<slang::TidyKind, std::unordered_map<std::string, CheckOptions>> checkKinds;
 
     // List of files that won't be checked by slang-tidy
     std::vector<std::string> skipFiles;
@@ -101,12 +117,12 @@ private:
     void toggleAl(CheckStatus status);
 
     /// Enables or disables all the checks implemented in the TidyKind provided based on status
-    void toggleGroup(slang::TidyKind kind, CheckStatus status);
+    void toggleGroup(slang::TidyKind kind, CheckStatus status, std::optional<slang::DiagnosticSeverity> severity);
 
     /// Disables or enables a particular check implemented in the TidyKind provided based on status.
     /// It will return false if the check do not exist.
     [[nodiscard]] bool toggleCheck(slang::TidyKind kind, const std::string& checkName,
-                                   CheckStatus status);
+                                   CheckStatus status, std::optional<slang::DiagnosticSeverity> severity);
 
     /// Visits the value of a check config. Will throw an invalid_argument exception
     /// if the configName is unknown

--- a/tools/tidy/include/TidyConfigParser.h
+++ b/tools/tidy/include/TidyConfigParser.h
@@ -8,12 +8,13 @@
 #pragma once
 
 #include "TidyConfig.h"
-#include "slang/diagnostics/Diagnostics.h"
 #include <filesystem>
 #include <sstream>
 #include <string>
 #include <string_view>
 #include <unordered_map>
+
+#include "slang/diagnostics/Diagnostics.h"
 
 class TidyConfigParser {
 public:
@@ -107,13 +108,14 @@ private:
 
     /// Toggles the specified check with the status provided
     void toggleCheck(const std::string& groupName, const std::string& checkName,
-                     TidyConfig::CheckStatus status, std::optional<slang::DiagnosticSeverity> severity);
+                     TidyConfig::CheckStatus status,
+                     std::optional<slang::DiagnosticSeverity> severity);
 
     /// Sets the check config with the provided value
     void setCheckConfig(const std::string& configName, std::vector<std::string> configValue);
 
     /// Return the DiagnosticSeverity type corresponding to name.
-    auto getSeverity(std::string const &name) -> std::optional<slang::DiagnosticSeverity>;
+    auto getSeverity(std::string const& name) -> std::optional<slang::DiagnosticSeverity>;
 
     /// The name format of the checks provided by the user are required to be: this-is-my-check
     /// but the registered names in the TidyFactory are ThisIsMyCheck. This function translates from

--- a/tools/tidy/include/TidyConfigParser.h
+++ b/tools/tidy/include/TidyConfigParser.h
@@ -8,6 +8,7 @@
 #pragma once
 
 #include "TidyConfig.h"
+#include "slang/diagnostics/Diagnostics.h"
 #include <filesystem>
 #include <sstream>
 #include <string>
@@ -101,14 +102,18 @@ private:
     void toggleAllChecks(TidyConfig::CheckStatus status);
 
     /// Toggles all checks in the specified group with the status provided
-    void toggleAllGroupChecks(const std::string& groupName, TidyConfig::CheckStatus status);
+    void toggleAllGroupChecks(const std::string& groupName, TidyConfig::CheckStatus status,
+                              std::optional<slang::DiagnosticSeverity> severity);
 
     /// Toggles the specified check with the status provided
     void toggleCheck(const std::string& groupName, const std::string& checkName,
-                     TidyConfig::CheckStatus status);
+                     TidyConfig::CheckStatus status, std::optional<slang::DiagnosticSeverity> severity);
 
     /// Sets the check config with the provided value
     void setCheckConfig(const std::string& configName, std::vector<std::string> configValue);
+
+    /// Return the DiagnosticSeverity type corresponding to name.
+    auto getSeverity(std::string const &name) -> std::optional<slang::DiagnosticSeverity>;
 
     /// The name format of the checks provided by the user are required to be: this-is-my-check
     /// but the registered names in the TidyFactory are ThisIsMyCheck. This function translates from

--- a/tools/tidy/include/TidyFactory.h
+++ b/tools/tidy/include/TidyFactory.h
@@ -141,7 +141,7 @@ protected:
     std::optional<slang::DiagnosticSeverity> severity;
 };
 
-#define REGISTER(name, class_name, kind)                                              \
-    static auto name##_entry = Registry::add(#name, kind, []() {                      \
+#define REGISTER(name, class_name, kind)                                               \
+    static auto name##_entry = Registry::add(#name, kind, []() {                       \
         return std::make_unique<class_name>(kind, Registry::getSeverity(kind, #name)); \
     });

--- a/tools/tidy/src/TidyConfig.cpp
+++ b/tools/tidy/src/TidyConfig.cpp
@@ -75,15 +75,16 @@ void TidyConfig::toggleAl(CheckStatus status) {
     }
 }
 
-void TidyConfig::toggleGroup(slang::TidyKind kind, CheckStatus status, std::optional<slang::DiagnosticSeverity> severity) {
+void TidyConfig::toggleGroup(slang::TidyKind kind, CheckStatus status,
+                             std::optional<slang::DiagnosticSeverity> severity) {
     for (auto& check : checkKinds.at(kind)) {
         check.second.status = status;
         check.second.severity = severity;
     }
 }
 
-bool TidyConfig::toggleCheck(slang::TidyKind kind, const std::string& checkName,
-                             CheckStatus status, std::optional<slang::DiagnosticSeverity> severity) {
+bool TidyConfig::toggleCheck(slang::TidyKind kind, const std::string& checkName, CheckStatus status,
+                             std::optional<slang::DiagnosticSeverity> severity) {
     auto registeredChecks = Registry::getRegisteredChecks();
     if (std::find(registeredChecks.begin(), registeredChecks.end(), checkName) ==
         registeredChecks.end()) {

--- a/tools/tidy/src/TidyConfigParser.cpp
+++ b/tools/tidy/src/TidyConfigParser.cpp
@@ -263,16 +263,17 @@ void TidyConfigParser::parseChecks() {
         // Parse check name
         std::string severity;
         auto readSeverity = [&]() {
-            while (currentChar != '\n' && currentChar != ',') {
-                severity += currentChar;
-                currentChar = nextChar();
-            }
+                  while (currentChar != '\n' && currentChar != ',' && currentChar != 0) {
+                    severity += currentChar;
+                    currentChar = nextChar();
+                  }
         };
         bool checkParsed = false;
         currentChar = nextChar();
         while (true) {
             if (currentChar == ',') {
                 toggleCheck(checkGroup, checkName, newCheckState, getSeverity(severity));
+                checkParsed = true;
                 severity.clear();
                 if (nextChar() != '\n') {
                     reportErrorAndExit(fmt::format("Expected new line but found: ({}){}",
@@ -281,16 +282,18 @@ void TidyConfigParser::parseChecks() {
                 break;
             }
             else if (currentChar == '*') {
-                if (peekChar() == '=') {
-                    currentChar = nextChar();
-                    currentChar = nextChar();
-                    readSeverity();
-                }
                 if (checkName.size())
                     reportErrorAndExit("Unexpected '*'");
+                if (peekChar() == '=') {
+                  currentChar = nextChar();
+                  currentChar = nextChar();
+                  readSeverity();
+                } else {
+                  currentChar = nextChar();
+                }
                 toggleAllGroupChecks(checkGroup, newCheckState, getSeverity(severity));
                 checkParsed = true;
-                currentChar = nextChar();
+                severity.clear();
             }
             else if (isalpha(currentChar) || currentChar == '-') {
                 checkName.push_back(currentChar);

--- a/tools/tidy/src/TidyConfigParser.cpp
+++ b/tools/tidy/src/TidyConfigParser.cpp
@@ -153,6 +153,19 @@ auto TidyConfigParser::getSeverity(std::string const& name)
     reportErrorAndExit(
         fmt::format("Invalid severity '{}', expected ignored, note, warning or error", name));
     return std::nullopt;
+  if (name == "ignored")
+      return slang::DiagnosticSeverity::Ignored;
+  if (name == "note")
+      return slang::DiagnosticSeverity::Note;
+  if (name == "warning")
+      return slang::DiagnosticSeverity::Warning;
+  if (name == "error")
+      return slang::DiagnosticSeverity::Error;
+  if (name == "fatal")
+      return slang::DiagnosticSeverity::Fatal;
+  reportErrorAndExit(
+      fmt::format("Invalid severity '{}', expected ignored, note, warning or error", name));
+  return std::nullopt;
 }
 
 void TidyConfigParser::parseChecks() {

--- a/tools/tidy/src/TidyConfigParser.cpp
+++ b/tools/tidy/src/TidyConfigParser.cpp
@@ -140,21 +140,21 @@ void TidyConfigParser::parseInitial() {
 
 auto TidyConfigParser::getSeverity(std::string const& name)
     -> std::optional<slang::DiagnosticSeverity> {
-  if (name.empty())
+    if (name.empty())
+        return std::nullopt;
+    if (name == "ignored")
+        return slang::DiagnosticSeverity::Ignored;
+    if (name == "note")
+        return slang::DiagnosticSeverity::Note;
+    if (name == "warning")
+        return slang::DiagnosticSeverity::Warning;
+    if (name == "error")
+        return slang::DiagnosticSeverity::Error;
+    if (name == "fatal")
+        return slang::DiagnosticSeverity::Fatal;
+    reportErrorAndExit(
+        fmt::format("Invalid severity '{}', expected ignored, note, warning or error", name));
     return std::nullopt;
-  if (name == "ignored")
-      return slang::DiagnosticSeverity::Ignored;
-  if (name == "note")
-      return slang::DiagnosticSeverity::Note;
-  if (name == "warning")
-      return slang::DiagnosticSeverity::Warning;
-  if (name == "error")
-      return slang::DiagnosticSeverity::Error;
-  if (name == "fatal")
-      return slang::DiagnosticSeverity::Fatal;
-  reportErrorAndExit(
-      fmt::format("Invalid severity '{}', expected ignored, note, warning or error", name));
-  return std::nullopt;
 }
 
 void TidyConfigParser::parseChecks() {
@@ -252,20 +252,21 @@ void TidyConfigParser::parseChecks() {
         // Parse check name
         std::string severity;
         auto readSeverity = [&]() {
-                  while (currentChar != '\n' && currentChar != ',' && currentChar != 0) {
-                    severity += currentChar;
-                    currentChar = nextChar();
-                  }
+            while (currentChar != '\n' && currentChar != ',' && currentChar != 0) {
+                severity += currentChar;
+                currentChar = nextChar();
+            }
         };
         bool checkParsed = false;
         bool checkGroupSet = false;
         auto toggleChecks = [&]() {
-                if (checkGroupSet) {
-                  toggleAllGroupChecks(checkGroup, newCheckState, getSeverity(severity));
-                  checkGroupSet = false;
-                } else { 
-                  toggleCheck(checkGroup, checkName, newCheckState, getSeverity(severity));
-                }
+            if (checkGroupSet) {
+                toggleAllGroupChecks(checkGroup, newCheckState, getSeverity(severity));
+                checkGroupSet = false;
+            }
+            else {
+                toggleCheck(checkGroup, checkName, newCheckState, getSeverity(severity));
+            }
         };
         currentChar = nextChar();
         while (true) {
@@ -297,7 +298,7 @@ void TidyConfigParser::parseChecks() {
                 while (peekChar() == '\n')
                     nextChar();
                 if (!checkParsed) {
-                  toggleChecks();
+                    toggleChecks();
                 }
                 parserState = ParserState::Initial;
                 return;

--- a/tools/tidy/src/TidyConfigParser.cpp
+++ b/tools/tidy/src/TidyConfigParser.cpp
@@ -6,6 +6,7 @@
 #include "fmt/format.h"
 #include <fstream>
 
+#include "slang/diagnostics/Diagnostics.h"
 #include "slang/util/OS.h"
 
 template<typename T>
@@ -137,6 +138,22 @@ void TidyConfigParser::parseInitial() {
     }
 }
 
+auto TidyConfigParser::getSeverity(std::string const &name) -> std::optional<slang::DiagnosticSeverity> {
+  if (name.empty())
+    return std::nullopt;
+  if (name == "ignored")
+      return slang::DiagnosticSeverity::Ignored;
+  if (name == "note")
+      return slang::DiagnosticSeverity::Note;
+  if (name == "warning")
+      return slang::DiagnosticSeverity::Warning;
+  if (name == "error")
+      return slang::DiagnosticSeverity::Error;
+  reportErrorAndExit(
+      fmt::format("Invalid severity '{}', expected ignored, note, warning or error", name));
+  return std::nullopt;
+}
+
 void TidyConfigParser::parseChecks() {
     while (!fileStream.eof()) {
         TidyConfig::CheckStatus newCheckState = TidyConfig::CheckStatus::ENABLED;
@@ -230,11 +247,19 @@ void TidyConfigParser::parseChecks() {
         }
 
         // Parse check name
+        std::string severity;
+        auto readSeverity = [&]() {
+                  while (currentChar != '\n' && currentChar != ',') {
+                    severity += currentChar;
+                    currentChar = nextChar();
+                  }
+        };
         bool checkParsed = false;
+        currentChar = nextChar();
         while (true) {
-            currentChar = nextChar();
             if (currentChar == ',') {
-                toggleCheck(checkGroup, checkName, newCheckState);
+                toggleCheck(checkGroup, checkName, newCheckState, getSeverity(severity));
+                severity.clear();
                 if (nextChar() != '\n') {
                     reportErrorAndExit(fmt::format("Expected new line but found: ({}){}",
                                                    +currentChar, currentChar));
@@ -242,19 +267,30 @@ void TidyConfigParser::parseChecks() {
                 break;
             }
             else if (currentChar == '*') {
+                if (peekChar() == '=') {
+                  currentChar = nextChar();
+                  currentChar = nextChar();
+                  readSeverity();
+                }
                 if (checkName.size())
                     reportErrorAndExit("Unexpected '*'");
-                toggleAllGroupChecks(checkGroup, newCheckState);
+                toggleAllGroupChecks(checkGroup, newCheckState, getSeverity(severity));
                 checkParsed = true;
+                currentChar = nextChar();
             }
             else if (isalpha(currentChar) || currentChar == '-') {
                 checkName.push_back(currentChar);
+                currentChar = nextChar();
+            }
+            else if (currentChar == '=') {
+              currentChar = nextChar();
+              readSeverity();
             }
             else if (currentChar == '\n' || currentChar == 0) {
                 while (peekChar() == '\n')
                     nextChar();
                 if (!checkParsed)
-                    toggleCheck(checkGroup, checkName, newCheckState);
+                    toggleCheck(checkGroup, checkName, newCheckState, getSeverity(severity));
                 parserState = ParserState::Initial;
                 return;
             }
@@ -356,16 +392,16 @@ void TidyConfigParser::toggleAllChecks(TidyConfig::CheckStatus status) {
 }
 
 void TidyConfigParser::toggleAllGroupChecks(const std::string& groupName,
-                                            TidyConfig::CheckStatus status) {
+                                            TidyConfig::CheckStatus status, std::optional<slang::DiagnosticSeverity> severity) {
     auto kind = slang::tidyKindFromStr(groupName);
     if (!kind)
         reportErrorAndExit(fmt::format("Group {} does not exist", groupName));
 
-    config.toggleGroup(kind.value(), status);
+    config.toggleGroup(kind.value(), status, severity);
 }
 
 void TidyConfigParser::toggleCheck(const std::string& groupName, const std::string& checkName,
-                                   TidyConfig::CheckStatus status) {
+                                   TidyConfig::CheckStatus status, std::optional<slang::DiagnosticSeverity> severity) {
     if (checkName.empty()) {
         reportWarning(fmt::format(
             "Empty check name in group {0}, you can toggle the whole group with {0}-*", groupName));
@@ -375,7 +411,7 @@ void TidyConfigParser::toggleCheck(const std::string& groupName, const std::stri
     auto kind = slang::tidyKindFromStr(groupName);
     if (!kind)
         reportErrorAndExit(fmt::format("Group {} does not exist", groupName));
-    bool found = config.toggleCheck(kind.value(), formatCheckName(checkName), status);
+    bool found = config.toggleCheck(kind.value(), formatCheckName(checkName), status, severity);
 
     if (!found)
         reportWarning(

--- a/tools/tidy/src/TidyConfigParser.cpp
+++ b/tools/tidy/src/TidyConfigParser.cpp
@@ -138,20 +138,21 @@ void TidyConfigParser::parseInitial() {
     }
 }
 
-auto TidyConfigParser::getSeverity(std::string const &name) -> std::optional<slang::DiagnosticSeverity> {
-  if (name.empty())
+auto TidyConfigParser::getSeverity(std::string const& name)
+    -> std::optional<slang::DiagnosticSeverity> {
+    if (name.empty())
+        return std::nullopt;
+    if (name == "ignored")
+        return slang::DiagnosticSeverity::Ignored;
+    if (name == "note")
+        return slang::DiagnosticSeverity::Note;
+    if (name == "warning")
+        return slang::DiagnosticSeverity::Warning;
+    if (name == "error")
+        return slang::DiagnosticSeverity::Error;
+    reportErrorAndExit(
+        fmt::format("Invalid severity '{}', expected ignored, note, warning or error", name));
     return std::nullopt;
-  if (name == "ignored")
-      return slang::DiagnosticSeverity::Ignored;
-  if (name == "note")
-      return slang::DiagnosticSeverity::Note;
-  if (name == "warning")
-      return slang::DiagnosticSeverity::Warning;
-  if (name == "error")
-      return slang::DiagnosticSeverity::Error;
-  reportErrorAndExit(
-      fmt::format("Invalid severity '{}', expected ignored, note, warning or error", name));
-  return std::nullopt;
 }
 
 void TidyConfigParser::parseChecks() {
@@ -249,10 +250,10 @@ void TidyConfigParser::parseChecks() {
         // Parse check name
         std::string severity;
         auto readSeverity = [&]() {
-                  while (currentChar != '\n' && currentChar != ',') {
-                    severity += currentChar;
-                    currentChar = nextChar();
-                  }
+            while (currentChar != '\n' && currentChar != ',') {
+                severity += currentChar;
+                currentChar = nextChar();
+            }
         };
         bool checkParsed = false;
         currentChar = nextChar();
@@ -268,9 +269,9 @@ void TidyConfigParser::parseChecks() {
             }
             else if (currentChar == '*') {
                 if (peekChar() == '=') {
-                  currentChar = nextChar();
-                  currentChar = nextChar();
-                  readSeverity();
+                    currentChar = nextChar();
+                    currentChar = nextChar();
+                    readSeverity();
                 }
                 if (checkName.size())
                     reportErrorAndExit("Unexpected '*'");
@@ -283,8 +284,8 @@ void TidyConfigParser::parseChecks() {
                 currentChar = nextChar();
             }
             else if (currentChar == '=') {
-              currentChar = nextChar();
-              readSeverity();
+                currentChar = nextChar();
+                readSeverity();
             }
             else if (currentChar == '\n' || currentChar == 0) {
                 while (peekChar() == '\n')
@@ -392,7 +393,8 @@ void TidyConfigParser::toggleAllChecks(TidyConfig::CheckStatus status) {
 }
 
 void TidyConfigParser::toggleAllGroupChecks(const std::string& groupName,
-                                            TidyConfig::CheckStatus status, std::optional<slang::DiagnosticSeverity> severity) {
+                                            TidyConfig::CheckStatus status,
+                                            std::optional<slang::DiagnosticSeverity> severity) {
     auto kind = slang::tidyKindFromStr(groupName);
     if (!kind)
         reportErrorAndExit(fmt::format("Group {} does not exist", groupName));
@@ -401,7 +403,8 @@ void TidyConfigParser::toggleAllGroupChecks(const std::string& groupName,
 }
 
 void TidyConfigParser::toggleCheck(const std::string& groupName, const std::string& checkName,
-                                   TidyConfig::CheckStatus status, std::optional<slang::DiagnosticSeverity> severity) {
+                                   TidyConfig::CheckStatus status,
+                                   std::optional<slang::DiagnosticSeverity> severity) {
     if (checkName.empty()) {
         reportWarning(fmt::format(
             "Empty check name in group {0}, you can toggle the whole group with {0}-*", groupName));

--- a/tools/tidy/src/style/AlwaysCombNamed.cpp
+++ b/tools/tidy/src/style/AlwaysCombNamed.cpp
@@ -35,7 +35,9 @@ struct MainVisitor : public TidyVisitor, ASTVisitor<MainVisitor, true, false> {
 using namespace always_comb_named;
 class AlwaysCombBlockNamed : public TidyCheck {
 public:
-    [[maybe_unused]] explicit AlwaysCombBlockNamed(TidyKind kind, std::optional<slang::DiagnosticSeverity> severity) : TidyCheck(kind, severity) {}
+    [[maybe_unused]] explicit AlwaysCombBlockNamed(
+        TidyKind kind, std::optional<slang::DiagnosticSeverity> severity) :
+        TidyCheck(kind, severity) {}
 
     bool check(const ast::RootSymbol& root, const slang::analysis::AnalysisManager&) override {
         MainVisitor visitor(diagnostics);

--- a/tools/tidy/src/style/AlwaysCombNamed.cpp
+++ b/tools/tidy/src/style/AlwaysCombNamed.cpp
@@ -35,7 +35,7 @@ struct MainVisitor : public TidyVisitor, ASTVisitor<MainVisitor, true, false> {
 using namespace always_comb_named;
 class AlwaysCombBlockNamed : public TidyCheck {
 public:
-    [[maybe_unused]] explicit AlwaysCombBlockNamed(TidyKind kind) : TidyCheck(kind) {}
+    [[maybe_unused]] explicit AlwaysCombBlockNamed(TidyKind kind, std::optional<slang::DiagnosticSeverity> severity) : TidyCheck(kind, severity) {}
 
     bool check(const ast::RootSymbol& root, const slang::analysis::AnalysisManager&) override {
         MainVisitor visitor(diagnostics);
@@ -44,7 +44,7 @@ public:
     }
 
     DiagCode diagCode() const override { return diag::AlwaysCombBlockNamed; }
-    DiagnosticSeverity diagSeverity() const override { return DiagnosticSeverity::Warning; }
+    DiagnosticSeverity diagDefaultSeverity() const override { return DiagnosticSeverity::Warning; }
     std::string diagString() const override { return "definition of an unnamed always_comb block"; }
     std::string name() const override { return "AlwaysCombBlockNamed"; }
     std::string description() const override { return shortDescription(); }

--- a/tools/tidy/src/style/AlwaysCombNonBlocking.cpp
+++ b/tools/tidy/src/style/AlwaysCombNonBlocking.cpp
@@ -35,7 +35,7 @@ struct MainVisitor : public TidyVisitor, ASTVisitor<MainVisitor, true, false> {
 using namespace always_comb_non_blocking;
 class AlwaysCombNonBlocking : public TidyCheck {
 public:
-    [[maybe_unused]] explicit AlwaysCombNonBlocking(TidyKind kind) : TidyCheck(kind) {}
+    [[maybe_unused]] explicit AlwaysCombNonBlocking(TidyKind kind, std::optional<slang::DiagnosticSeverity> severity) : TidyCheck(kind, severity) {}
 
     bool check(const ast::RootSymbol& root, const slang::analysis::AnalysisManager&) override {
         MainVisitor visitor(diagnostics);
@@ -44,7 +44,7 @@ public:
     }
 
     DiagCode diagCode() const override { return diag::AlwaysCombNonBlocking; }
-    DiagnosticSeverity diagSeverity() const override { return DiagnosticSeverity::Warning; }
+    DiagnosticSeverity diagDefaultSeverity() const override { return DiagnosticSeverity::Warning; }
     std::string diagString() const override {
         return "use of a non blocking assignment inside always_comb";
     }

--- a/tools/tidy/src/style/AlwaysCombNonBlocking.cpp
+++ b/tools/tidy/src/style/AlwaysCombNonBlocking.cpp
@@ -35,7 +35,9 @@ struct MainVisitor : public TidyVisitor, ASTVisitor<MainVisitor, true, false> {
 using namespace always_comb_non_blocking;
 class AlwaysCombNonBlocking : public TidyCheck {
 public:
-    [[maybe_unused]] explicit AlwaysCombNonBlocking(TidyKind kind, std::optional<slang::DiagnosticSeverity> severity) : TidyCheck(kind, severity) {}
+    [[maybe_unused]] explicit AlwaysCombNonBlocking(
+        TidyKind kind, std::optional<slang::DiagnosticSeverity> severity) :
+        TidyCheck(kind, severity) {}
 
     bool check(const ast::RootSymbol& root, const slang::analysis::AnalysisManager&) override {
         MainVisitor visitor(diagnostics);

--- a/tools/tidy/src/style/AlwaysFFBlocking.cpp
+++ b/tools/tidy/src/style/AlwaysFFBlocking.cpp
@@ -46,7 +46,9 @@ struct MainVisitor : public TidyVisitor, ASTVisitor<MainVisitor, true, false> {
 using namespace always_ff_blocking;
 class AlwaysFFBlocking : public TidyCheck {
 public:
-    [[maybe_unused]] explicit AlwaysFFBlocking(TidyKind kind) : TidyCheck(kind) {}
+    [[maybe_unused]] explicit AlwaysFFBlocking(TidyKind kind,
+                                               std::optional<slang::DiagnosticSeverity> severity) :
+        TidyCheck(kind, severity) {}
 
     bool check(const ast::RootSymbol& root, const slang::analysis::AnalysisManager&) override {
         MainVisitor visitor(diagnostics);
@@ -55,7 +57,7 @@ public:
     }
 
     DiagCode diagCode() const override { return diag::AlwaysFFBlocking; }
-    DiagnosticSeverity diagSeverity() const override { return DiagnosticSeverity::Warning; }
+    DiagnosticSeverity diagDefaultSeverity() const override { return DiagnosticSeverity::Warning; }
     std::string diagString() const override {
         return "use of a blocking assignment for a non local variables inside always_ff";
     }

--- a/tools/tidy/src/style/EnforceModuleInstantiationPrefix.cpp
+++ b/tools/tidy/src/style/EnforceModuleInstantiationPrefix.cpp
@@ -34,7 +34,9 @@ struct MainVisitor : public TidyVisitor, ASTVisitor<MainVisitor, true, false> {
 using namespace enforce_module_instantiation_prefix;
 class EnforceModuleInstantiationPrefix : public TidyCheck {
 public:
-    [[maybe_unused]] explicit EnforceModuleInstantiationPrefix(TidyKind kind) : TidyCheck(kind) {}
+    [[maybe_unused]] explicit EnforceModuleInstantiationPrefix(
+        TidyKind kind, std::optional<slang::DiagnosticSeverity> severity) :
+        TidyCheck(kind, severity) {}
 
     bool check(const ast::RootSymbol& root, const slang::analysis::AnalysisManager&) override {
         MainVisitor visitor(diagnostics);
@@ -43,7 +45,7 @@ public:
     }
 
     DiagCode diagCode() const override { return diag::EnforceModuleInstantiationPrefix; }
-    DiagnosticSeverity diagSeverity() const override { return DiagnosticSeverity::Warning; }
+    DiagnosticSeverity diagDefaultSeverity() const override { return DiagnosticSeverity::Warning; }
     std::string diagString() const override {
         return "module instantiation '{}' is not correctly prefixed with prefix: '{}'";
     }

--- a/tools/tidy/src/style/EnforcePortPrefix.cpp
+++ b/tools/tidy/src/style/EnforcePortPrefix.cpp
@@ -54,7 +54,9 @@ struct MainVisitor : public TidyVisitor, ASTVisitor<MainVisitor, true, false> {
 using namespace enforce_port_prefix;
 class EnforcePortPrefix : public TidyCheck {
 public:
-    [[maybe_unused]] explicit EnforcePortPrefix(TidyKind kind) : TidyCheck(kind) {}
+    [[maybe_unused]] explicit EnforcePortPrefix(TidyKind kind,
+                                                std::optional<slang::DiagnosticSeverity> severity) :
+        TidyCheck(kind, severity) {}
 
     bool check(const ast::RootSymbol& root, const slang::analysis::AnalysisManager&) override {
         MainVisitor visitor(diagnostics);
@@ -63,7 +65,7 @@ public:
     }
 
     DiagCode diagCode() const override { return diag::EnforcePortPrefix; }
-    DiagnosticSeverity diagSeverity() const override { return DiagnosticSeverity::Warning; }
+    DiagnosticSeverity diagDefaultSeverity() const override { return DiagnosticSeverity::Warning; }
     std::string diagString() const override {
         return "port '{}' is not correctly prefixed with prefix: {}";
     }

--- a/tools/tidy/src/style/EnforcePortSuffix.cpp
+++ b/tools/tidy/src/style/EnforcePortSuffix.cpp
@@ -54,7 +54,9 @@ struct MainVisitor : public TidyVisitor, ASTVisitor<MainVisitor, true, false> {
 using namespace enforce_port_suffix;
 class EnforcePortSuffix : public TidyCheck {
 public:
-    [[maybe_unused]] explicit EnforcePortSuffix(TidyKind kind, std::optional<slang::DiagnosticSeverity> severity) : TidyCheck(kind, severity) {}
+    [[maybe_unused]] explicit EnforcePortSuffix(TidyKind kind,
+                                                std::optional<slang::DiagnosticSeverity> severity) :
+        TidyCheck(kind, severity) {}
 
     bool check(const ast::RootSymbol& root, const slang::analysis::AnalysisManager&) override {
         MainVisitor visitor(diagnostics);

--- a/tools/tidy/src/style/EnforcePortSuffix.cpp
+++ b/tools/tidy/src/style/EnforcePortSuffix.cpp
@@ -54,7 +54,7 @@ struct MainVisitor : public TidyVisitor, ASTVisitor<MainVisitor, true, false> {
 using namespace enforce_port_suffix;
 class EnforcePortSuffix : public TidyCheck {
 public:
-    [[maybe_unused]] explicit EnforcePortSuffix(TidyKind kind) : TidyCheck(kind) {}
+    [[maybe_unused]] explicit EnforcePortSuffix(TidyKind kind, std::optional<slang::DiagnosticSeverity> severity) : TidyCheck(kind, severity) {}
 
     bool check(const ast::RootSymbol& root, const slang::analysis::AnalysisManager&) override {
         MainVisitor visitor(diagnostics);
@@ -63,7 +63,7 @@ public:
     }
 
     DiagCode diagCode() const override { return diag::EnforcePortSuffix; }
-    DiagnosticSeverity diagSeverity() const override { return DiagnosticSeverity::Warning; }
+    DiagnosticSeverity diagDefaultSeverity() const override { return DiagnosticSeverity::Warning; }
     std::string diagString() const override {
         return "port '{}' is not correctly suffixed with suffix: {}";
     }

--- a/tools/tidy/src/style/GenerateNamed.cpp
+++ b/tools/tidy/src/style/GenerateNamed.cpp
@@ -40,7 +40,9 @@ struct MainVisitor : public TidyVisitor, ASTVisitor<MainVisitor, true, false> {
 using namespace generate_named;
 class GenerateNamed : public TidyCheck {
 public:
-    [[maybe_unused]] explicit GenerateNamed(TidyKind kind) : TidyCheck(kind) {}
+    [[maybe_unused]] explicit GenerateNamed(TidyKind kind,
+                                            std::optional<slang::DiagnosticSeverity> severity) :
+        TidyCheck(kind, severity) {}
 
     bool check(const ast::RootSymbol& root, const slang::analysis::AnalysisManager&) override {
         MainVisitor visitor(diagnostics);
@@ -49,7 +51,7 @@ public:
     }
 
     DiagCode diagCode() const override { return diag::GenerateNamed; }
-    DiagnosticSeverity diagSeverity() const override { return DiagnosticSeverity::Warning; }
+    DiagnosticSeverity diagDefaultSeverity() const override { return DiagnosticSeverity::Warning; }
     std::string diagString() const override { return "definition of an unnamed generate block"; }
     std::string name() const override { return "GenerateNamed"; }
     std::string description() const override { return shortDescription(); }

--- a/tools/tidy/src/style/NoDotStarInPortConnection.cpp
+++ b/tools/tidy/src/style/NoDotStarInPortConnection.cpp
@@ -37,7 +37,9 @@ using namespace no_dot_start_in_port_connection;
 
 class NoDotStarInPortConnection : public TidyCheck {
 public:
-    [[maybe_unused]] explicit NoDotStarInPortConnection(TidyKind kind, std::optional<slang::DiagnosticSeverity> severity) : TidyCheck(kind, severity) {}
+    [[maybe_unused]] explicit NoDotStarInPortConnection(
+        TidyKind kind, std::optional<slang::DiagnosticSeverity> severity) :
+        TidyCheck(kind, severity) {}
 
     bool check(const RootSymbol& root, const slang::analysis::AnalysisManager&) override {
         MainVisitor visitor(diagnostics);

--- a/tools/tidy/src/style/NoDotStarInPortConnection.cpp
+++ b/tools/tidy/src/style/NoDotStarInPortConnection.cpp
@@ -37,7 +37,7 @@ using namespace no_dot_start_in_port_connection;
 
 class NoDotStarInPortConnection : public TidyCheck {
 public:
-    [[maybe_unused]] explicit NoDotStarInPortConnection(TidyKind kind) : TidyCheck(kind) {}
+    [[maybe_unused]] explicit NoDotStarInPortConnection(TidyKind kind, std::optional<slang::DiagnosticSeverity> severity) : TidyCheck(kind, severity) {}
 
     bool check(const RootSymbol& root, const slang::analysis::AnalysisManager&) override {
         MainVisitor visitor(diagnostics);
@@ -49,7 +49,7 @@ public:
 
     std::string diagString() const override { return "use of .* in port connection list"; }
 
-    DiagnosticSeverity diagSeverity() const override { return DiagnosticSeverity::Warning; }
+    DiagnosticSeverity diagDefaultSeverity() const override { return DiagnosticSeverity::Warning; }
 
     std::string name() const override { return "NoDotStarInPortConnection"; }
 

--- a/tools/tidy/src/style/NoDotVarInPortConnection.cpp
+++ b/tools/tidy/src/style/NoDotVarInPortConnection.cpp
@@ -44,7 +44,7 @@ using namespace no_dot_var_in_port_connection;
 
 class NoDotVarInPortConnection final : public TidyCheck {
 public:
-    [[maybe_unused]] explicit NoDotVarInPortConnection(const TidyKind kind) : TidyCheck(kind) {}
+    [[maybe_unused]] explicit NoDotVarInPortConnection(const TidyKind kind, std::optional<slang::DiagnosticSeverity> severity) : TidyCheck(kind, severity) {}
 
     bool check(const RootSymbol& root, const slang::analysis::AnalysisManager&) override {
         MainVisitor visitor(diagnostics);
@@ -58,7 +58,7 @@ public:
         return "use of '{}' in port connection list, consider using '{}({})' instead";
     }
 
-    DiagnosticSeverity diagSeverity() const override { return DiagnosticSeverity::Warning; }
+    DiagnosticSeverity diagDefaultSeverity() const override { return DiagnosticSeverity::Warning; }
 
     std::string name() const override { return "NoDotVarInPortConnection"; }
 

--- a/tools/tidy/src/style/NoDotVarInPortConnection.cpp
+++ b/tools/tidy/src/style/NoDotVarInPortConnection.cpp
@@ -44,7 +44,9 @@ using namespace no_dot_var_in_port_connection;
 
 class NoDotVarInPortConnection final : public TidyCheck {
 public:
-    [[maybe_unused]] explicit NoDotVarInPortConnection(const TidyKind kind, std::optional<slang::DiagnosticSeverity> severity) : TidyCheck(kind, severity) {}
+    [[maybe_unused]] explicit NoDotVarInPortConnection(
+        const TidyKind kind, std::optional<slang::DiagnosticSeverity> severity) :
+        TidyCheck(kind, severity) {}
 
     bool check(const RootSymbol& root, const slang::analysis::AnalysisManager&) override {
         MainVisitor visitor(diagnostics);

--- a/tools/tidy/src/style/NoImplicitPortNameInPortConnection.cpp
+++ b/tools/tidy/src/style/NoImplicitPortNameInPortConnection.cpp
@@ -41,7 +41,9 @@ using namespace no_implicit_port_name_in_port_connection;
 
 class NoImplicitPortNameInPortConnection : public TidyCheck {
 public:
-    [[maybe_unused]] explicit NoImplicitPortNameInPortConnection(TidyKind kind, std::optional<slang::DiagnosticSeverity> severity) : TidyCheck(kind, severity) {}
+    [[maybe_unused]] explicit NoImplicitPortNameInPortConnection(
+        TidyKind kind, std::optional<slang::DiagnosticSeverity> severity) :
+        TidyCheck(kind, severity) {}
 
     bool check(const RootSymbol& root, const slang::analysis::AnalysisManager&) override {
         MainVisitor visitor(diagnostics);

--- a/tools/tidy/src/style/NoImplicitPortNameInPortConnection.cpp
+++ b/tools/tidy/src/style/NoImplicitPortNameInPortConnection.cpp
@@ -41,7 +41,7 @@ using namespace no_implicit_port_name_in_port_connection;
 
 class NoImplicitPortNameInPortConnection : public TidyCheck {
 public:
-    [[maybe_unused]] explicit NoImplicitPortNameInPortConnection(TidyKind kind) : TidyCheck(kind) {}
+    [[maybe_unused]] explicit NoImplicitPortNameInPortConnection(TidyKind kind, std::optional<slang::DiagnosticSeverity> severity) : TidyCheck(kind, severity) {}
 
     bool check(const RootSymbol& root, const slang::analysis::AnalysisManager&) override {
         MainVisitor visitor(diagnostics);
@@ -55,7 +55,7 @@ public:
         return "port name not specified. Please use .port_name(net) syntax.";
     }
 
-    DiagnosticSeverity diagSeverity() const override { return DiagnosticSeverity::Warning; }
+    DiagnosticSeverity diagDefaultSeverity() const override { return DiagnosticSeverity::Warning; }
 
     std::string name() const override { return "NoImplicitPortNameInPortConnection"; }
 

--- a/tools/tidy/src/style/NoLegacyGenerate.cpp
+++ b/tools/tidy/src/style/NoLegacyGenerate.cpp
@@ -42,7 +42,9 @@ struct MainVisitor : public TidyVisitor, ASTVisitor<MainVisitor, true, true> {
 using namespace no_legacy_generate;
 class NoLegacyGenerate : public TidyCheck {
 public:
-    [[maybe_unused]] explicit NoLegacyGenerate(TidyKind kind, std::optional<slang::DiagnosticSeverity> severity) : TidyCheck(kind, severity) {}
+    [[maybe_unused]] explicit NoLegacyGenerate(TidyKind kind,
+                                               std::optional<slang::DiagnosticSeverity> severity) :
+        TidyCheck(kind, severity) {}
 
     bool check(const ast::RootSymbol& root, const slang::analysis::AnalysisManager&) override {
         MainVisitor visitor(diagnostics);

--- a/tools/tidy/src/style/NoLegacyGenerate.cpp
+++ b/tools/tidy/src/style/NoLegacyGenerate.cpp
@@ -42,7 +42,7 @@ struct MainVisitor : public TidyVisitor, ASTVisitor<MainVisitor, true, true> {
 using namespace no_legacy_generate;
 class NoLegacyGenerate : public TidyCheck {
 public:
-    [[maybe_unused]] explicit NoLegacyGenerate(TidyKind kind) : TidyCheck(kind) {}
+    [[maybe_unused]] explicit NoLegacyGenerate(TidyKind kind, std::optional<slang::DiagnosticSeverity> severity) : TidyCheck(kind, severity) {}
 
     bool check(const ast::RootSymbol& root, const slang::analysis::AnalysisManager&) override {
         MainVisitor visitor(diagnostics);
@@ -51,7 +51,7 @@ public:
     }
 
     DiagCode diagCode() const override { return diag::NoLegacyGenerate; }
-    DiagnosticSeverity diagSeverity() const override { return DiagnosticSeverity::Warning; }
+    DiagnosticSeverity diagDefaultSeverity() const override { return DiagnosticSeverity::Warning; }
     std::string diagString() const override { return "usage of generate block is deprecated"; }
     std::string name() const override { return "NoLegacyGenerate"; }
     std::string description() const override { return shortDescription(); }

--- a/tools/tidy/src/style/NoOldAlwaysSyntax.cpp
+++ b/tools/tidy/src/style/NoOldAlwaysSyntax.cpp
@@ -43,7 +43,9 @@ using namespace no_old_always_syntax;
 
 class NoOldAlwaysSyntax : public TidyCheck {
 public:
-    [[maybe_unused]] explicit NoOldAlwaysSyntax(TidyKind kind, std::optional<slang::DiagnosticSeverity> severity) : TidyCheck(kind, severity) {}
+    [[maybe_unused]] explicit NoOldAlwaysSyntax(TidyKind kind,
+                                                std::optional<slang::DiagnosticSeverity> severity) :
+        TidyCheck(kind, severity) {}
 
     bool check(const RootSymbol& root, const slang::analysis::AnalysisManager&) override {
         MainVisitor visitor(diagnostics);

--- a/tools/tidy/src/style/NoOldAlwaysSyntax.cpp
+++ b/tools/tidy/src/style/NoOldAlwaysSyntax.cpp
@@ -43,7 +43,7 @@ using namespace no_old_always_syntax;
 
 class NoOldAlwaysSyntax : public TidyCheck {
 public:
-    [[maybe_unused]] explicit NoOldAlwaysSyntax(TidyKind kind) : TidyCheck(kind) {}
+    [[maybe_unused]] explicit NoOldAlwaysSyntax(TidyKind kind, std::optional<slang::DiagnosticSeverity> severity) : TidyCheck(kind, severity) {}
 
     bool check(const RootSymbol& root, const slang::analysis::AnalysisManager&) override {
         MainVisitor visitor(diagnostics);
@@ -55,7 +55,7 @@ public:
 
     std::string diagString() const override { return "use of old always verilog syntax"; }
 
-    DiagnosticSeverity diagSeverity() const override { return DiagnosticSeverity::Warning; }
+    DiagnosticSeverity diagDefaultSeverity() const override { return DiagnosticSeverity::Warning; }
 
     std::string name() const override { return "NoOldAlwaysSyntax"; }
 

--- a/tools/tidy/src/style/OnlyANSIPortDecl.cpp
+++ b/tools/tidy/src/style/OnlyANSIPortDecl.cpp
@@ -26,7 +26,9 @@ struct MainVisitor : public TidyVisitor, ASTVisitor<MainVisitor, true, false> {
 using namespace no_ansi_port_decl;
 class OnlyANSIPortDecl : public TidyCheck {
 public:
-    [[maybe_unused]] explicit OnlyANSIPortDecl(TidyKind kind, std::optional<slang::DiagnosticSeverity> severity) : TidyCheck(kind, severity) {}
+    [[maybe_unused]] explicit OnlyANSIPortDecl(TidyKind kind,
+                                               std::optional<slang::DiagnosticSeverity> severity) :
+        TidyCheck(kind, severity) {}
 
     bool check(const ast::RootSymbol& root, const slang::analysis::AnalysisManager&) override {
         MainVisitor visitor(diagnostics);

--- a/tools/tidy/src/style/OnlyANSIPortDecl.cpp
+++ b/tools/tidy/src/style/OnlyANSIPortDecl.cpp
@@ -26,7 +26,7 @@ struct MainVisitor : public TidyVisitor, ASTVisitor<MainVisitor, true, false> {
 using namespace no_ansi_port_decl;
 class OnlyANSIPortDecl : public TidyCheck {
 public:
-    [[maybe_unused]] explicit OnlyANSIPortDecl(TidyKind kind) : TidyCheck(kind) {}
+    [[maybe_unused]] explicit OnlyANSIPortDecl(TidyKind kind, std::optional<slang::DiagnosticSeverity> severity) : TidyCheck(kind, severity) {}
 
     bool check(const ast::RootSymbol& root, const slang::analysis::AnalysisManager&) override {
         MainVisitor visitor(diagnostics);
@@ -35,7 +35,7 @@ public:
     }
 
     DiagCode diagCode() const override { return diag::OnlyANSIPortDecl; }
-    DiagnosticSeverity diagSeverity() const override { return DiagnosticSeverity::Warning; }
+    DiagnosticSeverity diagDefaultSeverity() const override { return DiagnosticSeverity::Warning; }
     std::string diagString() const override {
         return "port '{}' is declared using non-ANSI port declaration style";
     }

--- a/tools/tidy/src/synthesis/AlwaysFFAssignmentOutsideConditional.cpp
+++ b/tools/tidy/src/synthesis/AlwaysFFAssignmentOutsideConditional.cpp
@@ -86,7 +86,7 @@ using namespace always_ff_assignment_outside_conditional;
 
 class AlwaysFFAssignmentOutsideConditional : public TidyCheck {
 public:
-    explicit AlwaysFFAssignmentOutsideConditional(TidyKind kind) : TidyCheck(kind) {}
+    explicit AlwaysFFAssignmentOutsideConditional(TidyKind kind, std::optional<slang::DiagnosticSeverity> severity) : TidyCheck(kind, severity) {}
 
     bool check(const RootSymbol& root, const AnalysisManager& analysisManager) override {
         MainVisitor visitor(diagnostics, analysisManager);
@@ -102,7 +102,7 @@ public:
                "inside the conditional block";
     }
 
-    DiagnosticSeverity diagSeverity() const override { return DiagnosticSeverity::Warning; }
+    DiagnosticSeverity diagDefaultSeverity() const override { return DiagnosticSeverity::Warning; }
 
     std::string name() const override { return "AlwaysFFAssignmentOutsideConditional"; }
 

--- a/tools/tidy/src/synthesis/AlwaysFFAssignmentOutsideConditional.cpp
+++ b/tools/tidy/src/synthesis/AlwaysFFAssignmentOutsideConditional.cpp
@@ -86,7 +86,9 @@ using namespace always_ff_assignment_outside_conditional;
 
 class AlwaysFFAssignmentOutsideConditional : public TidyCheck {
 public:
-    explicit AlwaysFFAssignmentOutsideConditional(TidyKind kind, std::optional<slang::DiagnosticSeverity> severity) : TidyCheck(kind, severity) {}
+    explicit AlwaysFFAssignmentOutsideConditional(
+        TidyKind kind, std::optional<slang::DiagnosticSeverity> severity) :
+        TidyCheck(kind, severity) {}
 
     bool check(const RootSymbol& root, const AnalysisManager& analysisManager) override {
         MainVisitor visitor(diagnostics, analysisManager);

--- a/tools/tidy/src/synthesis/CastSignedIndex.cpp
+++ b/tools/tidy/src/synthesis/CastSignedIndex.cpp
@@ -26,7 +26,7 @@ using namespace cast_signed_index;
 
 class CastSignedIndex : public TidyCheck {
 public:
-    [[maybe_unused]] explicit CastSignedIndex(TidyKind kind) : TidyCheck(kind) {}
+    [[maybe_unused]] explicit CastSignedIndex(TidyKind kind, std::optional<slang::DiagnosticSeverity> severity) : TidyCheck(kind, severity) {}
 
     bool check(const RootSymbol& root, const slang::analysis::AnalysisManager&) override {
         MainVisitor visitor(diagnostics);
@@ -41,7 +41,7 @@ public:
                "cast or make the index unsigned";
     }
 
-    DiagnosticSeverity diagSeverity() const override { return DiagnosticSeverity::Warning; }
+    DiagnosticSeverity diagDefaultSeverity() const override { return DiagnosticSeverity::Warning; }
 
     std::string name() const override { return "CastSignedIndex"; }
 

--- a/tools/tidy/src/synthesis/CastSignedIndex.cpp
+++ b/tools/tidy/src/synthesis/CastSignedIndex.cpp
@@ -26,7 +26,9 @@ using namespace cast_signed_index;
 
 class CastSignedIndex : public TidyCheck {
 public:
-    [[maybe_unused]] explicit CastSignedIndex(TidyKind kind, std::optional<slang::DiagnosticSeverity> severity) : TidyCheck(kind, severity) {}
+    [[maybe_unused]] explicit CastSignedIndex(TidyKind kind,
+                                              std::optional<slang::DiagnosticSeverity> severity) :
+        TidyCheck(kind, severity) {}
 
     bool check(const RootSymbol& root, const slang::analysis::AnalysisManager&) override {
         MainVisitor visitor(diagnostics);

--- a/tools/tidy/src/synthesis/NoLatchesOnDesign.cpp
+++ b/tools/tidy/src/synthesis/NoLatchesOnDesign.cpp
@@ -38,7 +38,9 @@ using namespace no_latches_on_design;
 
 class NoLatchesOnDesign : public TidyCheck {
 public:
-    [[maybe_unused]] explicit NoLatchesOnDesign(TidyKind kind) : TidyCheck(kind) {}
+    [[maybe_unused]] explicit NoLatchesOnDesign(TidyKind kind,
+                                                std::optional<slang::DiagnosticSeverity> severity) :
+        TidyCheck(kind, severity) {}
 
     bool check(const RootSymbol& root, const AnalysisManager& analysisManager) override {
         MainVisitor visitor(diagnostics, analysisManager);
@@ -50,7 +52,7 @@ public:
 
     std::string diagString() const override { return "latches are not allowed in this design"; }
 
-    DiagnosticSeverity diagSeverity() const override { return DiagnosticSeverity::Error; }
+    DiagnosticSeverity diagDefaultSeverity() const override { return DiagnosticSeverity::Error; }
 
     std::string name() const override { return "NoLatchesOnDesign"; }
 

--- a/tools/tidy/src/synthesis/OnlyAssignedOnReset.cpp
+++ b/tools/tidy/src/synthesis/OnlyAssignedOnReset.cpp
@@ -118,7 +118,7 @@ struct MainVisitor : public TidyVisitor, ASTVisitor<MainVisitor, true, true> {
 using namespace only_assigned_on_reset;
 class OnlyAssignedOnReset : public TidyCheck {
 public:
-    explicit OnlyAssignedOnReset(TidyKind kind) : TidyCheck(kind) {}
+    explicit OnlyAssignedOnReset(TidyKind kind, std::optional<slang::DiagnosticSeverity> severity) : TidyCheck(kind, severity) {}
 
     bool check(const RootSymbol& root, const AnalysisManager& analysisManager) override {
         MainVisitor visitor(diagnostics, analysisManager);
@@ -130,7 +130,7 @@ public:
 
     std::string diagString() const override { return "register '{}' is only assigned on reset"; }
 
-    DiagnosticSeverity diagSeverity() const override { return DiagnosticSeverity::Warning; }
+    DiagnosticSeverity diagDefaultSeverity() const override { return DiagnosticSeverity::Warning; }
 
     std::string name() const override { return "OnlyAssignedOnReset"; }
 

--- a/tools/tidy/src/synthesis/OnlyAssignedOnReset.cpp
+++ b/tools/tidy/src/synthesis/OnlyAssignedOnReset.cpp
@@ -118,7 +118,8 @@ struct MainVisitor : public TidyVisitor, ASTVisitor<MainVisitor, true, true> {
 using namespace only_assigned_on_reset;
 class OnlyAssignedOnReset : public TidyCheck {
 public:
-    explicit OnlyAssignedOnReset(TidyKind kind, std::optional<slang::DiagnosticSeverity> severity) : TidyCheck(kind, severity) {}
+    explicit OnlyAssignedOnReset(TidyKind kind, std::optional<slang::DiagnosticSeverity> severity) :
+        TidyCheck(kind, severity) {}
 
     bool check(const RootSymbol& root, const AnalysisManager& analysisManager) override {
         MainVisitor visitor(diagnostics, analysisManager);

--- a/tools/tidy/src/synthesis/RegisterHasNoReset.cpp
+++ b/tools/tidy/src/synthesis/RegisterHasNoReset.cpp
@@ -125,7 +125,7 @@ using namespace register_has_no_reset;
 
 class RegisterHasNoReset : public TidyCheck {
 public:
-    explicit RegisterHasNoReset(TidyKind kind) : TidyCheck(kind) {}
+    explicit RegisterHasNoReset(TidyKind kind, std::optional<slang::DiagnosticSeverity> severity) : TidyCheck(kind, severity) {}
 
     bool check(const RootSymbol& root, const AnalysisManager& analysisManager) override {
         MainVisitor visitor(diagnostics, analysisManager);
@@ -141,7 +141,7 @@ public:
                "reset or set a value on reset";
     }
 
-    DiagnosticSeverity diagSeverity() const override { return DiagnosticSeverity::Warning; }
+    DiagnosticSeverity diagDefaultSeverity() const override { return DiagnosticSeverity::Warning; }
 
     std::string name() const override { return "RegisterHasNoReset"; }
 

--- a/tools/tidy/src/synthesis/RegisterHasNoReset.cpp
+++ b/tools/tidy/src/synthesis/RegisterHasNoReset.cpp
@@ -125,7 +125,8 @@ using namespace register_has_no_reset;
 
 class RegisterHasNoReset : public TidyCheck {
 public:
-    explicit RegisterHasNoReset(TidyKind kind, std::optional<slang::DiagnosticSeverity> severity) : TidyCheck(kind, severity) {}
+    explicit RegisterHasNoReset(TidyKind kind, std::optional<slang::DiagnosticSeverity> severity) :
+        TidyCheck(kind, severity) {}
 
     bool check(const RootSymbol& root, const AnalysisManager& analysisManager) override {
         MainVisitor visitor(diagnostics, analysisManager);

--- a/tools/tidy/src/synthesis/UndrivenRange.cpp
+++ b/tools/tidy/src/synthesis/UndrivenRange.cpp
@@ -74,7 +74,7 @@ using namespace undriven_range;
 
 class UndrivenRange : public TidyCheck {
 public:
-    [[maybe_unused]] explicit UndrivenRange(TidyKind kind) : TidyCheck(kind) {}
+    [[maybe_unused]] explicit UndrivenRange(TidyKind kind, std::optional<slang::DiagnosticSeverity> severity) : TidyCheck(kind, severity) {}
 
     bool check(const RootSymbol& root, const AnalysisManager& analysisManager) override {
         UndrivenRangeVisitor visitor(diagnostics, analysisManager);
@@ -86,7 +86,7 @@ public:
 
     std::string diagString() const override { return "variable {} has undriven bits: {}"; }
 
-    DiagnosticSeverity diagSeverity() const override { return DiagnosticSeverity::Warning; }
+    DiagnosticSeverity diagDefaultSeverity() const override { return DiagnosticSeverity::Warning; }
 
     std::string name() const override { return "UndrivenRange"; }
 

--- a/tools/tidy/src/synthesis/UndrivenRange.cpp
+++ b/tools/tidy/src/synthesis/UndrivenRange.cpp
@@ -74,7 +74,9 @@ using namespace undriven_range;
 
 class UndrivenRange : public TidyCheck {
 public:
-    [[maybe_unused]] explicit UndrivenRange(TidyKind kind, std::optional<slang::DiagnosticSeverity> severity) : TidyCheck(kind, severity) {}
+    [[maybe_unused]] explicit UndrivenRange(TidyKind kind,
+                                            std::optional<slang::DiagnosticSeverity> severity) :
+        TidyCheck(kind, severity) {}
 
     bool check(const RootSymbol& root, const AnalysisManager& analysisManager) override {
         UndrivenRangeVisitor visitor(diagnostics, analysisManager);

--- a/tools/tidy/src/synthesis/UnusedSensitiveSignal.cpp
+++ b/tools/tidy/src/synthesis/UnusedSensitiveSignal.cpp
@@ -69,7 +69,7 @@ using namespace unused_sensitive_signal;
 
 class UnusedSensitiveSignal : public TidyCheck {
 public:
-    [[maybe_unused]] explicit UnusedSensitiveSignal(TidyKind kind) : TidyCheck(kind) {}
+    [[maybe_unused]] explicit UnusedSensitiveSignal(TidyKind kind, std::optional<slang::DiagnosticSeverity> severity) : TidyCheck(kind, severity) {}
 
     bool check(const RootSymbol& root, const slang::analysis::AnalysisManager&) override {
         MainVisitor visitor(diagnostics);
@@ -85,7 +85,7 @@ public:
                "or removing it from the sensitivity list";
     }
 
-    DiagnosticSeverity diagSeverity() const override { return DiagnosticSeverity::Warning; }
+    DiagnosticSeverity diagDefaultSeverity() const override { return DiagnosticSeverity::Warning; }
 
     std::string name() const override { return "UnusedSensitiveSignal"; }
 

--- a/tools/tidy/src/synthesis/UnusedSensitiveSignal.cpp
+++ b/tools/tidy/src/synthesis/UnusedSensitiveSignal.cpp
@@ -69,7 +69,9 @@ using namespace unused_sensitive_signal;
 
 class UnusedSensitiveSignal : public TidyCheck {
 public:
-    [[maybe_unused]] explicit UnusedSensitiveSignal(TidyKind kind, std::optional<slang::DiagnosticSeverity> severity) : TidyCheck(kind, severity) {}
+    [[maybe_unused]] explicit UnusedSensitiveSignal(
+        TidyKind kind, std::optional<slang::DiagnosticSeverity> severity) :
+        TidyCheck(kind, severity) {}
 
     bool check(const RootSymbol& root, const slang::analysis::AnalysisManager&) override {
         MainVisitor visitor(diagnostics);

--- a/tools/tidy/src/synthesis/XilinxDoNotCareValues.cpp
+++ b/tools/tidy/src/synthesis/XilinxDoNotCareValues.cpp
@@ -34,7 +34,7 @@ using namespace xilinx_do_not_care_values;
 
 class XilinxDoNotCareValues : public TidyCheck {
 public:
-    explicit XilinxDoNotCareValues(TidyKind kind) : TidyCheck(kind) {}
+    explicit XilinxDoNotCareValues(TidyKind kind, std::optional<slang::DiagnosticSeverity> severity) : TidyCheck(kind, severity) {}
 
     bool check(const RootSymbol& root, const slang::analysis::AnalysisManager&) override {
         MainVisitor visitor(diagnostics);
@@ -48,7 +48,7 @@ public:
         return "use of x'd? for do-not-care values is not recommended use x'b? instead";
     }
 
-    DiagnosticSeverity diagSeverity() const override { return DiagnosticSeverity::Warning; }
+    DiagnosticSeverity diagDefaultSeverity() const override { return DiagnosticSeverity::Warning; }
 
     std::string name() const override { return "XilinxDoNotCareValues"; }
 

--- a/tools/tidy/src/synthesis/XilinxDoNotCareValues.cpp
+++ b/tools/tidy/src/synthesis/XilinxDoNotCareValues.cpp
@@ -34,7 +34,9 @@ using namespace xilinx_do_not_care_values;
 
 class XilinxDoNotCareValues : public TidyCheck {
 public:
-    explicit XilinxDoNotCareValues(TidyKind kind, std::optional<slang::DiagnosticSeverity> severity) : TidyCheck(kind, severity) {}
+    explicit XilinxDoNotCareValues(TidyKind kind,
+                                   std::optional<slang::DiagnosticSeverity> severity) :
+        TidyCheck(kind, severity) {}
 
     bool check(const RootSymbol& root, const slang::analysis::AnalysisManager&) override {
         MainVisitor visitor(diagnostics);

--- a/tools/tidy/src/tidy.cpp
+++ b/tools/tidy/src/tidy.cpp
@@ -225,18 +225,28 @@ int main(int argc, char** argv) {
 
         auto checkOk = check->check(compilation->getRoot(), *analysisManager);
         if (!checkOk) {
-            retCode = 1;
 
             if (!quiet) {
-                if (check->diagSeverity() == DiagnosticSeverity::Warning) {
+                if (check->diagSeverity() == DiagnosticSeverity::Ignored) {
+                  // Skip.
+                }
+                else if (check->diagSeverity() == DiagnosticSeverity::Note) {
+                    OS::print(fmt::emphasis::bold |
+                                  fmt::fg(tdc.getSeverityColor(DiagnosticSeverity::Note)),
+                              " NOTE\n");
+                }
+                else if (check->diagSeverity() == DiagnosticSeverity::Warning) {
                     OS::print(fmt::emphasis::bold |
                                   fmt::fg(tdc.getSeverityColor(DiagnosticSeverity::Warning)),
                               " WARN\n");
                 }
-                else if (check->diagSeverity() == DiagnosticSeverity::Error) {
+                else if (check->diagSeverity() == DiagnosticSeverity::Error ||
+                    check->diagSeverity() == DiagnosticSeverity::Fatal) {
                     OS::print(fmt::emphasis::bold |
                                   fmt::fg(tdc.getSeverityColor(DiagnosticSeverity::Error)),
                               " FAIL\n");
+                    // Any errors are propagated to the return code.
+                    retCode = 1;
                 }
                 else {
                     SLANG_UNREACHABLE;

--- a/tools/tidy/src/tidy.cpp
+++ b/tools/tidy/src/tidy.cpp
@@ -228,7 +228,7 @@ int main(int argc, char** argv) {
 
             if (!quiet) {
                 if (check->diagSeverity() == DiagnosticSeverity::Ignored) {
-                  // Skip.
+                    // Skip.
                 }
                 else if (check->diagSeverity() == DiagnosticSeverity::Note) {
                     OS::print(fmt::emphasis::bold |
@@ -241,7 +241,7 @@ int main(int argc, char** argv) {
                               " WARN\n");
                 }
                 else if (check->diagSeverity() == DiagnosticSeverity::Error ||
-                    check->diagSeverity() == DiagnosticSeverity::Fatal) {
+                         check->diagSeverity() == DiagnosticSeverity::Fatal) {
                     OS::print(fmt::emphasis::bold |
                                   fmt::fg(tdc.getSeverityColor(DiagnosticSeverity::Error)),
                               " FAIL\n");

--- a/tools/tidy/tests/TidyConfigParserTest.cpp
+++ b/tools/tidy/tests/TidyConfigParserTest.cpp
@@ -3,6 +3,7 @@
 
 #include "Test.h"
 #include "TidyConfigParser.h"
+#include "TidyFactory.h"
 #include "slang/diagnostics/Diagnostics.h"
 
 TEST_CASE("TidyParser: Enable all") {
@@ -223,13 +224,13 @@ TEST_CASE("TidyParser: single check error severity") {
 
 TEST_CASE("TidyParser: single group error severity") {
     auto config_str = std::string(R"(Checks:
-  synthesis-*=error,
-  -style-*)");
+  -*,
+  synthesis-*=error)");
     TidyConfigParser parser(config_str);
     auto config = parser.getConfig();
+    Registry::setConfig(config);
 
-    auto checks = {"UndrivenRange", "AlwaysFFAssignmentOutsideConditional", "UnusedSensitiveSignal", "CastSignedIndex", "OnlyAssignedOnReset"};
-    for (auto *check : checks) {
+    for (auto const &check : Registry::getEnabledChecks()) {
       CHECK(config.getCheckSeverity(slang::TidyKind::Synthesis, check) == slang::DiagnosticSeverity::Error);
     }
 }
@@ -245,10 +246,16 @@ TEST_CASE("TidyParser: single check various severities") {
     TidyConfigParser parser(config_str);
     auto config = parser.getConfig();
 
-    CHECK(config.getCheckSeverity(slang::TidyKind::Synthesis, "UndrivenRange") == slang::DiagnosticSeverity::Ignored);
-    CHECK(config.getCheckSeverity(slang::TidyKind::Synthesis, "AlwaysFFAssignmentOutsideConditional") == slang::DiagnosticSeverity::Note);
-    CHECK(config.getCheckSeverity(slang::TidyKind::Synthesis, "UnusedSensitiveSignal") == slang::DiagnosticSeverity::Warning);
-    CHECK(config.getCheckSeverity(slang::TidyKind::Style, "NoLegacyGenerate") == slang::DiagnosticSeverity::Error);
-    CHECK(config.getCheckSeverity(slang::TidyKind::Style, "NoDotVarInPortConnection") == slang::DiagnosticSeverity::Fatal);
+    CHECK(config.getCheckSeverity(slang::TidyKind::Synthesis, "UndrivenRange") ==
+          slang::DiagnosticSeverity::Ignored);
+    CHECK(config.getCheckSeverity(slang::TidyKind::Synthesis,
+                                  "AlwaysFFAssignmentOutsideConditional") ==
+          slang::DiagnosticSeverity::Note);
+    CHECK(config.getCheckSeverity(slang::TidyKind::Synthesis, "UnusedSensitiveSignal") ==
+          slang::DiagnosticSeverity::Warning);
+    CHECK(config.getCheckSeverity(slang::TidyKind::Style, "NoLegacyGenerate") ==
+          slang::DiagnosticSeverity::Error);
+    CHECK(config.getCheckSeverity(slang::TidyKind::Style, "NoDotVarInPortConnection") ==
+          slang::DiagnosticSeverity::Fatal);
 }
 

--- a/tools/tidy/tests/TidyConfigParserTest.cpp
+++ b/tools/tidy/tests/TidyConfigParserTest.cpp
@@ -3,6 +3,7 @@
 
 #include "Test.h"
 #include "TidyConfigParser.h"
+#include "slang/diagnostics/Diagnostics.h"
 
 TEST_CASE("TidyParser: Enable all") {
     auto config_str = std::string(R"(Checks: *)");
@@ -209,3 +210,45 @@ TEST_CASE("TidyParser: existing checker in the wrong group") {
 
     CHECK_FALSE(config.isCheckEnabled(slang::TidyKind::Style, "EnforcePortSuffix"));
 }
+
+TEST_CASE("TidyParser: single check error severity") {
+    auto config_str = std::string(R"(Checks:
+  synthesis-only-assigned-on-reset=error)");
+    TidyConfigParser parser(config_str);
+    auto config = parser.getConfig();
+
+    CHECK(config.isCheckEnabled(slang::TidyKind::Synthesis, "OnlyAssignedOnReset"));
+    CHECK(config.getCheckSeverity(slang::TidyKind::Synthesis, "OnlyAssignedOnReset") == slang::DiagnosticSeverity::Error);
+}
+
+TEST_CASE("TidyParser: single group error severity") {
+    auto config_str = std::string(R"(Checks:
+  synthesis-*=error,
+  -style-*)");
+    TidyConfigParser parser(config_str);
+    auto config = parser.getConfig();
+
+    auto checks = {"UndrivenRange", "AlwaysFFAssignmentOutsideConditional", "UnusedSensitiveSignal", "CastSignedIndex", "OnlyAssignedOnReset"};
+    for (auto *check : checks) {
+      CHECK(config.getCheckSeverity(slang::TidyKind::Synthesis, check) == slang::DiagnosticSeverity::Error);
+    }
+}
+
+TEST_CASE("TidyParser: single check various severities") {
+    auto config_str = std::string(R"(Checks:
+  synthesis-undriven-range=ignored,
+  synthesis-always-f-f-assignment-outside-conditional=note,
+  synthesis-unused-sensitive-signal=warning,
+  style-no-legacy-generate=error,
+  style-no-dot-var-in-port-connection=fatal
+)");
+    TidyConfigParser parser(config_str);
+    auto config = parser.getConfig();
+
+    CHECK(config.getCheckSeverity(slang::TidyKind::Synthesis, "UndrivenRange") == slang::DiagnosticSeverity::Ignored);
+    CHECK(config.getCheckSeverity(slang::TidyKind::Synthesis, "AlwaysFFAssignmentOutsideConditional") == slang::DiagnosticSeverity::Note);
+    CHECK(config.getCheckSeverity(slang::TidyKind::Synthesis, "UnusedSensitiveSignal") == slang::DiagnosticSeverity::Warning);
+    CHECK(config.getCheckSeverity(slang::TidyKind::Style, "NoLegacyGenerate") == slang::DiagnosticSeverity::Error);
+    CHECK(config.getCheckSeverity(slang::TidyKind::Style, "NoDotVarInPortConnection") == slang::DiagnosticSeverity::Fatal);
+}
+

--- a/tools/tidy/tests/TidyConfigParserTest.cpp
+++ b/tools/tidy/tests/TidyConfigParserTest.cpp
@@ -4,6 +4,7 @@
 #include "Test.h"
 #include "TidyConfigParser.h"
 #include "TidyFactory.h"
+
 #include "slang/diagnostics/Diagnostics.h"
 
 TEST_CASE("TidyParser: Enable all") {
@@ -219,7 +220,8 @@ TEST_CASE("TidyParser: single check error severity") {
     auto config = parser.getConfig();
 
     CHECK(config.isCheckEnabled(slang::TidyKind::Synthesis, "OnlyAssignedOnReset"));
-    CHECK(config.getCheckSeverity(slang::TidyKind::Synthesis, "OnlyAssignedOnReset") == slang::DiagnosticSeverity::Error);
+    CHECK(config.getCheckSeverity(slang::TidyKind::Synthesis, "OnlyAssignedOnReset") ==
+          slang::DiagnosticSeverity::Error);
 }
 
 TEST_CASE("TidyParser: single group error severity") {
@@ -230,8 +232,9 @@ TEST_CASE("TidyParser: single group error severity") {
     auto config = parser.getConfig();
     Registry::setConfig(config);
 
-    for (auto const &check : Registry::getEnabledChecks()) {
-      CHECK(config.getCheckSeverity(slang::TidyKind::Synthesis, check) == slang::DiagnosticSeverity::Error);
+    for (auto const& check : Registry::getEnabledChecks()) {
+        CHECK(config.getCheckSeverity(slang::TidyKind::Synthesis, check) ==
+              slang::DiagnosticSeverity::Error);
     }
 }
 
@@ -258,4 +261,3 @@ TEST_CASE("TidyParser: single check various severities") {
     CHECK(config.getCheckSeverity(slang::TidyKind::Style, "NoDotVarInPortConnection") ==
           slang::DiagnosticSeverity::Fatal);
 }
-


### PR DESCRIPTION
This patch adds support for user-specified severities for slang-tidy checks.

The configuration file syntax is extended to allow severities to be specified per check and per group, eg:
```
Checks:
  synthesis-only-assigned-on-reset=error,
  style-*=info
```

The tidy command-line tool will now return a non-zero code when a diagnostic with error or fatal severity has been issued. 