### PR TITLE
Assert that general always blocks have some timing control

### DIFF
--- a/include/slang/analysis/AnalysisManager.h
+++ b/include/slang/analysis/AnalysisManager.h
@@ -171,6 +171,11 @@ public:
                             SmallSet<const ast::SubroutineSymbol*, 2>& visited,
                             std::vector<SymbolDriverListPair>& drivers);
 
+    /// Helper method to get all timing controls from a call to a task.
+    void getTaskTimingControls(const ast::CallExpression& expr,
+                               SmallSet<const ast::SubroutineSymbol*, 2>& visited,
+                               std::vector<const ast::Statement*>& controls);
+
 private:
     friend struct AnalysisScopeVisitor;
 

--- a/include/slang/analysis/AnalyzedProcedure.h
+++ b/include/slang/analysis/AnalyzedProcedure.h
@@ -63,11 +63,15 @@ public:
         return callExpressions;
     }
 
+    /// Gets all of the timing control statements directly in the procedure
+    std::span<const ast::Statement* const> getTimingControls() const { return timingControls; }
+
 private:
     const ast::TimingControl* inferredClock = nullptr;
     std::vector<SymbolDriverListPair> drivers;
     std::vector<AnalyzedAssertion> assertions;
     std::vector<const ast::CallExpression*> callExpressions;
+    std::vector<const ast::Statement*> timingControls;
 };
 
 } // namespace slang::analysis

--- a/scripts/diagnostics.txt
+++ b/scripts/diagnostics.txt
@@ -1150,6 +1150,7 @@ error MultipleUDNTDrivers "net '{}' with user-defined nettype '{}' cannot have m
 error InputPortAssign "cannot assign to input port '{}'"
 error ClockVarTargetAssign "cannot write to '{}' with a continuous assignment since it's associated with an output clocking signal"
 error LocalFormalVarMultiAssign "cannot bind local variable '{}' to more than one output or inout local variable formal argument"
+error AlwaysWithoutTimingControl "'always' procedure does not advance time and so will create a simulation deadlock."
 note NoteRequiredHere "required here"
 note NoteClockHere "clock here"
 warning unused-def UnusedDefinition "{} definition is unused"


### PR DESCRIPTION
From 9.2.2.1 General purpose always procedure:

"""
The always keyword represents a general purpose always procedure, which can be used to represent
repetitive behavior such as clock oscillators. The construct can also be used with proper timing controls to
represent combinational, latched, and sequential hardware behavior.

The general purpose always procedure, because of its looping nature, is only useful when used in
conjunction with some form of timing control. If an always procedure has no control for simulation time to
advance, it will create a simulation deadlock condition.

The following code, for example, creates a zero-delay infinite loop:
`always areg = ~areg;`
Providing a timing control to the preceding code creates a potentially useful description as shown in the
following:
`always #half_period areg = ~areg;`
"""

I've held off on updating all the failing tests because I want to get feedback on implementation first regarding where it should go:
  - Parser, where it is in this pr. The diag here seems a bit a premature, but the other option I saw was to place it in block symbols. This impl only operates on syntax, and so would either do redundant checks or need to cache results.
  - AnalysisManager, since technically that's correct, although this implementation is at the syntax level. It could also catch more cases with constant folding, but the major foot-guns are fairly simple as in the first example above.