### PR TITLE
Fix unittests when slang is vendored

### DIFF
--- a/tests/regression/CMakeLists.txt
+++ b/tests/regression/CMakeLists.txt
@@ -15,7 +15,7 @@ add_test(NAME regression_all_file
 add_test(
   NAME regression_cst_json_roundtrip
   COMMAND
-    ${Python_EXECUTABLE} ${CMAKE_SOURCE_DIR}/scripts/reconstruct_from_json.py
+    ${Python_EXECUTABLE} ${PROJECT_SOURCE_DIR}/scripts/reconstruct_from_json.py
     ${CMAKE_CURRENT_BINARY_DIR}/all_cst.json --compare
     ${CMAKE_CURRENT_LIST_DIR}/all.sv)
 

--- a/tests/unittests/CMakeLists.txt
+++ b/tests/unittests/CMakeLists.txt
@@ -67,12 +67,17 @@ if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
   target_link_options(unittests PUBLIC "-Wno-stringop-overflow")
 endif()
 
-# Copy the data directory for running tests from the build folder.
+# Copy the data directory for running tests from the build folder# and build the
+# tests with a reference to that folder.
+
+set(TEST_DATA_DEST "${CMAKE_CURRENT_BINARY_DIR}/data")
+
 add_custom_command(
   TARGET unittests
   POST_BUILD
   COMMAND ${CMAKE_COMMAND} -E copy_directory ${CMAKE_CURRENT_SOURCE_DIR}/data
-          ${CMAKE_CURRENT_BINARY_DIR}/data)
+          ${TEST_DATA_DEST})
+
 add_custom_command(
   TARGET unittests
   POST_BUILD
@@ -82,4 +87,8 @@ add_custom_command(
     ${CMAKE_CURRENT_BINARY_DIR}/../regression)
 
 add_test(NAME unittests COMMAND unittests)
+
+target_compile_definitions(unittests
+                           PRIVATE "TEST_DATA_DIR=\"${TEST_DATA_DEST}/\"")
+
 set_tests_properties(unittests PROPERTIES TIMEOUT 60)

--- a/tests/unittests/Test.cpp
+++ b/tests/unittests/Test.cpp
@@ -11,14 +11,12 @@
 #include "slang/parsing/Preprocessor.h"
 #include "slang/text/SourceManager.h"
 
-static std::string findTestDirInternal() {
-    auto path = fs::current_path();
-    while (!fs::exists(path / "tests")) {
-        path = path.parent_path();
-        SLANG_ASSERT(!path.empty());
-    }
+#ifndef TEST_DATA_DIR
+#    error "TEST_DATA_DIR is not defined. Please configure with CMake."
+#endif
 
-    return (path / "tests/unittests/data/").string();
+static std::string findTestDirInternal() {
+    return TEST_DATA_DIR;
 }
 
 std::string findTestDir() {

--- a/tools/tidy/tests/CMakeLists.txt
+++ b/tools/tidy/tests/CMakeLists.txt
@@ -35,6 +35,9 @@ target_link_libraries(tidy_unittests PRIVATE Catch2::Catch2 slang_tidy_obj_lib)
 target_compile_definitions(tidy_unittests PRIVATE UNITTESTS)
 target_include_directories(tidy_unittests PRIVATE ../../../tests/unittests)
 
+target_compile_definitions(tidy_unittests
+                           PRIVATE "TEST_DATA_DIR=\"${TEST_DATA_DEST}/\"")
+
 add_test(NAME tidy_unittests COMMAND tidy_unittests)
 
 if(CMAKE_SYSTEM_NAME MATCHES "Windows")


### PR DESCRIPTION
This allows repos that vendor slang to also run it's `unittests` target from their build system, rather than making a separate build/ in external/slang. It also cleans up the logic for finding the test data dir.