### PR TITLE
[slang-tidy] Fix EnforcePortSuffix checker assertion related to empty port name

### DIFF
--- a/tools/tidy/src/style/EnforcePortSuffix.cpp
+++ b/tools/tidy/src/style/EnforcePortSuffix.cpp
@@ -39,7 +39,8 @@ struct MainVisitor : public TidyVisitor, ASTVisitor<MainVisitor, true, false, fa
             matched |= port.name.ends_with(suffix);
         }
         if (!matched) {
-            auto& diag = diags.add(diag::EnforcePortSuffix, port.location) << port.name;
+            std::string_view portName = !port.name.empty() ? port.name : "<unnamed>";
+            auto& diag = diags.add(diag::EnforcePortSuffix, port.location) << portName;
             if (suffixes->size() == 1) {
                 diag << fmt::format("\"{}\"", suffixes->front());
             }

--- a/tools/tidy/tests/EnforcePortSuffixTest.cpp
+++ b/tools/tidy/tests/EnforcePortSuffixTest.cpp
@@ -138,3 +138,14 @@ endmodule
 )");
     CHECK_FALSE(result);
 }
+
+TEST_CASE("EnforcePortSuffix: Implicit port name") {
+    auto result = runCheckTest("EnforcePortSuffix", R"(
+module top (
+  i[31:0]
+);
+    output var [31:0] i;
+endmodule
+)");
+    CHECK_FALSE(result);
+}


### PR DESCRIPTION
Using `gcc-debug-shared` build this checker may fail with an assertion:

```
  Assertion '!arg.empty()' failed
    in file /home/projects/github/slang/source/diagnostics/Diagnostics.cpp,
```