### PR TITLE
Implement --cst-json

### DIFF
--- a/docs/command-line-ref.dox
+++ b/docs/command-line-ref.dox
@@ -283,6 +283,25 @@ When dumping AST to JSON, include source line and file information.
 When dumping AST to JSON, include expanded type information in the output instead of
 condensing all types into a human-friendly string.
 
+`--cst-json <file>`
+
+Dump the concrete syntax trees (CST) in JSON format to the specified file, or '-' for stdout.
+The CST represents the parsed structure of the source code including all tokens, whitespace,
+and comments exactly as they appear in the source.
+
+`--cst-json-mode <mode>`
+
+Controls the level of detail included in the CST JSON output. The available modes in order of most to least detailed are:
+
+| Mode | Description |
+|------|-------------|
+| `full` | Full token objects with complete trivia information including whitespace, comments, and formatting details |
+| `simple-trivia` | Full token objects with trivia simplified to concatenated strings instead of detailed arrays and kinds |
+| `no-trivia` | Full token objects but with all trivia objects excluded from the output |
+| `simple-tokens` | Tokens represented as simple strings with no trivia or token kind information |
+
+The default mode is `full` if this option is not specified.
+
 @section compilation-limits Compilation
 
 `--top <name>`

--- a/include/slang/syntax/CSTSerializer.h
+++ b/include/slang/syntax/CSTSerializer.h
@@ -1,0 +1,39 @@
+//------------------------------------------------------------------------------
+//! @file CSTSerializer.h
+//! @brief Concrete Syntax Tree JSON serialization
+//
+// SPDX-FileCopyrightText: Michael Popoloski
+// SPDX-License-Identifier: MIT
+//------------------------------------------------------------------------------
+#pragma once
+
+#include "slang/syntax/SyntaxNode.h"
+#include "slang/text/Json.h"
+
+namespace slang::syntax {
+
+class SyntaxTree;
+
+#define MODE(x) x(Full) x(SimpleTrivia) x(NoTrivia) x(SimpleTokens)
+SLANG_ENUM(CSTJsonMode, MODE)
+#undef MODE
+
+/// Converts concrete syntax trees to JSON format for debugging and analysis
+class SLANG_EXPORT CSTSerializer {
+public:
+    explicit CSTSerializer(JsonWriter& writer, CSTJsonMode mode = CSTJsonMode::Full);
+
+    /// Serialize a syntax tree to JSON
+    void serialize(const SyntaxTree& tree);
+
+    /// Serialize a syntax node to JSON
+    void serialize(const SyntaxNode& node);
+
+private:
+    void visitToken(parsing::Token token);
+    void writeTokenTrivia(parsing::Token token);
+
+    JsonWriter& writer;
+    CSTJsonMode mode;
+};
+} // namespace slang::syntax

--- a/include/slang/util/CommandLine.h
+++ b/include/slang/util/CommandLine.h
@@ -7,6 +7,8 @@
 //------------------------------------------------------------------------------
 #pragma once
 
+#include <cctype>
+#include <fmt/core.h>
 #include <functional>
 #include <map>
 #include <optional>
@@ -16,6 +18,7 @@
 
 #include "slang/util/Enum.h"
 #include "slang/util/SmallVector.h"
+#include "slang/util/String.h"
 #include "slang/util/Util.h"
 
 namespace slang {
@@ -246,6 +249,22 @@ public:
     void add(std::string_view name, OptionCallback cb, std::string_view desc,
              std::string_view valueName = {}, bitmask<CommandLineFlags> flags = {});
 
+    /// Register an option with @a name that will be parsed as a string enum value.
+    /// The string will be matched against the available enum values using their toString()
+    /// representation. If the option is not provided on a command line, the value will remain
+    /// unset.
+    ///
+    /// @param name a comma separated list of long form and short form names
+    ///             (including the dashes) that are accepted for this option
+    /// @param value a value that will be set if the option is provided
+    /// @param desc a human-friendly description for printing help text. Valid options will be
+    /// appended to this documentation if given.
+    /// @param valueName an example name for the value when printing help text
+    /// @param flags additional flags that control how the option behaves
+    template<typename T, typename Traits>
+    void addEnum(std::string_view name, std::optional<T>& value, std::string_view desc,
+                 std::string_view valueName = {}, bitmask<CommandLineFlags> flags = {});
+
     /// Set a variable that will receive any positional arguments provided
     /// on the command line. They will be returned as a list of strings.
     ///
@@ -400,7 +419,11 @@ private:
 
     void handleArg(std::string_view arg, Option*& expectingVal, std::string& expectingValName,
                    bool& hadUnknowns, ParseOptions options);
+
     void handlePlusArg(std::string_view arg, ParseOptions options, bool& hadUnknowns);
+
+    /// Converts CamelCase strings to kebab-case (e.g. "SimpleTrivia" -> "simple-trivia").
+    static std::string toKebabCase(std::string_view str);
 
     Option* findOption(std::string_view arg, std::string_view& value) const;
     Option* tryGroupOrPrefix(std::string_view& arg, std::string_view& value, ParseOptions options);
@@ -425,5 +448,55 @@ private:
     std::string programName;
     std::vector<std::string> errors;
 };
+
+// Impl must be in header because of the templates.
+template<typename T, typename Traits>
+void CommandLine::addEnum(std::string_view name, std::optional<T>& value, std::string_view desc,
+                          std::string_view valueName, bitmask<CommandLineFlags> flags) {
+    static_assert(Traits::values.size() > 0,
+                  "Traits::values must be defined with at least one value");
+
+    // Helper to build comma-separated list of valid options
+    auto buildValidOptionsList = []() -> std::string {
+        std::string validOptions;
+        bool first = true;
+        for (auto enumVal : Traits::values) {
+            if (!first)
+                validOptions += ", ";
+            validOptions += "'";
+            validOptions += CommandLine::toKebabCase(toString(enumVal));
+            validOptions += "'";
+            first = false;
+        }
+        return validOptions;
+    };
+
+    // Create a callback that parses the string and converts it to the enum value
+    auto parseValue = [&value, buildValidOptionsList](std::string_view str) -> std::string {
+        // Iterate through all possible enum values and find a match
+        for (auto enumVal : Traits::values) {
+            std::string kebabName = CommandLine::toKebabCase(toString(enumVal));
+            if (kebabName == str) {
+                value = enumVal;
+                return {};
+            }
+        }
+
+        return fmt::format("invalid value '{}', valid options are: {}", str,
+                           buildValidOptionsList());
+    };
+
+    // Build description with valid options listed
+    std::string validOptions = buildValidOptionsList();
+    std::string fullDesc = std::string(desc);
+    if (!validOptions.empty()) {
+        if (!fullDesc.empty()) {
+            fullDesc += ". ";
+        }
+        fullDesc += "Valid options: " + validOptions;
+    }
+
+    add(name, parseValue, fullDesc, valueName, flags);
+}
 
 } // namespace slang

--- a/include/slang/util/CommandLine.h
+++ b/include/slang/util/CommandLine.h
@@ -250,10 +250,12 @@ public:
              std::string_view valueName = {}, bitmask<CommandLineFlags> flags = {});
 
     /// Register an option with @a name that will be parsed as a string enum value.
-    /// The string will be matched against the available enum values using their toString()
-    /// representation. If the option is not provided on a command line, the value will remain
-    /// unset.
+    /// The string will be matched against the available enum values using the kebab case name
+    /// created from their toString() representation. If the option is not provided on a command
+    /// line, the value will remain unset.
     ///
+    /// @param T the type of the enum value
+    /// @param Traits a traits class, typically generated as T_traits by the SLANG_ENUM macro
     /// @param name a comma separated list of long form and short form names
     ///             (including the dashes) that are accepted for this option
     /// @param value a value that will be set if the option is provided

--- a/pyslang/tests/test_cst_json.py
+++ b/pyslang/tests/test_cst_json.py
@@ -1,0 +1,238 @@
+# SPDX-FileCopyrightText: Michael Popoloski
+# SPDX-License-Identifier: MIT
+
+import json
+from functools import cache
+from typing import Any, Dict, List, Union
+
+import pyslang
+
+
+def to_dict(tree, mode: pyslang.CSTJsonMode):
+    json_str = tree.to_json(mode)
+    return json.loads(json_str)
+
+
+def get_enum_names(enum_class) -> set:
+    return set([k for k in enum_class.__members__])
+
+
+SYNTAX_KINDS = get_enum_names(pyslang.SyntaxKind)
+TOKEN_KINDS = get_enum_names(pyslang.TokenKind)
+TRIVIA_KINDS = get_enum_names(pyslang.TriviaKind)
+
+
+class CSTValidator:
+    """Validates CST JSON structure properties based on serialization mode."""
+
+    def __init__(self, mode: pyslang.CSTJsonMode):
+        self.mode = mode
+        self.errors = list[str]()
+
+    def validate(self, json_data: Any, path: str = "root") -> bool:
+        """Validate CST JSON data and return True if valid."""
+        self.errors = []
+        self._validate_node(json_data, path)
+        return len(self.errors) == 0
+
+    def get_errors(self) -> List[str]:
+        """Get list of validation errors."""
+        return self.errors.copy()
+
+    def _error(self, message: str, path: str):
+        """Record a validation error."""
+        self.errors.append(f"{path}: {message}")
+
+    def _validate_node(self, node: Any, path: str):
+        """Validate a single node in the CST."""
+        if not isinstance(node, dict):
+            self._error(f"Expected dict, got {type(node)}", path)
+            return
+
+        # Every node must have a 'kind' field
+        if "kind" not in node:
+            self._error("Missing 'kind' field", path)
+            return
+
+        kind = node["kind"]
+
+        # Validate kind value
+        if not isinstance(kind, str):
+            self._error(f"'kind' must be string, got {type(kind)}", path)
+            return
+
+        # Handle special cases that are not in the enum
+        special_kinds = {"SyntaxTree"}
+
+        if kind not in (SYNTAX_KINDS | TOKEN_KINDS | special_kinds):
+            self._error(f"Unknown kind '{kind}'", path)
+
+        # Validate based on node type
+        if kind in TOKEN_KINDS:
+            self._validate_token(node, path)
+        elif kind in SYNTAX_KINDS or kind in special_kinds:
+            self._validate_syntax_node(node, path)
+
+        # Validate trivia constraints based on mode
+        self._validate_trivia_constraints(node, path)
+
+    def _validate_token(self, token: Dict[str, Any], path: str):
+        """Validate a token node."""
+        kind = token["kind"]
+
+        if self.mode == pyslang.CSTJsonMode.SimpleTokens:
+            # In SimpleTokens mode, some tokens might be collapsed to strings
+            return
+
+        # Token must have 'text' field
+        if "text" not in token:
+            self._error(f"Token '{kind}' missing 'text' field", path)
+            return
+
+        text = token["text"]
+        if not isinstance(text, str):
+            self._error(f"Token 'text' must be string, got {type(text)}", path)
+            return
+
+        # Text should not be empty for most tokens
+        if not text.strip() and kind not in {"Whitespace"}:
+            self._error(f"Token '{kind}' has empty text", path)
+
+        # Validate trivia if present
+        if "trivia" in token:
+            self._validate_trivia(token["trivia"], f"{path}.trivia")
+
+    def _validate_syntax_node(self, node: Dict[str, Any], path: str):
+        """Validate a syntax node (non-token)."""
+        for key, value in node.items():
+            if key == "kind":
+                continue
+
+            child_path = f"{path}.{key}"
+
+            if isinstance(value, dict):
+                self._validate_node(value, child_path)
+            elif isinstance(value, list):
+                for i, item in enumerate(value):
+                    if isinstance(item, dict):
+                        self._validate_node(item, f"{child_path}[{i}]")
+                    elif self.mode == pyslang.CSTJsonMode.SimpleTokens and isinstance(
+                        item, str
+                    ):
+                        # In SimpleTokens mode, some nested structures might be strings
+                        if not item.strip():
+                            self._error("Empty string value", f"{child_path}[{i}]")
+                    else:
+                        self._error(
+                            f"Unexpected list item type {type(item)}",
+                            f"{child_path}[{i}]",
+                        )
+            elif isinstance(value, str):
+                # In SimpleTokens mode, some fields might be collapsed to strings
+                if self.mode == pyslang.CSTJsonMode.SimpleTokens:
+                    if not value.strip():
+                        self._error("Empty string value", child_path)
+                else:
+                    self._error("Unexpected string value in syntax node", child_path)
+            else:
+                self._error(f"Unexpected value type {type(value)}", child_path)
+
+    def _validate_trivia(self, trivia: Any, path: str):
+        """Validate trivia field."""
+        if self.mode == pyslang.CSTJsonMode.NoTrivia:
+            self._error("Trivia should not be present in NoTrivia mode", path)
+            return
+
+        if self.mode == pyslang.CSTJsonMode.SimpleTrivia:
+            if not isinstance(trivia, str):
+                self._error(
+                    f"Trivia should be string in SimpleTrivia mode, got {type(trivia)}",
+                    path,
+                )
+            return
+
+        # Full mode: trivia should be a list of trivia objects
+        if self.mode == pyslang.CSTJsonMode.Full:
+            if not isinstance(trivia, list):
+                self._error(
+                    f"Trivia should be list in Full mode, got {type(trivia)}", path
+                )
+                return
+
+            for i, trivia_item in enumerate(trivia):
+                if not isinstance(trivia_item, dict):
+                    self._error(
+                        f"Trivia item should be dict, got {type(trivia_item)}",
+                        f"{path}[{i}]",
+                    )
+                    continue
+
+                if "kind" not in trivia_item:
+                    self._error("Trivia item missing 'kind'", f"{path}[{i}]")
+                    continue
+
+                kind = trivia_item["kind"]
+                if kind not in TRIVIA_KINDS:
+                    self._error(f"Unknown trivia kind '{kind}'", f"{path}[{i}]")
+
+                if "text" not in trivia_item:
+                    self._error("Trivia item missing 'text'", f"{path}[{i}]")
+                    continue
+
+                if not isinstance(trivia_item["text"], str):
+                    self._error(
+                        f"Trivia text should be string, got {type(trivia_item['text'])}",
+                        f"{path}[{i}]",
+                    )
+
+    def _validate_trivia_constraints(self, node: Dict[str, Any], path: str):
+        """Validate trivia constraints based on mode."""
+        has_trivia = "trivia" in node
+
+        if self.mode == pyslang.CSTJsonMode.NoTrivia and has_trivia:
+            self._error("Node should not have trivia in NoTrivia mode", path)
+
+        if has_trivia:
+            self._validate_trivia(node["trivia"], f"{path}.trivia")
+
+
+def test_cst_json():
+    """Test structural properties of CST JSON across different inputs"""
+    test_cases = [
+        "module simple; endmodule",
+        'module complex; initial $display("test"); endmodule',
+        "module empty; endmodule",
+        "module empty; asdf endmodule",
+    ]
+
+    for test_code in test_cases:
+        tree = pyslang.SyntaxTree.fromText(test_code)
+
+        for mode in [
+            pyslang.CSTJsonMode.Full,
+            pyslang.CSTJsonMode.SimpleTrivia,
+            pyslang.CSTJsonMode.NoTrivia,
+            pyslang.CSTJsonMode.SimpleTokens,
+        ]:
+            json_data = to_dict(tree, mode)
+
+            # Verify tree has correct root structure
+            assert "kind" in json_data, f"Tree JSON missing 'kind' for mode {mode}"
+            assert (
+                json_data["kind"] == "SyntaxTree"
+            ), f"Tree kind should be 'SyntaxTree' for mode {mode}"
+            assert "root" in json_data, f"Tree JSON missing 'root' for mode {mode}"
+
+            # Run the validator
+            validator = CSTValidator(mode)
+            is_valid = validator.validate(json_data)
+            if not is_valid:
+                errors = "\n".join(validator.get_errors())
+                raise AssertionError(
+                    f"Validation failed for {test_code} in {mode}:\n{errors}"
+                )
+
+            # Verify that the root node matches the tree's root serialization
+            assert json_data["root"] == to_dict(
+                tree.root, mode
+            ), f"Tree root does not match node serialization for {test_code} in {mode}"

--- a/scripts/reconstruct_from_json.py
+++ b/scripts/reconstruct_from_json.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python3
+"""
+Reconstructs source code from CST JSON output to verify token completeness.
+
+This script extracts all tokens (including separators from SeparatedSyntaxList
+nodes) from the CST JSON and reconstructs the original source code to verify
+that all tokens are properly captured in the JSON output.
+"""
+
+import argparse
+import json
+import sys
+
+
+def extract_tokens(node, tokens):
+    """Recursively extract all tokens from a CST node in order."""
+    if node is None:
+        return
+
+    if isinstance(node, dict):
+        # Check if this is a token node
+        if "kind" in node and "text" in node:
+            # This is a token - add its text and trivia
+            if "trivia" in node:
+                for trivia in node["trivia"]:
+                    if "text" in trivia:
+                        tokens.append(trivia["text"])
+            tokens.append(node["text"])
+        else:
+            # This is a syntax node - recurse through all properties
+            for key, value in node.items():
+                if key in ["kind"]:  # Skip metadata
+                    continue
+                extract_tokens(value, tokens)
+    elif isinstance(node, list):
+        # Array of nodes
+        for item in node:
+            extract_tokens(item, tokens)
+
+
+def reconstruct_source(json_file):
+    """Read CST JSON and reconstruct the original source code."""
+    with open(json_file, "r") as f:
+        data = json.load(f)
+
+    tokens = []
+
+    # Handle the top-level structure
+    if "syntaxTrees" in data:
+        for tree in data["syntaxTrees"]:
+            extract_tokens(tree, tokens)
+    else:
+        # Direct CST node
+        extract_tokens(data, tokens)
+
+    tokens.append("\n")  # Implicit newline
+
+    # Join all tokens to reconstruct source
+    reconstructed = "".join(tokens)
+
+    return reconstructed, len(tokens)
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Reconstruct source code from CST JSON"
+    )
+    parser.add_argument("json_file", help="CST JSON file to read")
+    parser.add_argument("--output", "-o", help="Output file (default: stdout)")
+    parser.add_argument(
+        "--compare", "-c", help="Original source file to compare against"
+    )
+    parser.add_argument(
+        "--stats", "-s", action="store_true", help="Show token statistics"
+    )
+
+    args = parser.parse_args()
+
+    try:
+        reconstructed, token_count = reconstruct_source(args.json_file)
+
+        if args.output:
+            with open(args.output, "w") as f:
+                f.write(reconstructed)
+            print(f"Reconstructed source written to {args.output}")
+        else:
+            print(reconstructed, end="")
+
+        if args.stats:
+            print("\nStatistics:", file=sys.stderr)
+            print(f"  Total tokens extracted: {token_count}", file=sys.stderr)
+            print(f"  Total characters: {len(reconstructed)}", file=sys.stderr)
+
+        if args.compare:
+            with open(args.compare, "r") as f:
+                original = f.read()
+
+            if reconstructed == original:
+                print("\n✓ Perfect match with original file!", file=sys.stderr)
+                return 0
+            else:
+                print("\n✗ Mismatch with original file:", file=sys.stderr)
+                print(f"  Original: {len(original)} chars", file=sys.stderr)
+                print(f"  Reconstructed: {len(reconstructed)} chars", file=sys.stderr)
+
+                # Show first difference
+                for i, (a, b) in enumerate(zip(original, reconstructed)):
+                    if a != b:
+                        print(
+                            f"  First difference at position {i}: '{a}' vs '{b}'",
+                            file=sys.stderr,
+                        )
+                        break
+
+                return 1
+
+        return 0
+
+    except Exception as e:
+        print(f"Error: {e}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -40,6 +40,7 @@ add_custom_command(
          ${CMAKE_CURRENT_BINARY_DIR}/SyntaxClone.cpp
          ${CMAKE_CURRENT_BINARY_DIR}/slang/syntax/SyntaxKind.h
          ${CMAKE_CURRENT_BINARY_DIR}/slang/syntax/SyntaxFwd.h
+         ${CMAKE_CURRENT_BINARY_DIR}/slang/syntax/CSTJsonVisitorGen.h
          ${CMAKE_CURRENT_BINARY_DIR}/slang/parsing/TokenKind.h
          ${CMAKE_CURRENT_BINARY_DIR}/slang/parsing/KnownSystemName.h
          ${CMAKE_CURRENT_BINARY_DIR}/TokenKind.cpp
@@ -95,6 +96,7 @@ add_library(
   parsing/Preprocessor_macros.cpp
   parsing/Preprocessor_pragmas.cpp
   parsing/Token.cpp
+  syntax/CSTSerializer.cpp
   syntax/SyntaxFacts.cpp
   syntax/SyntaxNode.cpp
   syntax/SyntaxPrinter.cpp

--- a/source/syntax/CSTSerializer.cpp
+++ b/source/syntax/CSTSerializer.cpp
@@ -44,10 +44,12 @@ struct CSTJsonVisitor {
         writer.writeProperty("kind");
         writer.writeValue(toString(node.kind));
 
-        if constexpr (requires { handle(node); })
+        if constexpr (requires { handle(node); }) {
             handle(node);
-        else
+        }
+        else {
             static_assert(always_false<T>::value, "Unhandled syntax node type in CSTJsonVisitor");
+        }
 
         writer.endObject();
     }

--- a/source/syntax/CSTSerializer.cpp
+++ b/source/syntax/CSTSerializer.cpp
@@ -1,0 +1,182 @@
+//------------------------------------------------------------------------------
+// CSTSerializer.cpp
+// Concrete Syntax Tree JSON serialization
+//
+// SPDX-FileCopyrightText: Michael Popoloski
+// SPDX-License-Identifier: MIT
+//------------------------------------------------------------------------------
+#include "slang/syntax/CSTSerializer.h"
+
+#include <string_view>
+
+#include "slang/parsing/Token.h"
+#include "slang/syntax/AllSyntax.h"
+#include "slang/syntax/SyntaxTree.h"
+#include "slang/syntax/SyntaxVisitor.h"
+#include "slang/util/Util.h"
+
+namespace slang::syntax {
+
+CSTSerializer::CSTSerializer(JsonWriter& writer, CSTJsonMode mode) : writer(writer), mode(mode) {
+}
+
+void CSTSerializer::serialize(const SyntaxTree& tree) {
+    writer.startObject();
+    writer.writeProperty("kind");
+    // Cast is needed because it will get converted to bool over string_view
+    writer.writeValue(std::string_view{"SyntaxTree"});
+    writer.writeProperty("root");
+    serialize(tree.root());
+    writer.endObject();
+}
+
+template<typename T>
+struct always_false : std::false_type {};
+struct CSTJsonVisitor {
+    JsonWriter& writer;
+    CSTJsonMode mode;
+
+    CSTJsonVisitor(JsonWriter& w, CSTJsonMode m) : writer(w), mode(m) {}
+
+    template<std::derived_from<SyntaxNode> T>
+    void visit(const T& node) {
+        writer.startObject();
+        writer.writeProperty("kind");
+        writer.writeValue(toString(node.kind));
+
+        if constexpr (requires { handle(node); })
+            handle(node);
+        else
+            static_assert(always_false<T>::value, "Unhandled syntax node type in CSTJsonVisitor");
+
+        writer.endObject();
+    }
+
+    // The child class's handlers should be called
+    void handle(const SyntaxListBase&) { SLANG_UNREACHABLE; }
+
+    // These are never actually constructed; SyntaxKind::Unknown would be of another class in this
+    // visitor
+    void handle(const detail::InvalidSyntaxNode&) { SLANG_UNREACHABLE; }
+
+    void writeToken(std::string_view name, parsing::Token token) {
+        if (token.valueText().empty()) {
+            return;
+        }
+        writer.writeProperty(name);
+        writeTokenValue(token);
+    }
+
+    void writeNode(std::string_view name, not_null<const SyntaxNode*> node) {
+        writer.writeProperty(name);
+        node->visit(*this);
+    }
+
+    void writeOptionalNode(std::string_view name, const SyntaxNode* node) {
+        if (node) {
+            writer.writeProperty(name);
+            node->visit(*this);
+        }
+    }
+
+    void writeTokenList(std::string_view name, const TokenList& tokenList) {
+        if (tokenList.empty()) {
+            return;
+        }
+        writer.writeProperty(name);
+        writer.startArray();
+        for (auto token : tokenList) {
+            writeTokenValue(token);
+        }
+        writer.endArray();
+    }
+
+    template<typename T>
+    void writeSyntaxList(std::string_view name, const SyntaxList<T>& syntaxList) {
+        if (syntaxList.empty()) {
+            return;
+        }
+        writer.writeProperty(name);
+        writer.startArray();
+        for (auto item : syntaxList) {
+            item->visit(*this);
+        }
+        writer.endArray();
+    }
+
+    template<typename T>
+    void writeSeparatedSyntaxList(std::string_view name,
+                                  const SeparatedSyntaxList<T>& separatedList) {
+        if (separatedList.empty()) {
+            return;
+        }
+        writer.writeProperty(name);
+        writer.startArray();
+        // SeparatedSyntaxList stores elements and separators alternately
+        for (size_t i = 0; i < separatedList.getChildCount(); i++) {
+            auto child = separatedList.childNode(i);
+            if (child) {
+                child->visit(*this);
+            }
+            else {
+                auto token = separatedList.childToken(i);
+                if (token) {
+                    writeTokenValue(token);
+                }
+            }
+        }
+        writer.endArray();
+    }
+
+    void writeTokenValue(parsing::Token token) {
+        // If simple-tokens mode, just write the text value
+        if (mode == CSTJsonMode::SimpleTokens) {
+            writer.writeValue(token.rawText());
+            return;
+        }
+
+        writer.startObject();
+        writer.writeProperty("kind");
+        writer.writeValue(toString(token.kind));
+        writer.writeProperty("text");
+        writer.writeValue(token.rawText());
+
+        // Handle trivia based on mode
+        if (mode != CSTJsonMode::NoTrivia && !token.trivia().empty()) {
+            writer.writeProperty("trivia");
+            if (mode == CSTJsonMode::SimpleTrivia) {
+                // Just write the concatenated trivia text
+                std::string triviaText;
+                for (auto trivia : token.trivia()) {
+                    triviaText += trivia.getRawText();
+                }
+                writer.writeValue(triviaText);
+            }
+            else {
+                // Write trivia kind and value
+                writer.startArray();
+                for (auto trivia : token.trivia()) {
+                    writer.startObject();
+                    writer.writeProperty("kind");
+                    writer.writeValue(toString(trivia.kind));
+                    writer.writeProperty("text");
+                    writer.writeValue(trivia.getRawText());
+                    writer.endObject();
+                }
+                writer.endArray();
+            }
+        }
+
+        writer.endObject();
+    }
+
+// Generated handle() methods for each syntax kind
+#include "slang/syntax/CSTJsonVisitorGen.h"
+};
+
+void CSTSerializer::serialize(const SyntaxNode& node) {
+    CSTJsonVisitor visitor(writer, mode);
+    node.visit(visitor);
+}
+
+} // namespace slang::syntax

--- a/source/util/CommandLine.cpp
+++ b/source/util/CommandLine.cpp
@@ -14,7 +14,6 @@
 #include "slang/text/CharInfo.h"
 #include "slang/util/OS.h"
 #include "slang/util/SmallVector.h"
-#include "slang/util/String.h"
 
 namespace fs = std::filesystem;
 
@@ -904,6 +903,18 @@ std::string CommandLine::addRenameCommand(std::string_view value) {
     value = value.substr(0, firstCommaIndex);
     cmdRename[std::string(value)] = slangName;
     return {};
+}
+
+std::string CommandLine::toKebabCase(std::string_view str) {
+    std::string result;
+    for (size_t i = 0; i < str.size(); ++i) {
+        char c = str[i];
+        if (i > 0 && std::isupper(c)) {
+            result += '-';
+        }
+        result += charToLower(c);
+    }
+    return result;
 }
 
 } // namespace slang

--- a/tests/regression/CMakeLists.txt
+++ b/tests/regression/CMakeLists.txt
@@ -11,6 +11,23 @@ add_test(NAME regression_all_file
          COMMAND slang::driver "${CMAKE_CURRENT_LIST_DIR}/all.sv"
                  "--ast-json=-" "--ast-json-detailed-types")
 
+# CST JSON round trip test
+add_test(
+  NAME regression_cst_json_roundtrip
+  COMMAND
+    ${Python_EXECUTABLE} ${CMAKE_SOURCE_DIR}/scripts/reconstruct_from_json.py
+    ${CMAKE_CURRENT_BINARY_DIR}/all_cst.json --compare
+    ${CMAKE_CURRENT_LIST_DIR}/all.sv)
+
+# Generate the CST JSON file as a prerequisite
+add_test(
+  NAME regression_cst_json_gen
+  COMMAND slang::driver --cst-json ${CMAKE_CURRENT_BINARY_DIR}/all_cst.json
+          ${CMAKE_CURRENT_LIST_DIR}/all.sv)
+
+set_tests_properties(regression_cst_json_roundtrip
+                     PROPERTIES DEPENDS regression_cst_json_gen)
+
 if(SLANG_INCLUDE_UVM_TEST)
   FetchContent_Declare(
     uvm

--- a/tests/unittests/util/CommandLineTests.cpp
+++ b/tests/unittests/util/CommandLineTests.cpp
@@ -626,3 +626,19 @@ TEST_CASE("Test CommandLine -- enum options with short name") {
     CHECK(cmdLine.parse("prog --mode slow"));
     CHECK(mode == TestMode::Slow);
 }
+
+TEST_CASE("Test CommandLine -- enum options invalid value with valid prefix") {
+    // Test invalid value that has a valid prefix
+    {
+        std::optional<TestMode> mode;
+        CommandLine cmdLine;
+        cmdLine.addEnum<TestMode, TestMode_traits>("--mode", mode, "Test mode");
+
+        CHECK(!cmdLine.parse("prog --mode fast-invalid"));
+        auto errors = cmdLine.getErrors();
+        REQUIRE(errors.size() == 1);
+        CHECK(errors[0] ==
+              "prog: invalid value 'fast-invalid', valid options are: 'fast', 'normal', "
+              "'slow', 'very-detailed-mode'");
+    }
+}

--- a/tests/unittests/util/CommandLineTests.cpp
+++ b/tests/unittests/util/CommandLineTests.cpp
@@ -6,30 +6,11 @@
 #include "slang/text/SourceManager.h"
 #include "slang/util/CommandLine.h"
 
-// Test enum for enum command line option testing
-enum class TestMode { Fast, Normal, Slow, VeryDetailedMode };
-static std::string_view toString(TestMode mode) {
-    switch (mode) {
-        case TestMode::Fast:
-            return "Fast";
-        case TestMode::Normal:
-            return "Normal";
-        case TestMode::Slow:
-            return "Slow";
-        case TestMode::VeryDetailedMode:
-            return "VeryDetailedMode";
-    }
-    return "";
-}
+// Test enum for enum command line option testing using SLANG_ENUM
+#define TM(x) x(Fast) x(Normal) x(Slow) x(VeryDetailedMode)
 
-class TestMode_traits {
-public:
-    static const std::array<TestMode, 4> values;
-};
-
-const std::array<TestMode, 4> TestMode_traits::values = {TestMode::Fast, TestMode::Normal,
-                                                         TestMode::Slow,
-                                                         TestMode::VeryDetailedMode};
+SLANG_ENUM(TestMode, TM)
+#undef TM
 
 TEST_CASE("Test CommandLine -- basic") {
     std::optional<bool> a, b, longFlag, longFlag2;


### PR DESCRIPTION
Round trip verified with `build/bin/slang tests/regression/all.sv --cst-json all.json` then `python scripts/reconstruct_from_json.py all.json --compare tests/regression/all.sv`

- Addresses https://github.com/MikePopoloski/slang/issues/1321
- Added flags for different levels of verbosity with the cst output, defaulting to most verbose.
- Also added cmdline addEnum function for adding slang enums to arg parsers