### PR TITLE
[slang] Fix number parser segmentation fault

### DIFF
--- a/include/slang/parsing/NumberParser.h
+++ b/include/slang/parsing/NumberParser.h
@@ -91,10 +91,16 @@ public:
         Token next = first;
         firstLocation = first.location();
 
+        // To restore previously matched number parsing status
+        // due to the fact that it may be rewrited due to recursion in `consume` and `peek` lexer
+        // methods.
+        bool validSaved;
         do {
             count++;
             int index = append(next, count == 1);
+            validSaved = valid;
             stream.consume();
+            valid = validSaved;
 
             if (index >= 0) {
                 // This handles a really obnoxious case: 'h 3e+2
@@ -114,7 +120,9 @@ public:
                     break;
             }
 
+            validSaved = valid;
             next = stream.peek();
+            valid = validSaved;
         } while (syntax::SyntaxFacts::isPossibleVectorDigit(next.kind) && next.trivia().empty());
 
         return IntResult::vector(sizeToken, baseToken, finishValue(first, count == 1, isNegated));


### PR DESCRIPTION
Hello, `slang` number parser segfaults on this example:

```verilog
`pragma D's 11111111111111111110's 1.`pragma I's
```

Which happens due to this [code](https://github.com/MikePopoloski/slang/blob/master/include/slang/parsing/NumberParser.h#L117) in which `peek` can rewrite the value of `valid` value from `false` to `true` in nested calls to `numberParser` method which leads to avoiding of next number parser error handling process.

I don't know should I to add a test for this and which test category should I choose for this