### PR TITLE
disable MSAN instrumentation for SmallVector destructor

### DIFF
--- a/include/slang/util/SmallVector.h
+++ b/include/slang/util/SmallVector.h
@@ -636,6 +636,18 @@ public:
         }
     }
 
+#if defined(__has_feature)
+#    if __has_feature(memory_sanitizer)
+    // Elide msan check for SmallVector destructor.
+    //
+    // There is an issue with the destruction order: SmallVector frees the
+    // underlying storage (stackBase) and then cleanup accesses data in that
+    // region but MSAN has poisoned it already.
+
+    __attribute__((no_sanitize("memory"))) ~SmallVector() {}
+#    endif
+#endif
+
     /// Copy assignment from another vector.
     SmallVector& operator=(const Base& rhs) {
         Base::operator=(rhs);


### PR DESCRIPTION
Because of the destruction order when handling small vectors, MSAN is throwing a `use-of-uninitialized-value` error. The best explantation we came up with is that:
- first `SmallVector` releases the stackBase memory
- MSAN poisons the freed memory
- the `SmallVectorBase` destructor calls cleanup, which does a check for `isSmall()` which accesses the poisoned memory locations.

This "fix" essentially creates an explicit destructor for SmallVector which is annotated to disable MSAN checks because we are quite confident that the underlying memory released is still available for the cleanup check.