### PR TITLE
Clang 15 fixes

### DIFF
--- a/include/slang/ast/Compilation.h
+++ b/include/slang/ast/Compilation.h
@@ -1009,6 +1009,9 @@ private:
         AliasBitRange range;
         const Expression* firstExpr;
         const Expression* secondExpr;
+        
+        NetAlias(const Symbol* s, AliasBitRange r, const Expression* fe, const Expression* se)
+            : sym(s), range(r), firstExpr(fe), secondExpr(se) {}
     };
 
     using AliasIntervalMap = IntervalMap<uint64_t, const NetAlias*>;

--- a/include/slang/ast/Compilation.h
+++ b/include/slang/ast/Compilation.h
@@ -1009,9 +1009,9 @@ private:
         AliasBitRange range;
         const Expression* firstExpr;
         const Expression* secondExpr;
-        
-        NetAlias(const Symbol* s, AliasBitRange r, const Expression* fe, const Expression* se)
-            : sym(s), range(r), firstExpr(fe), secondExpr(se) {}
+
+        NetAlias(const Symbol* s, AliasBitRange r, const Expression* fe, const Expression* se) :
+            sym(s), range(r), firstExpr(fe), secondExpr(se) {}
     };
 
     using AliasIntervalMap = IntervalMap<uint64_t, const NetAlias*>;

--- a/source/analysis/DriverTracker.cpp
+++ b/source/analysis/DriverTracker.cpp
@@ -22,7 +22,7 @@ void DriverTracker::add(AnalysisContext& context, DriverAlloc& driverAlloc,
                         const AnalyzedProcedure& procedure) {
     SmallVector<std::pair<const HierarchicalReference*, const ValueDriver*>> ifacePortRefs;
     for (auto& [valueSym, drivers] : procedure.getDrivers()) {
-        auto updateFunc = [&](auto& elem) {
+        auto updateFunc = [&, drivers](auto& elem) {
             for (auto& [driver, bounds] : drivers) {
                 auto ref = addDriver(context, driverAlloc, *elem.first, elem.second, *driver,
                                      bounds);
@@ -114,7 +114,7 @@ void DriverTracker::add(AnalysisContext& context, DriverAlloc& driverAlloc, cons
 void DriverTracker::add(AnalysisContext& context, DriverAlloc& driverAlloc,
                         std::span<const SymbolDriverListPair> symbolDriverList) {
     for (auto& [valueSym, drivers] : symbolDriverList) {
-        auto updateFunc = [&](auto& elem) {
+        auto updateFunc = [&, drivers](auto& elem) {
             for (auto& [driver, bounds] : drivers) {
                 auto ref = addDriver(context, driverAlloc, *elem.first, elem.second, *driver,
                                      bounds);


### PR DESCRIPTION
I'm trying to compile an file-list pruning application https://github.com/Silimate/prunefl with AppleClang 15. This application links slang and is running on macOS (Apple M3 pro processor). I get the following errors:
```
prunefl/third_party/slang/source/analysis/DriverTracker.cpp:26:43: error: reference to local binding 'drivers' declared in enclosing function 'slang::analysis::DriverTracker::add'
            for (auto& [driver, bounds] : drivers) {
```
```
prunefl/third_party/slang/source/analysis/DriverTracker.cpp:118:43: error: reference to local binding 'drivers' declared in enclosing function 'slang::analysis::DriverTracker::add'
            for (auto& [driver, bounds] : drivers) {
```
```
prunefl/third_party/slang/source/../include/slang/util/BumpAllocator.h:41:54: error: no matching constructor for initialization of 'slang::ast::Compilation::NetAlias'
        return new (allocate(sizeof(T), alignof(T))) T(std::forward<Args>(args)...);
                                                     ^ ~~~~~~~~~~~~~~~~~~~~~~~~
```
This PR resolves these issues by add binding references and a constructor as necessary.