### PR TITLE
Rewriter with macro and include expansion

### DIFF
--- a/bindings/python/SyntaxBindings.cpp
+++ b/bindings/python/SyntaxBindings.cpp
@@ -394,8 +394,8 @@ void registerSyntax(py::module_& m) {
         .def("setIncludeMissing", &SyntaxPrinter::setIncludeMissing, byrefint, "include"_a)
         .def("setIncludeSkipped", &SyntaxPrinter::setIncludeSkipped, byrefint, "include"_a)
         .def("setIncludeDirectives", &SyntaxPrinter::setIncludeDirectives, byrefint, "include"_a)
-        .def("setIncludePreprocessed", &SyntaxPrinter::setIncludePreprocessed, byrefint,
-             "include"_a)
+        .def("setExpandMacros", &SyntaxPrinter::setExpandMacros, byrefint, "expand"_a)
+        .def("setExpandIncludes", &SyntaxPrinter::setExpandIncludes, byrefint, "expand"_a)
         .def("setIncludeComments", &SyntaxPrinter::setIncludeComments, byrefint, "include"_a)
         .def("setSquashNewlines", &SyntaxPrinter::setSquashNewlines, byrefint, "include"_a)
         .def("str", &SyntaxPrinter::str)

--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -12,7 +12,7 @@ set(catch2_min_version "3.8")
 # --- fmt lib ---
 set(find_pkg_args "")
 if(${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.24.0")
-  set(find_pkg_args "OVERRIDE_FIND_PACKAGE" "${fmt_min_version}")
+  set(find_pkg_args "FIND_PACKAGE_ARGS" "${fmt_min_version}")
 endif()
 
 set(FMT_SYSTEM_HEADERS

--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -12,7 +12,7 @@ set(catch2_min_version "3.8")
 # --- fmt lib ---
 set(find_pkg_args "")
 if(${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.24.0")
-  set(find_pkg_args "FIND_PACKAGE_ARGS" "${fmt_min_version}")
+  set(find_pkg_args "OVERRIDE_FIND_PACKAGE" "${fmt_min_version}")
 endif()
 
 set(FMT_SYSTEM_HEADERS

--- a/include/slang/syntax/SyntaxPrinter.h
+++ b/include/slang/syntax/SyntaxPrinter.h
@@ -69,6 +69,8 @@ public:
     }
 
     /// Sets whether to include preprocessor directives when printing syntax.
+    /// For controlling expansion of macros and includes, use `setExpandIncludes` and
+    /// `setExpandMacros`.
     /// @return a reference to this object, to allow chaining additional method calls.
     SyntaxPrinter& setIncludeDirectives(bool include) {
         includeDirectives = include;
@@ -86,13 +88,6 @@ public:
     /// @return a reference to this object, to allow chaining additional method calls.
     SyntaxPrinter& setExpandMacros(bool expand) {
         expandMacros = expand;
-        return *this;
-    }
-
-    /// Sets conflicting settings for use when expanding macros or includes.
-    /// @return a reference to this object, to allow chaining additional method calls.
-    SyntaxPrinter& setExpansionMode() {
-        includeDirectives = true;
         return *this;
     }
 

--- a/include/slang/syntax/SyntaxPrinter.h
+++ b/include/slang/syntax/SyntaxPrinter.h
@@ -75,13 +75,6 @@ public:
         return *this;
     }
 
-    /// Sets whether to include preprocessor-expanded tokens when printing syntax.
-    /// @return a reference to this object, to allow chaining additional method calls.
-    SyntaxPrinter& setIncludePreprocessed(bool include) {
-        includePreprocessed = include;
-        return *this;
-    }
-
     /// Sets whether to expand include directives when printing syntax.
     /// @return a reference to this object, to allow chaining additional method calls.
     SyntaxPrinter& setExpandIncludes(bool expand) {
@@ -99,10 +92,10 @@ public:
     /// Sets conflicting settings for use when expanding macros or includes.
     /// @return a reference to this object, to allow chaining additional method calls.
     SyntaxPrinter& setExpansionMode() {
-        includePreprocessed = false;
         includeDirectives = true;
         return *this;
     }
+
     /// Sets whether to include comments when printing syntax.
     /// @return a reference to this object, to allow chaining additional method calls.
     SyntaxPrinter& setIncludeComments(bool include) {
@@ -126,13 +119,15 @@ public:
     static std::string printFile(const SyntaxTree& tree);
 
 private:
+    bool shouldPrint(SyntaxNode& syntax);
+    bool shouldPrint(SourceLocation loc);
+
     std::string buffer;
     const SourceManager* sourceManager = nullptr;
     bool includeTrivia = true;
     bool includeMissing = false;
     bool includeSkipped = false;
     bool includeDirectives = false;
-    bool includePreprocessed = true;
     bool expandIncludes = false;
     bool expandMacros = false;
     bool includeComments = true;

--- a/include/slang/syntax/SyntaxPrinter.h
+++ b/include/slang/syntax/SyntaxPrinter.h
@@ -114,8 +114,8 @@ public:
     static std::string printFile(const SyntaxTree& tree);
 
 private:
-    bool shouldPrint(SyntaxNode& syntax);
-    bool shouldPrint(SourceLocation loc);
+    bool shouldPrint(SyntaxNode& syntax) const;
+    bool shouldPrint(SourceLocation loc) const;
 
     std::string buffer;
     const SourceManager* sourceManager = nullptr;

--- a/include/slang/syntax/SyntaxPrinter.h
+++ b/include/slang/syntax/SyntaxPrinter.h
@@ -82,6 +82,27 @@ public:
         return *this;
     }
 
+    /// Sets whether to expand include directives when printing syntax.
+    /// @return a reference to this object, to allow chaining additional method calls.
+    SyntaxPrinter& setExpandIncludes(bool expand) {
+        expandIncludes = expand;
+        return *this;
+    }
+
+    /// Sets whether to expand macro directives when printing syntax.
+    /// @return a reference to this object, to allow chaining additional method calls.
+    SyntaxPrinter& setExpandMacros(bool expand) {
+        expandMacros = expand;
+        return *this;
+    }
+
+    /// Sets conflicting settings for use when expanding macros or includes.
+    /// @return a reference to this object, to allow chaining additional method calls.
+    SyntaxPrinter& setExpansionMode() {
+        includePreprocessed = false;
+        includeDirectives = true;
+        return *this;
+    }
     /// Sets whether to include comments when printing syntax.
     /// @return a reference to this object, to allow chaining additional method calls.
     SyntaxPrinter& setIncludeComments(bool include) {
@@ -112,6 +133,8 @@ private:
     bool includeSkipped = false;
     bool includeDirectives = false;
     bool includePreprocessed = true;
+    bool expandIncludes = false;
+    bool expandMacros = false;
     bool includeComments = true;
     bool squashNewlines = true;
 };

--- a/include/slang/text/SourceManager.h
+++ b/include/slang/text/SourceManager.h
@@ -328,6 +328,12 @@ private:
     FileInfo* getFileInfo(BufferID buffer, TLock& lock);
 
     template<IsLock TLock>
+    bool isIncludedFileLocImpl(SourceLocation location, TLock& lock) const;
+
+    template<IsLock TLock>
+    SourceLocation getIncludedFromImpl(BufferID buffer, TLock& lock) const;
+
+    template<IsLock TLock>
     const FileInfo* getFileInfo(BufferID buffer, TLock& lock) const;
 
     SourceBuffer createBufferEntry(FileData* fd, SourceLocation includedFrom,

--- a/source/syntax/SyntaxPrinter.cpp
+++ b/source/syntax/SyntaxPrinter.cpp
@@ -65,7 +65,7 @@ SyntaxPrinter& SyntaxPrinter::print(Token token) {
     bool excluded = !shouldPrint(token.location());
 
     if (includeTrivia) {
-        if (!includeDirectives || !sourceManager) {
+        if (!sourceManager) {
             for (const auto& t : token.trivia())
                 print(t);
         }
@@ -186,19 +186,19 @@ bool SyntaxPrinter::shouldPrint(SourceLocation loc) {
     if (!sourceManager)
         return true;
 
-    if (!sourceManager->isPreprocessedLoc(loc))
-        return true;
-
-    if (expandMacros) {
+    if (sourceManager->isMacroLoc(loc)) {
+        if (!expandMacros) {
+            return false;
+        }
         if (expandIncludes)
             return true;
         return !sourceManager->isIncludedFileLoc(loc);
     }
-
-    if (expandIncludes) {
-        return sourceManager->isIncludedFileLoc(loc);
+    else if (sourceManager->isIncludedFileLoc(loc)) {
+        return expandIncludes;
     }
-    return !includeDirectives;
+    // Not a preprocessed location, so we should print it.
+    return true;
 }
 
 bool SyntaxPrinter::shouldPrint(SyntaxNode& /* DirectiveSyntax& */ syntax) {

--- a/source/syntax/SyntaxPrinter.cpp
+++ b/source/syntax/SyntaxPrinter.cpp
@@ -178,7 +178,7 @@ SyntaxPrinter& SyntaxPrinter::append(std::string_view text) {
     return *this;
 }
 
-bool SyntaxPrinter::shouldPrint(SourceLocation loc) {
+bool SyntaxPrinter::shouldPrint(SourceLocation loc) const {
     if (!sourceManager)
         return true;
 
@@ -199,7 +199,7 @@ bool SyntaxPrinter::shouldPrint(SourceLocation loc) {
     return true;
 }
 
-bool SyntaxPrinter::shouldPrint(SyntaxNode& /* DirectiveSyntax& */ syntax) {
+bool SyntaxPrinter::shouldPrint(SyntaxNode& /* DirectiveSyntax& */ syntax) const {
     if (!sourceManager)
         return includeDirectives;
 

--- a/tests/unittests/CMakeLists.txt
+++ b/tests/unittests/CMakeLists.txt
@@ -34,6 +34,7 @@ add_executable(
   parsing/LexerTests.cpp
   parsing/MemberParsingTests.cpp
   parsing/PreprocessorTests.cpp
+  parsing/RewriterExpandTests.cpp
   parsing/VisitorTests.cpp
   parsing/StatementParsingTests.cpp
   util/CommandLineTests.cpp

--- a/tests/unittests/parsing/RewriterExpandTests.cpp
+++ b/tests/unittests/parsing/RewriterExpandTests.cpp
@@ -28,7 +28,7 @@ endmodule)";
 
         // Test with expandMacros enabled
         SyntaxPrinter printer(tree->sourceManager());
-        printer.setExpansionMode();
+        printer.setIncludeDirectives(true);
         printer.setExpandMacros(true);
 
         auto result = printer.print(*tree);
@@ -55,7 +55,7 @@ endmodule)";
 
         // Test with expandMacros disabled (default)
         SyntaxPrinter printer(tree->sourceManager());
-        printer.setExpansionMode();
+        printer.setIncludeDirectives(true);
         printer.setExpandMacros(false);
 
         auto result = printer.print(*tree);
@@ -65,6 +65,33 @@ endmodule)";
         auto expected = R"(`define MY_MACRO 42
 `define FUNC_MACRO(x) (x + 1)
 `define SIMPLE_MACRO 200
+module test;
+    int a = `MY_MACRO;
+    int b = `FUNC_MACRO(5);
+    int c = `MY_MACRO + `FUNC_MACRO(10);
+    int d = `SIMPLE_MACRO;
+endmodule)";
+        CHECK(resultStr == expected);
+    }
+
+    SECTION("Test macro round trip") {
+        // Parse the test file
+        auto tree = SyntaxTree::fromText(testText);
+        // Note: root could be CompilationUnit or ModuleDeclaration depending on parsing
+        REQUIRE(tree != nullptr);
+
+        // Test with expandMacros disabled (default)
+        SyntaxPrinter printer(tree->sourceManager());
+
+        auto result = printer.print(*tree);
+        auto resultStr = result.str();
+
+        // This had issues with a shortcut for printing triva-
+        // `FUNC_MACRO(10); would turn into `FUNC_MACRO(10)    ;, since trivia was not handled
+        // correctly
+
+        // When macros are not expanded, we should see the macro names
+        auto expected = R"(
 module test;
     int a = `MY_MACRO;
     int b = `FUNC_MACRO(5);
@@ -98,7 +125,7 @@ endmodule)";
 
         // Test with expandIncludes enabled
         SyntaxPrinter printer(tree->sourceManager());
-        printer.setExpansionMode();
+        printer.setIncludeDirectives(true);
         printer.setExpandIncludes(true);
 
         auto result = printer.print(*tree);
@@ -139,7 +166,7 @@ endmodule)";
 
         // Test with expandIncludes disabled (default)
         SyntaxPrinter printer(tree->sourceManager());
-        printer.setExpansionMode();
+        printer.setIncludeDirectives(true);
         printer.setExpandIncludes(false);
 
         auto result = printer.print(*tree);
@@ -180,7 +207,7 @@ endmodule)";
 
         // Test with both options enabled
         SyntaxPrinter printer(tree->sourceManager());
-        printer.setExpansionMode();
+        printer.setIncludeDirectives(true);
         printer.setExpandIncludes(true);
         printer.setExpandMacros(true);
 
@@ -228,7 +255,7 @@ endmodule
 
         // Test with both options enabled
         SyntaxPrinter printer(tree->sourceManager());
-        printer.setExpansionMode();
+        printer.setIncludeDirectives(true);
         printer.setExpandMacros(true);
 
         auto result = printer.print(*tree);

--- a/tests/unittests/parsing/RewriterExpandTests.cpp
+++ b/tests/unittests/parsing/RewriterExpandTests.cpp
@@ -1,0 +1,201 @@
+// SPDX-FileCopyrightText: Michael Popoloski
+// SPDX-License-Identifier: MIT
+
+#include "Test.h"
+
+#include "slang/syntax/SyntaxPrinter.h"
+#include "slang/syntax/SyntaxTree.h"
+#include "slang/text/SourceManager.h"
+
+TEST_CASE("Rewriter expand macros functionality") {
+    // Simple test case with inline macro definitions
+    auto testText = R"(`define MY_MACRO 42
+`define FUNC_MACRO(x) (x + 1)
+`define SIMPLE_MACRO 200
+
+module test;
+    int a = `MY_MACRO;
+    int b = `FUNC_MACRO(5);
+    int c = `MY_MACRO + `FUNC_MACRO(10);
+    int d = `SIMPLE_MACRO;
+endmodule)";
+
+    SECTION("Test expandMacros option") {
+        // Parse the test file
+        auto tree = SyntaxTree::fromText(testText);
+        // Note: root could be CompilationUnit or ModuleDeclaration depending on parsing
+        REQUIRE(tree != nullptr);
+
+        // Test with expandMacros enabled
+        SyntaxPrinter printer(tree->sourceManager());
+        printer.setExpansionMode();
+        printer.setExpandMacros(true);
+
+        auto result = printer.print(*tree);
+        auto resultStr = result.str();
+
+        // When macros are expanded, we should see the literal values instead of macro names
+        auto expected = R"(`define MY_MACRO 42
+`define FUNC_MACRO(x) (x + 1)
+`define SIMPLE_MACRO 200
+module test;
+    int a = 42;
+    int b = (5 + 1);
+    int c = 42 + (10 + 1);
+    int d = 200;
+endmodule)";
+        CHECK(resultStr == expected);
+    }
+
+    SECTION("Test expandMacros disabled") {
+        // Parse the test file
+        auto tree = SyntaxTree::fromText(testText);
+        // Note: root could be CompilationUnit or ModuleDeclaration depending on parsing
+        REQUIRE(tree != nullptr);
+
+        // Test with expandMacros disabled (default)
+        SyntaxPrinter printer(tree->sourceManager());
+        printer.setExpansionMode();
+        printer.setExpandMacros(false);
+
+        auto result = printer.print(*tree);
+        auto resultStr = result.str();
+
+        // When macros are not expanded, we should see the macro names
+        auto expected = R"(`define MY_MACRO 42
+`define FUNC_MACRO(x) (x + 1)
+`define SIMPLE_MACRO 200
+module test;
+    int a = `MY_MACRO;
+    int b = `FUNC_MACRO(5);
+    int c = `MY_MACRO + `FUNC_MACRO(10);
+    int d = `SIMPLE_MACRO;
+endmodule)";
+        CHECK(resultStr == expected);
+    }
+
+    SECTION("Test expandIncludes option") {
+        // Create a custom SourceManager and add include file content
+        SourceManager sourceManager;
+        sourceManager.setDisableProximatePaths(true);
+
+        // Add the include file content to SourceManager
+        auto includeContent = R"(`define INCLUDED_MACRO 999
+`define INCLUDED_FUNC(x) ((x) + 100))";
+        sourceManager.assignText("test_header.svh", includeContent);
+
+        // Test case with actual include directive
+        auto includeTestText = R"(`include "test_header.svh"
+
+module test;
+    int a = `INCLUDED_MACRO;
+    int b = `INCLUDED_FUNC(10);
+endmodule)";
+
+        // Parse the test file with our custom SourceManager
+        auto tree = SyntaxTree::fromText(includeTestText, sourceManager);
+        REQUIRE(tree != nullptr);
+
+        // Test with expandIncludes enabled
+        SyntaxPrinter printer(tree->sourceManager());
+        printer.setExpansionMode();
+        printer.setExpandIncludes(true);
+
+        auto result = printer.print(*tree);
+        auto resultStr = result.str();
+
+        // When expandIncludes is true, include directives are EXCLUDED from output
+        // The included content is processed but directives themselves are removed
+        auto expected = R"(`define INCLUDED_MACRO 999
+`define INCLUDED_FUNC(x) ((x) + 100)
+module test;
+    int a = `INCLUDED_MACRO;
+    int b = `INCLUDED_FUNC(10);
+endmodule)";
+        CHECK(resultStr == expected);
+    }
+
+    SECTION("Test expandIncludes disabled") {
+        // Create a custom SourceManager and add include file content
+        SourceManager sourceManager;
+        sourceManager.setDisableProximatePaths(true);
+
+        // Add the include file content to SourceManager
+        auto includeContent = R"(`define INCLUDED_MACRO 999
+`define INCLUDED_FUNC(x) ((x) + 100))";
+        sourceManager.assignText("test_header.svh", includeContent);
+
+        // Test case with actual include directive
+        auto includeTestText = R"(`include "test_header.svh"
+
+module test;
+    int a = `INCLUDED_MACRO;
+    int b = `INCLUDED_FUNC(10);
+endmodule)";
+
+        // Parse the test file with our custom SourceManager
+        auto tree = SyntaxTree::fromText(includeTestText, sourceManager);
+        REQUIRE(tree != nullptr);
+
+        // Test with expandIncludes disabled (default)
+        SyntaxPrinter printer(tree->sourceManager());
+        printer.setExpansionMode();
+        printer.setExpandIncludes(false);
+
+        auto result = printer.print(*tree);
+        auto resultStr = result.str();
+
+        // When expandIncludes is false (default), include directives are INCLUDED in output
+        auto expected = R"(`include "test_header.svh"
+module test;
+    int a = `INCLUDED_MACRO;
+    int b = `INCLUDED_FUNC(10);
+endmodule)";
+        CHECK(resultStr == expected);
+    }
+
+    SECTION("Test both expandMacros and expandIncludes enabled") {
+        // Create a custom SourceManager and add include file content
+        SourceManager sourceManager;
+        sourceManager.setDisableProximatePaths(true);
+
+        // Add the include file content to SourceManager
+        auto includeContent = R"(`define INCLUDED_MACRO 777
+`define INCLUDED_FUNC(x) ((x) * 2))";
+        sourceManager.assignText("test_header.svh", includeContent);
+
+        // Test case combining macro expansion with include expansion
+        auto combinedTestText = R"(`define LOCAL_MACRO 555
+`include "test_header.svh"
+
+module test;
+    int a = `LOCAL_MACRO;
+    int b = `INCLUDED_MACRO;
+    int c = `INCLUDED_FUNC(5);
+endmodule)";
+
+        // Parse the test file with our custom SourceManager
+        auto tree = SyntaxTree::fromText(combinedTestText, sourceManager);
+        REQUIRE(tree != nullptr);
+
+        // Test with both options enabled
+        SyntaxPrinter printer(tree->sourceManager());
+        printer.setExpansionMode();
+        printer.setExpandIncludes(true);
+        printer.setExpandMacros(true);
+
+        auto result = printer.print(*tree);
+        auto resultStr = result.str();
+
+        // Should see expanded macros and included content with include directive removed
+        auto expected = R"(`define LOCAL_MACRO 555
+`define INCLUDED_MACRO 777
+`define INCLUDED_FUNC(x) ((x) * 2)
+module test;
+    int a = 555;
+    int b = 777;
+    int c = ((5) * 2);
+endmodule)";
+        CHECK(resultStr == expected);
+    }
+}

--- a/tools/rewriter/README.md
+++ b/tools/rewriter/README.md
@@ -1,12 +1,33 @@
-rewriter
-========
-A simple tool that shows using the syntax API to read in a source file,
-parse it, and write it back out again. This can be used for testing purposes,
-to make sure syntax trees round trip correctly, or as a basic example of
-working with the syntax API.
+# Rewriter
 
-Usage:
+A simple tool that prints a given input file, showcasing the round-trip ability of the library.
 
+## Description
+
+By default, rewriter prints the input file exactly as is. This tool can be used to:
+- Modify files before use in other tools
+- Better understand what the preprocessor is doing
+- Test the round-trip capability of the Slang library
+
+The tool accepts standard Slang arguments like include directories. When a macro or include is not found, it will be skipped.
+
+## Usage
+
+```bash
+rewriter [options] <file-name>
 ```
-rewriter <file-name>
-```
+
+## Options
+
+### Expansion Options
+- `--expand-includes` - Expand include directives to show included content
+- `--expand-macros` - Expand macro usages to show expanded content
+
+### Filtering Options
+- `--exclude-directives` - Exclude other directives in output (doesn't control include and macro directives)
+- `--exclude-comments` - Exclude comments in output
+- `--exclude-skipped` - Exclude skipped (error) nodes in output
+
+### Formatting Options
+- `--squash-newlines` - Squash adjacent newlines into one
+- `--include-missing` - Include missing (auto-inserted) nodes in output

--- a/tools/rewriter/rewriter.cpp
+++ b/tools/rewriter/rewriter.cpp
@@ -98,7 +98,6 @@ int main(int argc, char** argv) {
         SyntaxPrinter printer(driver.sourceManager);
 
         // These get in the way of expandMacros and expandIncludes, so hold these
-        printer.setIncludePreprocessed(false);
         printer.setIncludeDirectives(true);
         // Really should be false by default
         printer.setSquashNewlines(false);

--- a/tools/rewriter/rewriter.cpp
+++ b/tools/rewriter/rewriter.cpp
@@ -35,6 +35,7 @@ int main(int argc, char** argv) {
         // 1-1 mapping with selected SyntaxPrinter options
         std::optional<bool> expandIncludes;
         std::optional<bool> expandMacros;
+        std::optional<bool> excludeDirectives;
 
         // Defaulted to true in SyntaxPrinter; we should rephrase those eventually
         std::optional<bool> excludeComments;
@@ -53,6 +54,11 @@ int main(int argc, char** argv) {
                            "Expand include directives to show included content");
         driver.cmdLine.add("--expand-macros", expandMacros,
                            "Expand macro usages to show expanded content");
+
+        // Directive options
+        driver.cmdLine.add(
+            "--exclude-directives", excludeDirectives,
+            "Exclude other directives in output (Doesn't control include and macro directives)");
 
         // Trivia options
         driver.cmdLine.add("--exclude-comments", excludeComments, "Exclude comments in output");
@@ -112,6 +118,8 @@ int main(int argc, char** argv) {
             printer.setIncludeComments(false);
         if (squashNewlines == true)
             printer.setSquashNewlines(true);
+        if (excludeDirectives == true)
+            printer.setIncludeDirectives(false);
 
         if (includeMissing == true)
             printer.setIncludeMissing(true);

--- a/tools/rewriter/rewriter.cpp
+++ b/tools/rewriter/rewriter.cpp
@@ -1,7 +1,8 @@
 //------------------------------------------------------------------------------
 // rewriter.cpp
 // Simple tool that parses an input file and writes it back out; used
-// for verifying the round-trip nature of the parse tree.
+// for verifying the round-trip nature of the parse tree and for providing common rewriting
+// capabilities like expanding macros, removing comments, etc.
 //
 // SPDX-FileCopyrightText: Michael Popoloski
 // SPDX-License-Identifier: MIT
@@ -14,35 +15,116 @@
 #endif
 
 #include <fmt/format.h>
+#include <optional>
 
+#include "slang/driver/Driver.h"
 #include "slang/syntax/SyntaxPrinter.h"
-#include "slang/syntax/SyntaxTree.h"
+#include "slang/util/CommandLine.h"
 #include "slang/util/OS.h"
 
 using namespace slang;
 using namespace slang::syntax;
+using namespace slang::parsing;
 
 int main(int argc, char** argv) {
     OS::setupConsole();
 
     SLANG_TRY {
-        if (argc != 2) {
-            fmt::print(stderr, "usage: rewriter file\n");
+        std::optional<bool> showHelp;
+
+        // 1-1 mapping with selected SyntaxPrinter options
+        std::optional<bool> expandIncludes;
+        std::optional<bool> expandMacros;
+
+        // Defaulted to true in SyntaxPrinter; we should rephrase those eventually
+        std::optional<bool> excludeComments;
+        std::optional<bool> squashNewlines;
+
+        std::optional<bool> includeMissing;
+        std::optional<bool> includeSkipped;
+
+        driver::Driver driver;
+        driver.addStandardArgs();
+
+        driver.cmdLine.add("-h,--help", showHelp, "Display available options");
+
+        // Expansion options
+        driver.cmdLine.add("--expand-includes", expandIncludes,
+                           "Expand include directives to show included content");
+        driver.cmdLine.add("--expand-macros", expandMacros,
+                           "Expand macro usages to show expanded content");
+
+        // Trivia options
+        driver.cmdLine.add("--exclude-comments", excludeComments, "Exclude comments in output");
+        driver.cmdLine.add("--squash-newlines", squashNewlines,
+                           "Squash adjacent newlines into one");
+
+        // Missing/skipped node options
+        driver.cmdLine.add("--include-missing", includeMissing,
+                           "Include missing (auto-inserted) nodes in output");
+        driver.cmdLine.add("--exclude-skipped", includeSkipped,
+                           "Exclude skipped (error) nodes in output");
+
+        if (!driver.parseCommandLine(argc, argv))
+            return 1;
+
+        auto printHelp = [&]() {
+            OS::print(fmt::format(
+                "{}",
+                driver.cmdLine.getHelpText(
+                    "SystemVerilog rewriter- by default prints the input tree exactly as given.")));
+        };
+
+        if (showHelp == true) {
+            printHelp();
+            return 0;
+        }
+
+        bool ok = driver.parseAllSources();
+        if (!ok) {
+            OS::printE("error: failed to parse input files\n");
             return 1;
         }
 
-        auto tree = SyntaxTree::fromFile(argv[1]);
-        if (!tree) {
-            fmt::print(stderr, "error: '{}': {}\n", argv[1], tree.error().first.message());
+        if (driver.syntaxTrees.empty()) {
+            OS::printE("error: no input file specified\n");
+            printHelp();
             return 1;
         }
+
+        // By default print the last tree given (some flag files may pass syntax trees)
+        auto tree = driver.syntaxTrees.back();
+
+        SyntaxPrinter printer(driver.sourceManager);
+
+        // These get in the way of expandMacros and expandIncludes, so hold these
+        printer.setIncludePreprocessed(false);
+        printer.setIncludeDirectives(true);
+        // Really should be false by default
+        printer.setSquashNewlines(false);
+
+        // Apply command line overrides to defaults
+        if (expandIncludes == true)
+            printer.setExpandIncludes(true);
+        if (expandMacros == true)
+            printer.setExpandMacros(true);
+
+        if (excludeComments == true)
+            printer.setIncludeComments(false);
+        if (squashNewlines == true)
+            printer.setSquashNewlines(true);
+
+        if (includeMissing == true)
+            printer.setIncludeMissing(true);
+        if (includeSkipped == true)
+            printer.setIncludeSkipped(true);
 
         // Make sure we reproduce newlines correctly on Windows:
 #if defined(_WIN32)
         _setmode(_fileno(stdout), _O_BINARY);
 #endif
 
-        printf("%s", SyntaxPrinter::printFile(*tree.value()).c_str());
+        printf("%s", printer.print(*tree).str().c_str());
         return 0;
     }
     SLANG_CATCH(const std::exception& e) {


### PR DESCRIPTION
I wanted to add these options to the syntax printer for use in the rewriter and language servers.

These new options conflict with `includePreprocessed` and `includeDirectives`, but these options are widely used in tests, so I'm wondering if I should make a version of SyntaxPrinter for focused on rewriting- specifically spitting out equivalent but different code- for example these expansions, filtering out non-synthesizable constructs, getting rid of package star imports, etc. 

A lot of the options in the existing printer aren't too useful for the rewriter- for example setting includeTrivia to false isn't useful, since it takes out all whitespace and therefore prints invalid code.

Macros invoked in includes weren't being classified as being from includes- so I modified isincludedfileloc to address this case.

Eventually I want to allow for selectively expanding macros- either a single macro usage or a macro name, which I think should be possible without extra metadata. But doing a single macro usage without printing the whole file (language server use case) could be more efficient if ranges of the usage expansion were stored in the syntax tree.