### PR TITLE
[slang-tidy] Add missed config set for printing enabled checks

### DIFF
--- a/tools/tidy/src/tidy.cpp
+++ b/tools/tidy/src/tidy.cpp
@@ -174,6 +174,7 @@ int main(int argc, char** argv) {
 
     // Print the configuration file for the currently enabled checks.
     if (dumpConfig) {
+        Registry::setConfig(tidyConfig);
         OS::print(TidyConfigPrinter::dumpConfig(tidyConfig).str());
         return 0;
     }


### PR DESCRIPTION
`dumpConfig` traverses the enabled checks before applying the configuration file which leads to printing all registered checks instead of enabled