### PR TITLE
[slang] Fix eval script session segmentation fault

### DIFF
--- a/source/ast/ScriptSession.cpp
+++ b/source/ast/ScriptSession.cpp
@@ -35,7 +35,12 @@ ScriptSession::ScriptSession(Bag options) :
 }
 
 ConstantValue ScriptSession::eval(std::string_view text) {
-    syntaxTrees.emplace_back(SyntaxTree::fromText(text, options));
+    const auto& syntax = SyntaxTree::fromText(text, options);
+    for (auto& diag : syntax->diagnostics()) {
+        if (diag.isError())
+            return nullptr;
+    }
+    syntaxTrees.emplace_back(syntax);
 
     const auto& node = syntaxTrees.back()->root();
     switch (node.kind) {

--- a/tests/unittests/ast/EvalTests.cpp
+++ b/tests/unittests/ast/EvalTests.cpp
@@ -2645,3 +2645,8 @@ endpackage)");
 
     NO_SESSION_ERRORS;
 }
+
+TEST_CASE("Eval bad statement") {
+    ScriptSession session;
+    CHECK(!session.eval("fork=L:for"));
+}


### PR DESCRIPTION
This bug was founded using `slang` with this command line:

```
slang "-GA=fork=L:for" ../top.sv
```

It's not depends on content of `.sv` file. It is related to the fact that syntax trees in `SciptSession` are not validated before ast building at the moment.

I provide a fix for this but idk is it needs to show diagnostics from syntax parser in `ScriptSession` or not?