### PR TITLE
Add makeSyntaxVisitor() method

### DIFF
--- a/include/slang/syntax/SyntaxNode.h
+++ b/include/slang/syntax/SyntaxNode.h
@@ -187,12 +187,12 @@ public:
     /// Applies a visitor object to this node by dispatching based on the
     /// dynamic kind. The given @a args are forwarded to the visitor.
     template<typename TVisitor, typename... Args>
-    decltype(auto) visit(TVisitor& visitor, Args&&... args);
+    decltype(auto) visit(TVisitor&& visitor, Args&&... args);
 
     /// Applies a visitor object to this node by dispatching based on the
     /// dynamic kind. The given @a args are forwarded to the visitor.
     template<typename TVisitor, typename... Args>
-    decltype(auto) visit(TVisitor& visitor, Args&&... args) const;
+    decltype(auto) visit(TVisitor&& visitor, Args&&... args) const;
 
     /// A base implemention of the method that checks correctness of dynamic casting.
     /// Derived nodes should reimplement this and return true if the provided syntax kind

--- a/include/slang/syntax/SyntaxVisitor.h
+++ b/include/slang/syntax/SyntaxVisitor.h
@@ -67,14 +67,14 @@ private:
 ///
 /// @code
 /// int count = 0;
-/// makeVisitor([&](auto& visitor, const HierarchicalInstanceSyntax& node) {
+/// makeSyntaxVisitor([&](auto& visitor, const HierarchicalInstanceSyntax& node) {
 ///     count++;
 ///     visitor.visitDefault(node);
 /// })
 /// @endcode
 ///
 template<typename... Functions>
-auto makeCstVisitor(Functions... funcs) {
+auto makeSyntaxVisitor(Functions... funcs) {
     struct Result : public Functions..., public SyntaxVisitor<Result> {
         Result(Functions... funcs) : Functions(std::move(funcs))... {}
         using Functions::operator()...;

--- a/scripts/syntax_gen.py
+++ b/scripts/syntax_gen.py
@@ -698,7 +698,7 @@ const std::type_info* typeFromSyntaxKind(SyntaxKind kind) {
 
     outf.write("template<typename TNode, typename TVisitor, typename... Args>\n")
     outf.write(
-        "decltype(auto) visitSyntaxNode(TNode* node, TVisitor& visitor, Args&&... args) {\n"
+        "decltype(auto) visitSyntaxNode(TNode* node, TVisitor&& visitor, Args&&... args) {\n"
     )
     outf.write("    static constexpr bool isConst = std::is_const_v<TNode>;")
     outf.write("    switch (node->kind) {\n")
@@ -730,7 +730,7 @@ const std::type_info* typeFromSyntaxKind(SyntaxKind kind) {
 
     outf.write("template<typename TVisitor, typename... Args>\n")
     outf.write(
-        "decltype(auto) SyntaxNode::visit(TVisitor& visitor, Args&&... args) {\n"
+        "decltype(auto) SyntaxNode::visit(TVisitor&& visitor, Args&&... args) {\n"
     )
     outf.write(
         "    return detail::visitSyntaxNode(this, visitor, std::forward<Args>(args)...);\n"
@@ -739,7 +739,7 @@ const std::type_info* typeFromSyntaxKind(SyntaxKind kind) {
 
     outf.write("template<typename TVisitor, typename... Args>\n")
     outf.write(
-        "decltype(auto) SyntaxNode::visit(TVisitor& visitor, Args&&... args) const {\n"
+        "decltype(auto) SyntaxNode::visit(TVisitor&& visitor, Args&&... args) const {\n"
     )
     outf.write(
         "    return detail::visitSyntaxNode(this, visitor, std::forward<Args>(args)...);\n"

--- a/tests/unittests/parsing/VisitorTests.cpp
+++ b/tests/unittests/parsing/VisitorTests.cpp
@@ -734,16 +734,6 @@ class C; endclass
     }
 }
 
-struct CstCounter : public slang::syntax::SyntaxVisitor<CstCounter> {
-    template<typename T>
-    void handle(const T& syntaxNode) {
-        syntaxKinds.insert(syntaxNode.kind);
-        visitDefault(syntaxNode);
-    }
-
-    flat_hash_set<syntax::SyntaxKind> syntaxKinds;
-};
-
 TEST_CASE("Visit all file") {
     // Load a file containing all the SystemVerilog constructs and visit them
     // just to get coverage of all the visitor methods.
@@ -772,8 +762,13 @@ TEST_CASE("Visit all file") {
             v.visitDefault(node);
         }));
 
-    CstCounter syntaxes;
-    (*tree)->root().visit(syntaxes);
+    flat_hash_set<syntax::SyntaxKind> syntaxKinds;
+    (*tree)->root().visit(
+        // makeCstVisitor([&](auto& v, std::derived_from<syntax::SyntaxNode> auto& node) {
+        makeCstVisitor([&](auto& v, const auto& node) {
+            syntaxKinds.insert(node.kind);
+            v.visitDefault(node);
+        }));
 
     auto printMissing = [](const std::string_view name, const auto& kinds, const auto& visited) {
         for (auto kind : kinds) {
@@ -788,7 +783,8 @@ TEST_CASE("Visit all file") {
     // printMissing("statement", ast::StatementKind_traits::values, symbols.stmtKinds);
 
     // Ideally this should visit all kinds (be zero)
-    CHECK(218 == syntax::SyntaxKind_traits::values.size() - syntaxes.syntaxKinds.size());
+    CHECK(536 == syntax::SyntaxKind_traits::values.size());
+    CHECK(218 == syntax::SyntaxKind_traits::values.size() - syntaxKinds.size());
 
     CHECK(42 == ast::SymbolKind_traits::values.size() - symKinds.size());
     CHECK(11 == ast::ExpressionKind_traits::values.size() - exprKinds.size());

--- a/tests/unittests/parsing/VisitorTests.cpp
+++ b/tests/unittests/parsing/VisitorTests.cpp
@@ -763,12 +763,10 @@ TEST_CASE("Visit all file") {
         }));
 
     flat_hash_set<syntax::SyntaxKind> syntaxKinds;
-    (*tree)->root().visit(
-        // makeCstVisitor([&](auto& v, std::derived_from<syntax::SyntaxNode> auto& node) {
-        makeCstVisitor([&](auto& v, const auto& node) {
-            syntaxKinds.insert(node.kind);
-            v.visitDefault(node);
-        }));
+    (*tree)->root().visit(makeCstVisitor([&](auto& v, const auto& node) {
+        syntaxKinds.insert(node.kind);
+        v.visitDefault(node);
+    }));
 
     auto printMissing = [](const std::string_view name, const auto& kinds, const auto& visited) {
         for (auto kind : kinds) {
@@ -783,7 +781,6 @@ TEST_CASE("Visit all file") {
     // printMissing("statement", ast::StatementKind_traits::values, symbols.stmtKinds);
 
     // Ideally this should visit all kinds (be zero)
-    CHECK(536 == syntax::SyntaxKind_traits::values.size());
     CHECK(218 == syntax::SyntaxKind_traits::values.size() - syntaxKinds.size());
 
     CHECK(42 == ast::SymbolKind_traits::values.size() - symKinds.size());

--- a/tests/unittests/parsing/VisitorTests.cpp
+++ b/tests/unittests/parsing/VisitorTests.cpp
@@ -763,7 +763,7 @@ TEST_CASE("Visit all file") {
         }));
 
     flat_hash_set<syntax::SyntaxKind> syntaxKinds;
-    (*tree)->root().visit(makeCstVisitor([&](auto& v, const auto& node) {
+    (*tree)->root().visit(makeSyntaxVisitor([&](auto& v, const auto& node) {
         syntaxKinds.insert(node.kind);
         v.visitDefault(node);
     }));


### PR DESCRIPTION
This makes the SyntaxVisitor more like the AstVisitor, in particular bringing the improvements from https://github.com/MikePopoloski/slang/commit/3957da79c4c8149ba10e0f60599a054bfd40d95f

With regards to naming, it might make more sense to also rename makeVisitor to makeAstVisitor()