### PR TITLE
[slang] Remove redundant assertion

### DIFF
--- a/source/ast/symbols/PortSymbols.cpp
+++ b/source/ast/symbols/PortSymbols.cpp
@@ -1478,7 +1478,6 @@ void PortSymbol::fromSyntax(
 
     switch (syntax.kind) {
         case SyntaxKind::AnsiPortList: {
-            SLANG_ASSERT(portDeclarations.empty());
             AnsiPortListBuilder builder{scope, implicitMembers};
             for (auto port : syntax.as<AnsiPortListSyntax>().ports) {
                 switch (port->kind) {


### PR DESCRIPTION
For this syntactically incorrect code `slang` `gcc-debug-shared` build fails with assertion:

```verilog
module t(input pppppputputtttttpppppp( int y);

wire [0:1-+3] alk,rr[3% 9];
nput clk3, oput itput int y); inp#t clk2,nt y);

wi
(input �lk, i.put clk] arr[0:29];
```

assertion:

```
internal compiler error: Assertion 'portDeclarations.empty()' failed
  in file /home/projects/slang/source/ast/symbols/PortSymbols.cpp, line 1476
  function: static void slang::ast::PortSymbol::fromSyntax(const slang::syntax::PortListSyntax&, const slang::ast::Scope&, slang::SmallVectorBase<const slang::ast::Symbol*>&, slang::SmallVectorBase<std::pair<slang::ast::Symbol*, const slang::ast::Symbol*> >&, std::span<const std::pair<const slang::syntax::SyntaxNode*, const slang::ast::Symbol*> >)
``

I removed this assertion because I suppose it is redundant in this `switch-case` branch it is not used directly. May be it is needs to be replaced with compiler warning or error but idk.