### PR TITLE
[rewriter] Add --squash-blanklines

### DIFF
--- a/include/slang/syntax/SyntaxPrinter.h
+++ b/include/slang/syntax/SyntaxPrinter.h
@@ -105,8 +105,15 @@ public:
         return *this;
     }
 
+    /// Sets whether to squash blank lines down into one when printing syntax.
+    /// @return a reference to this object, to allow chaining additional method calls.
+    SyntaxPrinter& setSquashBlanklines(bool squash) {
+        squashBlankLines = squash;
+        return *this;
+    }
+
     /// @return a copy of the internal text buffer.
-    std::string str() const { return buffer; }
+    std::string str() const;
 
     /// A helper method that assists in printing an entire syntax tree back to source
     /// text. A SyntaxPrinter with useful defaults is constructed, the tree is printed,
@@ -127,6 +134,7 @@ private:
     bool expandMacros = false;
     bool includeComments = true;
     bool squashNewlines = true;
+    bool squashBlankLines = false;
 };
 
 } // namespace slang::syntax

--- a/source/syntax/SyntaxPrinter.cpp
+++ b/source/syntax/SyntaxPrinter.cpp
@@ -138,6 +138,62 @@ std::string SyntaxPrinter::printFile(const SyntaxTree& tree) {
         .str();
 }
 
+std::string SyntaxPrinter::str() const {
+    if (!squashBlankLines) {
+        return buffer;
+    }
+    // Split buffer into lines and process each one
+    std::string result;
+    result.reserve(buffer.size());
+
+    std::istringstream stream(buffer);
+    std::string line;
+    bool lastLineWasEmpty = false;
+    bool firstLine = true;
+
+    while (std::getline(stream, line)) {
+        // Check if line is empty or contains only whitespace
+        bool isEmpty = line.empty();
+        if (!isEmpty) {
+            isEmpty = true;
+            for (char c : line) {
+                if (c != ' ' && c != '\t') {
+                    isEmpty = false;
+                    break;
+                }
+            }
+        }
+
+        if (!isEmpty) {
+            // Line has content, always include it with full indentation
+            if (!firstLine) {
+                result.push_back('\n');
+            }
+            result.append(line);
+            lastLineWasEmpty = false;
+        }
+        else if (!lastLineWasEmpty) {
+            // First empty line in a sequence, include it as a single empty line (no
+            // indentation)
+            if (!firstLine) {
+                result.push_back('\n');
+            }
+            // For empty lines, don't include whitespace - just make it truly empty
+            lastLineWasEmpty = true;
+        }
+        // Skip subsequent empty/whitespace-only lines in sequence
+
+        firstLine = false;
+    }
+
+    // Handle the case where buffer doesn't end with newline
+    if (!buffer.empty() && (buffer.back() == '\n' || buffer.back() == '\r')) {
+        result.push_back('\n');
+    }
+
+    return result;
+}
+
 SyntaxPrinter& SyntaxPrinter::append(std::string_view text) {
     if (!squashNewlines) {
         buffer.append(text);

--- a/tests/unittests/CMakeLists.txt
+++ b/tests/unittests/CMakeLists.txt
@@ -34,7 +34,7 @@ add_executable(
   parsing/LexerTests.cpp
   parsing/MemberParsingTests.cpp
   parsing/PreprocessorTests.cpp
-  parsing/RewriterExpandTests.cpp
+  parsing/SyntaxPrinterTests.cpp
   parsing/VisitorTests.cpp
   parsing/StatementParsingTests.cpp
   util/CommandLineTests.cpp

--- a/tests/unittests/parsing/SyntaxPrinterTests.cpp
+++ b/tests/unittests/parsing/SyntaxPrinterTests.cpp
@@ -265,3 +265,155 @@ endmodule
         CHECK(resultStr.find("SOME_VALUE") == std::string::npos);
     }
 }
+
+TEST_CASE("SyntaxPrinter newline squashing functionality") {
+    SECTION("Test setSquashBlanklines enabled") {
+        auto testText = R"(module test;
+
+
+    int a = 1;
+
+
+    int b = 2;
+
+
+
+    int c = 3;
+endmodule)";
+
+        auto tree = SyntaxTree::fromText(testText);
+        REQUIRE(tree != nullptr);
+
+        SyntaxPrinter printer(tree->sourceManager());
+        printer.setSquashNewlines(false);
+        printer.setSquashBlanklines(true);
+
+        auto result = printer.print(*tree);
+        auto resultStr = result.str();
+
+        // Multiple consecutive newlines and whitespace-only lines should be squashed to single
+        // newlines
+        auto expected = R"(module test;
+
+    int a = 1;
+
+    int b = 2;
+
+    int c = 3;
+endmodule)";
+        CHECK(resultStr == expected);
+    }
+
+    SECTION("Test setSquashBlanklines disabled") {
+        auto testText = R"(module test;
+
+
+    int a = 1;
+
+
+    int b = 2;
+
+
+
+    int c = 3;
+endmodule)";
+
+        auto tree = SyntaxTree::fromText(testText);
+        REQUIRE(tree != nullptr);
+
+        SyntaxPrinter printer(tree->sourceManager());
+        printer.setSquashNewlines(false);
+        printer.setSquashBlanklines(false);
+
+        auto result = printer.print(*tree);
+        auto resultStr = result.str();
+
+        // All original newlines and whitespace should be preserved
+        CHECK(resultStr == testText);
+    }
+
+    SECTION("Test squashing with different whitespace patterns") {
+        auto testText = R"(module test;
+
+    int a = 1;
+
+
+
+    int b = 2;
+endmodule)";
+
+        auto tree = SyntaxTree::fromText(testText);
+        REQUIRE(tree != nullptr);
+
+        SyntaxPrinter printer(tree->sourceManager());
+        printer.setSquashNewlines(false);
+        printer.setSquashBlanklines(true);
+
+        auto result = printer.print(*tree);
+        auto resultStr = result.str();
+
+        // Lines with only spaces/tabs should be treated as empty and squashed
+        auto expected = R"(module test;
+
+    int a = 1;
+
+    int b = 2;
+endmodule)";
+        CHECK(resultStr == expected);
+    }
+
+    SECTION("Test squashing preserves meaningful spacing") {
+        auto testText = R"(module test;
+    int a = 1;
+    int b = 2;
+
+    int c = 3;
+endmodule)";
+
+        auto tree = SyntaxTree::fromText(testText);
+        REQUIRE(tree != nullptr);
+
+        SyntaxPrinter printer(tree->sourceManager());
+        printer.setSquashNewlines(false);
+        printer.setSquashBlanklines(true);
+
+        auto result = printer.print(*tree);
+        auto resultStr = result.str();
+
+        // Single blank lines should be preserved for readability
+        auto expected = R"(module test;
+    int a = 1;
+    int b = 2;
+
+    int c = 3;
+endmodule)";
+        CHECK(resultStr == expected);
+    }
+
+    SECTION("Test squashing with only empty/whitespace lines") {
+        auto testText = R"(
+
+
+
+
+
+
+
+)";
+
+        auto tree = SyntaxTree::fromText(testText);
+        REQUIRE(tree != nullptr);
+
+        SyntaxPrinter printer(tree->sourceManager());
+        printer.setSquashNewlines(false);
+        printer.setSquashBlanklines(true);
+
+        auto result = printer.print(*tree);
+        auto resultStr = result.str();
+
+        // Should result in a single newline
+        auto expected = R"(
+)";
+        CHECK(resultStr == expected);
+    }
+}

--- a/tools/rewriter/rewriter.cpp
+++ b/tools/rewriter/rewriter.cpp
@@ -62,8 +62,8 @@ int main(int argc, char** argv) {
 
         // Trivia options
         driver.cmdLine.add("--exclude-comments", excludeComments, "Exclude comments in output");
-        driver.cmdLine.add("--squash-newlines", squashNewlines,
-                           "Squash adjacent newlines into one");
+        driver.cmdLine.add("--squash-blanklines", squashNewlines,
+                           "Squash adjacent blank lines into one");
 
         // Missing/skipped node options
         driver.cmdLine.add("--include-missing", includeMissing,
@@ -117,7 +117,7 @@ int main(int argc, char** argv) {
         if (excludeComments == true)
             printer.setIncludeComments(false);
         if (squashNewlines == true)
-            printer.setSquashNewlines(true);
+            printer.setSquashBlanklines(true);
         if (excludeDirectives == true)
             printer.setIncludeDirectives(false);
 


### PR DESCRIPTION
The issue with --squash-newlines is that when macros are expanded and directives are ignored, the blank lines with tabs add up and don't get squashed, since they're all coming from different directives, resulting in sometimes a massive amount of blank lines at the beginning. This solves that by doing a pass at the end to squash these.

This is a use case for the rewriter as running the preprocessor in slang for other tools, and could be set as default for `-E,--preprocess` as well.