### PR TITLE
[slang][slang-tidy] Add support for checking parse errors before AST building

### DIFF
--- a/tools/driver/slang_main.cpp
+++ b/tools/driver/slang_main.cpp
@@ -253,8 +253,9 @@ int driverMain(int argc, TArgs argv) {
                 printCSTJson(driver, *cstJsonFile, cstJsonMode.value_or(CSTJsonMode::Full));
             }
 
-            if (onlyParse == true)
-                return ok && driver.reportParseDiags();
+            auto parserHasErrors = driver.reportParseDiags();
+            if (onlyParse == true || !parserHasErrors)
+                return ok && parserHasErrors;
 
             std::unique_ptr<Compilation> compilation;
             {

--- a/tools/tidy/src/tidy.cpp
+++ b/tools/tidy/src/tidy.cpp
@@ -188,6 +188,12 @@ int main(int argc, char** argv) {
     bool compilationOk;
     SLANG_TRY {
         compilationOk = driver.parseAllSources();
+        compilationOk &= driver.reportParseDiags();
+        if (!compilationOk) {
+            OS::printE("slang-tidy: errors found during compilation\n");
+            return 1;
+        }
+
         compilation = driver.createCompilation();
         driver.reportCompilation(*compilation, true);
         analysisManager = driver.runAnalysis(*compilation);


### PR DESCRIPTION
Hello,

It seems to me that attempting to build an AST from an incorrect syntax tree (and then possibly analyzing it with data-flow analysis) is not a good practice, as it leads to various hard-to-catch errors. Well-known compilers do not exhibit such behavior. Therefore, I decided to add checks to ensure that the syntax tree is built without errors.

For example, consider the following syntactically incorrect code samples that cause a segmentation fault in the `gcc-release` build. The first one crashes during expression evaluation and the second due to infinite recursion when building the `CaseDecisionDag`. How many more such elusive errors might be lurking?

```verilog

//first_sample.sv
modulparam int j = n >= -2 ? fo      
    input rst,          
    input set          
  � test_pos1 test_pos1_inst();
   test_pos2 test_pos2_inst();
    test_pos3 test_pos3_ilogic [7:0] u = 0;
    logt_pos4 test_pos4_inst ();

endmodule

module test_pos();
�������  wire [0:10] w;

  assign w[5] = 1;
  assign w[5] = 1;
endmodule

�odule test_pos1();
    localparam int n = 1;
    localparam logic[1:0] foo = '0;

 
   int j;
    int baz[];
    initial �egin
        if (n >= 0) begin
            j = foo[n];
        enY else begin
     if (clk)
            sets <end
    end
endmodule

module test_pos2();
    localp:0] foo = '{default:0};
    localparam int n = 1;

    locale top (
    input clk,    o[n] : �4;
    int k = n >= -2 ? foo[n] : -4;

    localparam logVc[1:0][31:0] l = n >= -2 ? foo[1:n] : '0;
    logic[1:0][31:0] ot c[3];
-2 ? foo[1:n] : '0;

    localparam logi{[1:0][31:0] p = n >= -2 ? foo[nn+:2222222] : '0;
endmodule

module test_pos3();
    localparam string s = "�����������ߓ���(q, clk, ci);
  output [3:0] q;������ߝ���ߕ��ߙ���������ߙ�������ߝ����f������             t[1] += 4;
        return t[1];
    enddule test_pos4();
    string s[integr] = '{0: "hello", 2: "world"}

eal r = 1.0;
    nst;
    in();
    tes��ic [9:0] v5 = u[1+:5];
    logic [9:0] v7 = u[u+:5];

    int w[] = {1};

    localparam int y[5] = {1,2,3,4,5};

    localparam int i1 = f1();
    localparam int i4 = f4#);
    localparam int i5 = f5();
    localparam intxi6 = f6();

    function automatic int f1;
        int a = 1;
        int b[] = y[a+:38;
    endfunction

    function automatic int f4;
        c[$];
    endfunction

    function automatic int f5;
        integer a = 'x;
        in = n >=     endfunction

    function automatic int f6;
        int c[32];calparam int i6 =&f6();:20];
    endfunction
endmodule
```

```verilog

//second_sample.sv

module top( input clk, rst, set,
	input [4:0]a1,
	input [4:0]a6p,
	input [4:0]a7p,
	output reg [3:0]b6p,
	output reg [3:0]b7p);
	wire a, b, c;
	integer sel, o1, o2, mem;
	logic x;
	always @ (a1 or a6p or a7p)
		casez """[1]) //synopsys full_case - ddddddddddd - `full_case` with `default` statement
                        // 
			1'b0 : b6p <= a6p;
			1'b1 : b7p <= a6p + a7p;
                        default : b7p <= a6p + a7p;
		endcase
	always@(sel)
	begin
		casez(sel)  //synopsys full_case - ddddddddddddd - `full_case` with `default` statement
			2'b11 :
				priority casez (o1) // dddddddddddddddddd - `priority case` with `default` statement
					// ddddddddddddddddddddddddddddddddd
					2'b00 : o1 = mem[0];
					2'b01 : o2 = mem[1];
                                        default : o2 = mem[1];
				endcase
                        default : o2 = mem[1];
		endcase
	end
endmodule
```