### PR TITLE
Fix compilation corrupting parent pointers for type params passed to insts

### DIFF
--- a/include/slang/syntax/SyntaxVisitor.h
+++ b/include/slang/syntax/SyntaxVisitor.h
@@ -83,7 +83,9 @@ auto makeSyntaxVisitor(Functions... funcs) {
     return Result(std::move(funcs)...);
 }
 
-/// Simple visitors with kinds that are left to the user to evaluate.
+/// @brief Simple visitors with kinds that are left to the user to evaluate.
+/// This is preferable over makeSyntaxVisitor([](auto, auto){...}), as the compile time cost is
+/// lower, and the compiler errors are better.
 struct AllSyntaxVisitor {
     AllSyntaxVisitor(std::function<void(const SyntaxNode&)> func) : handler(std::move(func)) {}
 
@@ -99,22 +101,6 @@ struct AllSyntaxVisitor {
 private:
     std::function<void(const SyntaxNode&)> handler;
 };
-
-/// @brief Creates a SyntaxVisitor with the provided handler function.
-///
-/// @param func The handler function to called during the preorder traversal of the syntax tree.
-///
-/// For example:
-/// @code
-/// auto visitor = makeSyntaxVisitor([&](const SyntaxNode& node) {
-///     std::cout << node.kind << std::endl;
-/// });
-/// visitor.visit(tree.root());
-/// @endcode
-///
-inline AllSyntaxVisitor makeAllSyntaxVisitor(std::function<void(const SyntaxNode&)> func) {
-    return AllSyntaxVisitor(std::move(func));
-}
 
 namespace detail {
 

--- a/include/slang/syntax/SyntaxVisitor.h
+++ b/include/slang/syntax/SyntaxVisitor.h
@@ -7,9 +7,11 @@
 //------------------------------------------------------------------------------
 #pragma once
 
+#include <functional>
 #include <vector>
 
 #include "slang/syntax/AllSyntax.h"
+#include "slang/syntax/SyntaxNode.h"
 #include "slang/syntax/SyntaxTree.h"
 #include "slang/util/FlatMap.h"
 #include "slang/util/TypeTraits.h"
@@ -37,8 +39,7 @@ public:
 
     /// The default handler invoked when no visit() method is overridden for a particular type.
     /// Will visit all child nodes by default.
-    template<typename T>
-    void visitDefault(const T& node) {
+    void visitDefault(const SyntaxNode& node) {
         for (uint32_t i = 0; i < node.getChildCount(); i++) {
             auto child = node.childNode(i);
             if (child)
@@ -80,6 +81,39 @@ auto makeSyntaxVisitor(Functions... funcs) {
         using Functions::operator()...;
     };
     return Result(std::move(funcs)...);
+}
+
+/// Simple visitors with kinds that are left to the user to evaluate.
+struct AllSyntaxVisitor {
+    AllSyntaxVisitor(std::function<void(const SyntaxNode&)> func) : handler(std::move(func)) {}
+
+    void visit(const SyntaxNode& node) {
+        handler(node);
+        for (uint32_t i = 0; i < node.getChildCount(); i++) {
+            auto child = node.childNode(i);
+            if (child)
+                visit(*child);
+        }
+    }
+
+private:
+    std::function<void(const SyntaxNode&)> handler;
+};
+
+/// @brief Creates a SyntaxVisitor with the provided handler function.
+///
+/// @param func The handler function to called during the preorder traversal of the syntax tree.
+///
+/// For example:
+/// @code
+/// auto visitor = makeSyntaxVisitor([&](const SyntaxNode& node) {
+///     std::cout << node.kind << std::endl;
+/// });
+/// visitor.visit(tree.root());
+/// @endcode
+///
+inline AllSyntaxVisitor makeAllSyntaxVisitor(std::function<void(const SyntaxNode&)> func) {
+    return AllSyntaxVisitor(std::move(func));
 }
 
 namespace detail {

--- a/source/ast/symbols/ParameterBuilder.cpp
+++ b/source/ast/symbols/ParameterBuilder.cpp
@@ -182,10 +182,8 @@ const ParameterSymbolBase& ParameterBuilder::createParam(
             // a type parameter, so fix it up into a NamedTypeSyntax to get a type from it.
             tt.addFlags(DeclaredTypeFlags::TypeOverridden);
             if (NameSyntax::isKind(newInitializer->kind)) {
-                // const_cast is ugly but safe here, we're only going to refer to it
-                // by const reference everywhere down.
-                auto& nameSyntax = const_cast<NameSyntax&>(newInitializer->as<NameSyntax>());
-                auto namedType = comp.emplace<NamedTypeSyntax>(nameSyntax);
+                auto nameSyntax = deepClone(newInitializer->as<NameSyntax>(), comp);
+                auto namedType = comp.emplace<NamedTypeSyntax>(*nameSyntax);
 
                 tt.setTypeSyntax(*namedType);
             }

--- a/tests/regression/all.sv
+++ b/tests/regression/all.sv
@@ -4,7 +4,7 @@ timeprecision 1ps;
 (* foo = 1 *) package static p;
     timeunit 1ns;
     parameter int x = 1;
-    parameter type y = logic[x:0];
+    parameter type y_t = logic[x:0];
     program; endprogram
     export *::*;
 endpackage
@@ -15,7 +15,11 @@ module automatic m1 import p::*; #(int i = 1)
     output [1:0] b;
 endmodule
 
-module m2 #(parameter i = 1, localparam j = i)
+module m2 #(
+    parameter i = 1,
+    localparam j = i,
+    parameter type x_t = bit
+)
     (input int a[], (* bar = "asdf" *) output logic b = 1, ref c,
      interface.mod d, .e());
 endmodule
@@ -32,7 +36,13 @@ macromodule m3;
     wire b;
     logic c;
     I d(.a(), .b());
-    m2 m(, b, c, d, );
+
+    typedef p::y_t y_t;
+
+    m2 #(
+        .x_t(y_t)
+    ) m (, b, c, d, );
+
 
     $info("Hello %s", "world");
 

--- a/tests/unittests/parsing/VisitorTests.cpp
+++ b/tests/unittests/parsing/VisitorTests.cpp
@@ -2,12 +2,15 @@
 // SPDX-License-Identifier: MIT
 
 #include "Test.h"
+#include "catch2/catch_test_macros.hpp"
 #include <fmt/core.h>
 
 #include "slang/analysis/AnalysisManager.h"
 #include "slang/ast/ASTVisitor.h"
 #include "slang/parsing/ParserMetadata.h"
+#include "slang/syntax/SyntaxNode.h"
 #include "slang/syntax/SyntaxPrinter.h"
+#include "slang/syntax/SyntaxTree.h"
 #include "slang/syntax/SyntaxVisitor.h"
 
 class SemanticModel {
@@ -733,6 +736,65 @@ class C; endclass
         }
     }
 }
+TEST_CASE("SyntaxTree/Compilation Invariant Checking") {
+
+    // Validates that the parent pointers in the syntax tree are correct, and provides debug info if
+    // not
+    auto validateParents = [](const syntax::SyntaxTree& tree) {
+        bool valid = true;
+        tree.root().visit(makeAllSyntaxVisitor([&](const SyntaxNode& node) {
+            if (node.kind == SyntaxKind::SyntaxList || node.kind == SyntaxKind::SeparatedList) {
+                return;
+            }
+            for (size_t i = 0; i < node.getChildCount(); i++) {
+                auto child = node.childNode(i);
+                if (!child)
+                    continue;
+                if (child->parent != &node) {
+                    valid = false;
+                    auto parentKind = toString(child->parent->kind);
+                    auto childKind = toString(child->kind);
+                    auto expectedParent = toString(node.kind);
+                    fmt::print("Parent pointer mismatch with `{}`. {}.parent should be {}, "
+                               "but is instead {}\n",
+                               node.toString(), childKind, expectedParent,
+                               !parentKind.empty() ? parentKind : "<garbage memory>");
+
+                    if (!parentKind.empty()) {
+                        fmt::print("Check for `comp.emplace<{}Syntax>` calls, and deep "
+                                   "clone the syntax nodes used to create it.",
+                                   parentKind);
+                    }
+                }
+            }
+        }));
+
+        return valid;
+    };
+
+    fs::path path = findTestDir();
+    path /= "../../regression/all.sv";
+    auto mTree = SyntaxTree::fromFile(path.string());
+    REQUIRE(mTree);
+    auto tree = *mTree;
+
+    REQUIRE(validateParents(*tree));
+
+    // Store the printed text
+    std::string originalSyntaxText = SyntaxPrinter::printFile(*tree);
+
+    // Compile
+    Compilation compilation;
+    compilation.addSyntaxTree(tree);
+    auto& _root = compilation.getRoot();
+
+    // Check parent pointers after compilation
+    REQUIRE(validateParents(*tree));
+
+    // Check the text as well
+    std::string syntaxTextAfterCompilation = SyntaxPrinter::printFile(*tree);
+    REQUIRE(originalSyntaxText == syntaxTextAfterCompilation);
+}
 
 TEST_CASE("Visit all file") {
     // Load a file containing all the SystemVerilog constructs and visit them
@@ -781,7 +843,7 @@ TEST_CASE("Visit all file") {
     // printMissing("statement", ast::StatementKind_traits::values, symbols.stmtKinds);
 
     // Ideally this should visit all kinds (be zero)
-    CHECK(219 == syntax::SyntaxKind_traits::values.size() - syntaxKinds.size());
+    CHECK(218 == syntax::SyntaxKind_traits::values.size() - syntaxKinds.size());
 
     CHECK(42 == ast::SymbolKind_traits::values.size() - symKinds.size());
     CHECK(11 == ast::ExpressionKind_traits::values.size() - exprKinds.size());


### PR DESCRIPTION
The compilation flow sometimes makes new syntax nodes; if any children are also syntax nodes, this repoints the parent pointers at the compilation alloced one, which is bad. This is fixed for this one case by deep cloning the child, but there may be more cases.

- Adds visitor test for all.sv to validate those parent pointers
- Removes template from syntax visitor's visitDefault(), which increased build time, and on some clang builds also increases binary size.
- Adds makeSyntaxVisitor impls for simple single method handlers