### PR TITLE
Split out text output functionality from Driver

### DIFF
--- a/include/slang/diagnostics/DiagnosticClient.h
+++ b/include/slang/diagnostics/DiagnosticClient.h
@@ -25,6 +25,9 @@ public:
     /// Called when a diagnostic is issued by the engine.
     virtual void report(const ReportedDiagnostic& diagnostic) = 0;
 
+    /// Called to report a simple message with a given severity.
+    virtual void reportMessage(DiagnosticSeverity severity, const std::string& message) = 0;
+
     /// Sets the engine that this client is associated with.
     /// This is called by the engine when the client is added to it.
     void setEngine(const DiagnosticEngine& engine);

--- a/include/slang/diagnostics/DiagnosticEngine.h
+++ b/include/slang/diagnostics/DiagnosticEngine.h
@@ -69,6 +69,9 @@ public:
     /// be filtered or remapped based on current settings.
     void issue(const Diagnostic& diagnostic);
 
+    /// Reports a simple message with the given severity to all registered clients.
+    void issueMessage(DiagnosticSeverity severity, const std::string& message);
+
     /// Gets the source manager associated with the engine.
     const SourceManager& getSourceManager() const { return sourceManager; }
 

--- a/include/slang/diagnostics/JsonDiagnosticClient.h
+++ b/include/slang/diagnostics/JsonDiagnosticClient.h
@@ -20,6 +20,7 @@ public:
     JsonDiagnosticClient(JsonWriter& writer) : writer(writer) {}
 
     void report(const ReportedDiagnostic& diagnostic) override;
+    void reportMessage(DiagnosticSeverity severity, const std::string& message) override;
 
 private:
     JsonWriter& writer;

--- a/include/slang/diagnostics/TextDiagnosticClient.h
+++ b/include/slang/diagnostics/TextDiagnosticClient.h
@@ -45,6 +45,7 @@ public:
     fmt::terminal_color getSeverityColor(DiagnosticSeverity severity) const;
 
     void report(const ReportedDiagnostic& diagnostic) override;
+    void reportMessage(DiagnosticSeverity severity, const std::string& message) override;
 
     void clear();
     std::string getString() const;

--- a/include/slang/driver/Driver.h
+++ b/include/slang/driver/Driver.h
@@ -1,62 +1,27 @@
 //------------------------------------------------------------------------------
 //! @file Driver.h
-//! @brief Top-level handler for processing arguments and
-//! constructing a compilation for a CLI tool.
+//! @brief Driver class with reporting and output functionality for CLI tools.
 //
 // SPDX-FileCopyrightText: Michael Popoloski
 // SPDX-License-Identifier: MIT
 //------------------------------------------------------------------------------
 #pragma once
 
-#include "slang/ast/Compilation.h"
-#include "slang/diagnostics/DiagnosticClient.h"
-#include "slang/diagnostics/DiagnosticEngine.h"
-#include "slang/driver/SourceLoader.h"
-#include "slang/text/SourceManager.h"
-#include "slang/util/Bag.h"
-#include "slang/util/CommandLine.h"
-#include "slang/util/LanguageVersion.h"
-#include "slang/util/OS.h"
-#include "slang/util/Util.h"
+#include "slang/diagnostics/TextDiagnosticClient.h"
+#include "slang/driver/BaseDriver.h"
 
 namespace slang {
-
 class JsonDiagnosticClient;
 class JsonWriter;
 class TextDiagnosticClient;
-enum class ShowHierarchyPathOption;
-
 } // namespace slang
-
-namespace slang::syntax {
-class SyntaxTree;
-}
-
-namespace slang::ast {
-
-class Compilation;
-enum class CompilationFlags;
-
-} // namespace slang::ast
-
-namespace slang::analysis {
-
-class AnalysisManager;
-enum class AnalysisFlags;
-
-} // namespace slang::analysis
 
 namespace slang::driver {
 
-#define COMPAT(x) x(Vcs) x(All)
-SLANG_ENUM(CompatMode, COMPAT)
-#undef COMPAT
-
-/// @brief A top-level class that handles argument parsing, option preparation,
-/// and invoking various parts of the slang compilation process.
+/// @brief Driver class with reporting and output methods for command-line tools.
 ///
-/// This is exposed as a convenience wrapper around the various components
-/// that could otherwise be used on their own.
+/// This class extends BaseDriver with methods for various types of output including
+/// preprocessor output, macro reporting, and diagnostic reporting.
 ///
 /// A typical compilation flow using the driver looks as follows:
 ///
@@ -70,151 +35,10 @@ SLANG_ENUM(CompatMode, COMPAT)
 /// else { ...success }
 /// @endcode
 ///
-class SLANG_EXPORT Driver {
-private:
-    // This exists to ensure we get a Compilation object created prior to anything else,
-    // such as the DiagnosticEngine, which wants a Compilation to register callbacks
-    // for printing symbol paths.
-    ast::Compilation defaultComp;
-
+class SLANG_EXPORT Driver : public ClientOwningDriver<TextDiagnosticClient> {
 public:
-    /// The command line object that will be used to parse
-    /// arguments if the @a parseCommandLine method is called.
-    CommandLine cmdLine;
-
-    /// The source manager that holds all loaded source files.
-    SourceManager sourceManager;
-
-    /// The diagnostics engine that will be used to report diagnostics.
-    DiagnosticEngine diagEngine;
-
-    /// The text diagnostics client that will be used to render diagnostics.
-    std::shared_ptr<TextDiagnosticClient> textDiagClient;
-
-    /// The (optional) JSON diagnostics client that will be used to render diagnostics.
-    std::shared_ptr<JsonDiagnosticClient> jsonDiagClient;
-
-    /// The object that handles loading and parsing source files.
-    SourceLoader sourceLoader;
-
-    /// A list of syntax trees that have been parsed.
-    std::vector<std::shared_ptr<syntax::SyntaxTree>> syntaxTrees;
-
-    /// The version of the SystemVerilog language to use.
-    LanguageVersion languageVersion = LanguageVersion::Default;
-
-    /// A container for various options that can be parsed and applied
-    /// to the compilation process.
-    struct SLANG_EXPORT Options {
-        /// The version of the SystemVerilog language to use.
-        std::optional<std::string> languageVersion;
-
-        /// @name Preprocessing
-        /// @{
-
-        /// The maximum depth of included files before an error is issued.
-        std::optional<uint32_t> maxIncludeDepth;
-
-        /// A list of macros that should be defined in each compilation unit.
-        std::vector<std::string> defines;
-
-        /// A list of macros that should be undefined in each compilation unit.
-        std::vector<std::string> undefines;
-
-        /// If true, library files will inherit macro definitions from primary source files.
-        std::optional<bool> librariesInheritMacros;
-
-        /// If true, the preprocessor will support legacy protected envelope directives,
-        /// for compatibility with old Verilog tools.
-        std::optional<bool> enableLegacyProtect;
-
-        /// A set of preprocessor directives to be ignored.
-        std::vector<std::string> ignoreDirectives;
-
-        /// A set of options controlling translate-off comment directives.
-        std::vector<std::string> translateOffOptions;
-
-        /// Disables "local" include path lookup, where include directives search
-        /// relative to the file containing the directive first.
-        std::optional<bool> disableLocalIncludes;
-
-        /// @}
-        /// @name Parsing
-        /// @{
-
-        /// The maximum call stack depth of parsing before an error is issued.
-        std::optional<uint32_t> maxParseDepth;
-
-        /// The maximum number of lexer errors that can be encountered before giving up.
-        std::optional<uint32_t> maxLexerErrors;
-
-        /// The number of threads to use for parsing.
-        std::optional<uint32_t> numThreads;
-
-        /// @}
-        /// @name Compilation
-        /// @{
-
-        /// The maximum depth of nested module instances (and interfaces/programs),
-        /// to detect infinite recursion.
-        std::optional<uint32_t> maxInstanceDepth;
-
-        /// The maximum number of steps that will be taken when expanding a single
-        /// generate construct, to detect infinite loops.
-        std::optional<uint32_t> maxGenerateSteps;
-
-        /// The maximum depth of nested function calls in constant expressions,
-        /// to detect infinite recursion.
-        std::optional<uint32_t> maxConstexprDepth;
-
-        /// The maximum number of steps to allow when evaluating a constant expressions,
-        /// to detect infinite loops.
-        std::optional<uint32_t> maxConstexprSteps;
-
-        /// The maximum number of frames in a callstack to display in diagnostics
-        /// before abbreviating them.
-        std::optional<uint32_t> maxConstexprBacktrace;
-
-        /// The maximum number of instances allowed in a single instance array.
-        std::optional<uint32_t> maxInstanceArray;
-
-        /// The maximum number of UDP coverage notes that will be generated for a single
-        /// warning about missing edge transitions.
-        std::optional<uint32_t> maxUDPCoverageNotes;
-
-        /// Preset compatibility modes for setting other options in one easy step.
-        std::optional<CompatMode> compat;
-
-        /// Indicates which set of (min:typ:max) expressions is valid for this compilation.
-        std::optional<ast::MinTypMax> minTypMax;
-
-        /// A string that indicates the default time scale to use for
-        /// any design elements that don't specify one explicitly.
-        std::optional<std::string> timeScale;
-
-        /// A collection of flags that control compilation.
-        std::map<ast::CompilationFlags, std::optional<bool>> compilationFlags;
-
-        /// If non-empty, specifies the list of modules that should serve as the
-        /// top modules in the design. If empty, this will be automatically determined
-        /// based on which modules are unreferenced elsewhere.
-        std::vector<std::string> topModules;
-
-        /// A list of parameters to override, of the form &lt;name>=&lt;value> -- note that
-        /// for now at least this only applies to parameters in top-level modules.
-        std::vector<std::string> paramOverrides;
-
-        /// A list of library names specifying the order in which module lookup
-        /// should be resolved between libraries.
-        std::vector<std::string> libraryOrder;
-
-        /// The name of the default library; if not set, defaults to "work".
-        std::optional<std::string> defaultLibName;
-
-        /// @}
-        /// @name Diagnostics control
-        /// @{
-
+    /// Options for configuring diagnostic output formatting.
+    struct SLANG_EXPORT DiagnosticFormatOptions {
         /// If true, print diagnostics with color.
         std::optional<bool> colorDiags;
 
@@ -248,28 +72,10 @@ public:
         /// If set, the path to a JSON file that will be written with diagnostic information.
         /// Can be '-' to indicate that the JSON should be written to stdout.
         std::optional<std::string> diagJson;
+    };
 
-        /// The maximum number of errors to print before giving up.
-        std::optional<uint32_t> errorLimit;
-
-        /// A list of warning options that will be passed to the DiagnosticEngine.
-        std::vector<std::string> warningOptions;
-
-        /// @}
-        /// @name File lists
-        /// @{
-
-        /// If set to true, all source files will be treated as part of a single
-        /// compilation unit, meaning all of their text will be merged together.
-        std::optional<bool> singleUnit;
-
-        /// A set of extensions that will be used to exclude files.
-        flat_hash_set<std::string> excludeExts;
-
-        /// @}
-        /// @name Dependency files
-        /// @{
-
+    /// Options for configuring dependency file generation.
+    struct SLANG_EXPORT DepFileOptions {
         /// Optional target name to include when writing dependency files.
         std::optional<std::string> depfileTarget;
 
@@ -287,69 +93,32 @@ public:
 
         /// Output path for a dependency file containing module source file dependencies.
         std::optional<std::string> moduleDepfile;
+    };
 
-        /// @}
-        /// @name Analysis
-        /// @{
+    /// Options for diagnostic output formatting.
+    DiagnosticFormatOptions diagFormatOptions;
 
-        /// A collection of flags that control analysis.
-        std::map<analysis::AnalysisFlags, std::optional<bool>> analysisFlags;
+    /// Options for dependency file generation.
+    DepFileOptions depFileOptions;
 
-        /// The maximum number of steps to take when analyzing a case statement.
-        std::optional<uint32_t> maxCaseAnalysisSteps;
+    /// The text diagnostics client that will be used to render diagnostics.
+    std::shared_ptr<TextDiagnosticClient> textDiagClient;
 
-        /// The maximum number of steps to take when analyzing a loop statement.
-        std::optional<uint32_t> maxLoopAnalysisSteps;
-
-        /// @}
-
-        /// Returns true if the lintMode option is provided.
-        bool lintMode() const;
-    } options;
+    /// The (optional) JSON diagnostics client that will be used to render diagnostics.
+    std::shared_ptr<JsonDiagnosticClient> jsonDiagClient;
 
     /// Constructs a new instance of the @a Driver class.
     Driver();
     ~Driver();
 
-    /// @brief Adds standard command line arguments to the @a cmdLine object.
+    /// @brief Adds standard command line arguments, including diagnostic formatting options.
     ///
-    /// If not called, no arguments will be added by default, though the user
-    /// can still add their own custom arguments if desired.
+    /// This calls the base class method and adds additional diagnostic-related arguments.
     void addStandardArgs();
 
-    /// @brief Parses command line arguments from the given C-style argument list.
+    /// @brief Processes and applies all configured options, including diagnostic client setup.
     ///
-    /// This is templated to support both char and wchar_t arg lists.
-    /// Any errors encountered will be printed to stderr.
-    template<typename TArgs>
-    [[nodiscard]] bool parseCommandLine(int argc, TArgs argv) {
-        if (!cmdLine.parse(argc, argv)) {
-            for (auto& err : cmdLine.getErrors())
-                OS::printE(err + '\n');
-            return false;
-        }
-        return !anyFailedLoads;
-    }
-
-    /// @brief Parses command line arguments from the given string.
-    ///
-    /// Any errors encountered will be printed to stderr.
-    [[nodiscard]] bool parseCommandLine(std::string_view argList,
-                                        CommandLine::ParseOptions parseOptions = {});
-
-    /// @brief Processes the given command file(s) for more options.
-    ///
-    /// Any errors encountered will be printed to stderr.
-    /// @param pattern a file path pattern indicating the command file(s) to process.
-    /// @param makeRelative indicates whether paths in the file are relative to the file
-    ///                     itself or to the current working directory.
-    /// @param separateUnit if true, the file is a separate compilation unit listing;
-    ///                     options within it apply only to that unit and not the
-    ///                     broader compilation.
-    /// @returns true on success and false if errors were encountered.
-    bool processCommandFiles(std::string_view pattern, bool makeRelative, bool separateUnit);
-
-    /// Processes and applies all configured options.
+    /// This calls the base class method and adds diagnostic client configuration.
     /// @returns true on success and false if errors were encountered.
     [[nodiscard]] bool processOptions();
 
@@ -374,22 +143,7 @@ public:
     /// (if such options have not been specified this method does nothing).
     void optionallyWriteDepFiles();
 
-    /// @brief Parses all loaded buffers into syntax trees and appends the resulting trees
-    /// to the @a syntaxTrees list.
-    ///
-    /// @returns true on success and false if errors were encountered.
-    [[nodiscard]] bool parseAllSources();
-
-    /// Creates an options bag from all of the currently set options.
-    [[nodiscard]] Bag createOptionBag() const;
-
-    /// Creates an options bag from all of the currently set parse options
-    [[nodiscard]] Bag createParseOptionBag() const;
-
-    /// Creates a compilation object from all of the current loaded state of the driver.
-    [[nodiscard]] std::unique_ptr<ast::Compilation> createCompilation();
-
-    /// Reports all parsing diagnostics found in all of the @a syntaxTrees
+    /// @brief Reports all parsing diagnostics found in all of the @a syntaxTrees
     /// @returns true on success and false if errors were encountered.
     [[nodiscard]] bool reportParseDiags();
 
@@ -397,11 +151,6 @@ public:
     ///
     /// If @a quiet is set to true, non-essential output will be suppressed.
     void reportCompilation(ast::Compilation& compilation, bool quiet);
-
-    /// @brief Runs analysis on a compilation and reports the results.
-    ///
-    /// @note The compilation will be frozen after this call.
-    std::unique_ptr<analysis::AnalysisManager> runAnalysis(ast::Compilation& compilation);
 
     /// @brief Reports all diagnostics to output.
     ///
@@ -417,26 +166,7 @@ public:
     /// @returns true if compilation succeeded and false if errors were encountered.
     [[nodiscard]] bool runFullCompilation(bool quiet = false);
 
-    /// Prints an error to stderr with appropriate terminal colors.
-    void printError(const std::string& message);
-
-    /// Prints a warning to stderr with appropriate terminal colors.
-    void printWarning(const std::string& message);
-
-    /// Prints a note to stderr with appropriate terminal colors.
-    void printNote(const std::string& message);
-
 private:
-    bool parseUnitListing(std::string_view text);
-    void addLibraryFiles(std::string_view pattern);
-    void addParseOptions(Bag& bag) const;
-    void addCompilationOptions(Bag& bag) const;
-    bool reportLoadErrors();
-
-    bool anyFailedLoads = false;
-    flat_hash_set<std::filesystem::path> activeCommandFiles;
-    std::vector<std::tuple<std::string_view, std::string_view, std::string_view>>
-        translateOffFormats;
     std::unique_ptr<JsonWriter> jsonWriter;
 };
 

--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -78,6 +78,7 @@ add_library(
   diagnostics/Diagnostics.cpp
   diagnostics/JsonDiagnosticClient.cpp
   diagnostics/TextDiagnosticClient.cpp
+  driver/BaseDriver.cpp
   driver/Driver.cpp
   driver/SourceLoader.cpp
   numeric/ConstantValue.cpp

--- a/source/diagnostics/DiagnosticEngine.cpp
+++ b/source/diagnostics/DiagnosticEngine.cpp
@@ -663,4 +663,9 @@ void DiagnosticEngine::clearIncludeStack() {
     reportedIncludeStack.clear();
 }
 
+void DiagnosticEngine::issueMessage(DiagnosticSeverity severity, const std::string& message) {
+    for (auto& client : clients)
+        client->reportMessage(severity, message);
+}
+
 } // namespace slang

--- a/source/diagnostics/JsonDiagnosticClient.cpp
+++ b/source/diagnostics/JsonDiagnosticClient.cpp
@@ -84,4 +84,9 @@ void JsonDiagnosticClient::report(const ReportedDiagnostic& diag) {
     writer.endObject();
 }
 
+void JsonDiagnosticClient::reportMessage(DiagnosticSeverity, const std::string&) {
+    // No op to match previous behavior. Changes are needed in driver and slang main to actually
+    // report these, since normally slang will error out earlier before the json is printed
+}
+
 } // namespace slang

--- a/source/diagnostics/TextDiagnosticClient.cpp
+++ b/source/diagnostics/TextDiagnosticClient.cpp
@@ -12,6 +12,7 @@
 #include "slang/text/CharInfo.h"
 #include "slang/text/FormatBuffer.h"
 #include "slang/text/SourceManager.h"
+#include "slang/util/OS.h"
 
 namespace slang {
 
@@ -358,6 +359,35 @@ void TextDiagnosticClient::formatDiag(SourceLocation loc, std::span<const Source
     }
 
     buffer->append("\n"sv);
+}
+
+void TextDiagnosticClient::reportMessage(DiagnosticSeverity severity, const std::string& message) {
+    fmt::terminal_color color;
+    std::string_view prefix;
+
+    switch (severity) {
+        case DiagnosticSeverity::Error:
+        case DiagnosticSeverity::Fatal:
+            color = errorColor;
+            prefix = "error: ";
+            break;
+        case DiagnosticSeverity::Warning:
+            color = warningColor;
+            prefix = "warning: ";
+            break;
+        case DiagnosticSeverity::Note:
+            color = noteColor;
+            prefix = "  note: ";
+            break;
+        default:
+            OS::printE(message);
+            OS::printE("\n");
+            return;
+    }
+
+    OS::printE(fg(color), prefix);
+    OS::printE(message);
+    OS::printE("\n");
 }
 
 } // namespace slang

--- a/source/driver/Driver.cpp
+++ b/source/driver/Driver.cpp
@@ -1,7 +1,6 @@
 //------------------------------------------------------------------------------
 // Driver.cpp
-// Top-level handler for processing arguments and
-// constructing a compilation for a CLI tool.
+// Driver implementation with reporting and output functionality for CLI tools
 //
 // SPDX-FileCopyrightText: Michael Popoloski
 // SPDX-License-Identifier: MIT
@@ -9,28 +8,25 @@
 #include "slang/driver/Driver.h"
 
 #include <fmt/color.h>
+#include <memory>
 
 #include "slang/analysis/AnalysisManager.h"
-#include "slang/ast/SemanticFacts.h"
+#include "slang/ast/Compilation.h"
 #include "slang/ast/symbols/CompilationUnitSymbols.h"
 #include "slang/ast/symbols/InstanceSymbols.h"
-#include "slang/diagnostics/DeclarationsDiags.h"
-#include "slang/diagnostics/ExpressionsDiags.h"
+#include "slang/diagnostics/DiagnosticClient.h"
+#include "slang/diagnostics/DiagnosticEngine.h"
 #include "slang/diagnostics/JsonDiagnosticClient.h"
-#include "slang/diagnostics/LookupDiags.h"
-#include "slang/diagnostics/ParserDiags.h"
-#include "slang/diagnostics/StatementsDiags.h"
-#include "slang/diagnostics/SysFuncsDiags.h"
 #include "slang/diagnostics/TextDiagnosticClient.h"
-#include "slang/driver/SourceLoader.h"
-#include "slang/parsing/Parser.h"
+#include "slang/driver/BaseDriver.h"
 #include "slang/parsing/Preprocessor.h"
+#include "slang/syntax/AllSyntax.h"
 #include "slang/syntax/SyntaxPrinter.h"
 #include "slang/syntax/SyntaxTree.h"
 #include "slang/text/FormatBuffer.h"
 #include "slang/text/Json.h"
+#include "slang/util/OS.h"
 #include "slang/util/Random.h"
-#include "slang/util/String.h"
 
 namespace fs = std::filesystem;
 
@@ -41,486 +37,72 @@ using namespace parsing;
 using namespace syntax;
 using namespace analysis;
 
-// clang-format off
-#define VCS_COMP_FLAGS \
-    CompilationFlags::AllowHierarchicalConst, \
-    CompilationFlags::RelaxEnumConversions, \
-    CompilationFlags::AllowUseBeforeDeclare, \
-    CompilationFlags::RelaxStringConversions, \
-    CompilationFlags::AllowRecursiveImplicitCall, \
-    CompilationFlags::AllowBareValParamAssignment, \
-    CompilationFlags::AllowSelfDeterminedStreamConcat, \
-    CompilationFlags::AllowMergingAnsiPorts
-
-static constexpr auto vcsCompFlags = {VCS_COMP_FLAGS};
-static constexpr auto allCompFlags = {
-    VCS_COMP_FLAGS,
-    CompilationFlags::AllowTopLevelIfacePorts,
-    CompilationFlags::AllowUnnamedGenerate
-};
-
-#define VCS_ANALYSIS_FLAGS \
-    AnalysisFlags::AllowMultiDrivenLocals
-
-static constexpr auto vcsAnalysisFlags = {VCS_ANALYSIS_FLAGS};
-static constexpr auto allAnalysisFlags = {
-    VCS_ANALYSIS_FLAGS,
-    AnalysisFlags::AllowDupInitialDrivers
-};
-// clang-format on
-
-Driver::Driver() : diagEngine(sourceManager), sourceLoader(sourceManager) {
-    textDiagClient = std::make_shared<TextDiagnosticClient>();
-    diagEngine.addClient(textDiagClient);
+Driver::Driver() : ClientOwningDriver<TextDiagnosticClient>() {
+    textDiagClient = this->diagClient;
 }
 
 Driver::~Driver() = default;
 
 void Driver::addStandardArgs() {
-    cmdLine.add("--std", options.languageVersion,
-                "The version of the SystemVerilog language to use",
-                "(1800-2017 | 1800-2023 | latest)");
-
-    // Include paths
-    cmdLine.add(
-        "-I,--include-directory,+incdir",
-        [this](std::string_view value) {
-            if (auto ec = sourceManager.addUserDirectories(value)) {
-                printWarning(fmt::format("include directory '{}': {}", value, ec.message()));
-            }
-            return "";
-        },
-        "Additional include search paths", "<dir-pattern>[,...]", CommandLineFlags::CommaList);
-
-    cmdLine.add(
-        "--isystem",
-        [this](std::string_view value) {
-            if (auto ec = sourceManager.addSystemDirectories(value)) {
-                printWarning(fmt::format("system include directory '{}': {}", value, ec.message()));
-            }
-            return "";
-        },
-        "Additional system include search paths", "<dir-pattern>[,...]",
-        CommandLineFlags::CommaList);
-
-    cmdLine.add("--disable-local-includes", options.disableLocalIncludes,
-                "Disables \"local\" include path lookup, where include directives search "
-                "relative to the file containing the directive first");
-
-    // Preprocessor
-    cmdLine.add("-D,--define-macro,+define", options.defines,
-                "Define <macro> to <value> (or 1 if <value> ommitted) in all source files",
-                "<macro>=<value>");
-    cmdLine.add("-U,--undefine-macro", options.undefines,
-                "Undefine macro name at the start of all source files", "<macro>",
-                CommandLineFlags::CommaList);
-    cmdLine.add("--max-include-depth", options.maxIncludeDepth,
-                "Maximum depth of nested include files allowed", "<depth>");
-    cmdLine.add("--libraries-inherit-macros", options.librariesInheritMacros,
-                "If true, library files will inherit macro definitions from the primary source "
-                "files. --single-unit must also be passed when this option is used.");
-    cmdLine.add("--enable-legacy-protect", options.enableLegacyProtect,
-                "If true, the preprocessor will support legacy protected envelope directives, "
-                "for compatibility with old Verilog tools");
-    cmdLine.add("--translate-off-format", options.translateOffOptions,
-                "Set a format for comment directives that mark a region of disabled "
-                "source text. The format is a common keyword, a start word, and an "
-                "end word, each separated by commas. For example, "
-                "'pragma,translate_off,translate_on'",
-                "<common>,<start>,<end>");
-
-    // Legacy vendor commands support
-    cmdLine.add(
-        "--cmd-ignore", [this](std::string_view value) { return cmdLine.addIgnoreCommand(value); },
-        "Define rule to ignore vendor command <vendor_cmd> with its following <N> parameters.\n"
-        "A command of the form +xyz will also match any vendor command of the form +xyz+abc,\n"
-        "as +abc is the command's argument, and doesn't need to be matched.",
-        "<vendor_cmd>,<N>");
-    cmdLine.add(
-        "--cmd-rename", [this](std::string_view value) { return cmdLine.addRenameCommand(value); },
-        "Define rule to rename vendor command <vendor_cmd> into existing <slang_cmd>",
-        "<vendor_cmd>,<slang_cmd>");
-    cmdLine.add("--ignore-directive", options.ignoreDirectives,
-                "Ignore preprocessor directive and all its arguments until EOL", "<directive>",
-                CommandLineFlags::CommaList);
-
-    // Parsing
-    cmdLine.add("--max-parse-depth", options.maxParseDepth,
-                "Maximum depth of nested language constructs allowed", "<depth>");
-    cmdLine.add("--max-lexer-errors", options.maxLexerErrors,
-                "Maximum number of errors that can occur during lexing before the rest of the file "
-                "is skipped",
-                "<count>");
-#if defined(SLANG_USE_THREADS)
-    cmdLine.add("-j,--threads", options.numThreads,
-                "The number of threads to use to parallelize parsing", "<count>");
-#else
-    options.numThreads = 1;
-#endif
-
-    cmdLine.add(
-        "-C",
-        [this](std::string_view value) {
-            processCommandFiles(value, /* makeRelative */ true, /* separateUnit */ true);
-            return "";
-        },
-        "One or more files containing independent compilation unit listings. "
-        "The files accept a subset of options that pertain specifically to parsing "
-        "that unit and optionally including it in a library.",
-        "<file-pattern>[,...]", CommandLineFlags::CommaList);
-
-    // Compilation
-    cmdLine.add("--max-hierarchy-depth", options.maxInstanceDepth,
-                "Maximum depth of the design hierarchy", "<depth>");
-    cmdLine.add("--max-generate-steps", options.maxGenerateSteps,
-                "Maximum number of steps that can occur during generate block "
-                "evaluation before giving up",
-                "<steps>");
-    cmdLine.add("--max-constexpr-depth", options.maxConstexprDepth,
-                "Maximum depth of a constant evaluation call stack", "<depth>");
-    cmdLine.add("--max-constexpr-steps", options.maxConstexprSteps,
-                "Maximum number of steps that can occur during constant "
-                "evaluation before giving up",
-                "<steps>");
-    cmdLine.add("--constexpr-backtrace-limit", options.maxConstexprBacktrace,
-                "Maximum number of frames to show when printing a constant evaluation "
-                "backtrace; the rest will be abbreviated",
-                "<limit>");
-    cmdLine.add("--max-instance-array", options.maxInstanceArray,
-                "Maximum number of instances allowed in a single instance array", "<limit>");
-    cmdLine.add("--max-udp-coverage-notes", options.maxUDPCoverageNotes,
-                "Maximum number of UDP coverage notes that will be generated for a single "
-                "warning about missing edge transitions",
-                "<limit>");
-    cmdLine.addEnum<CompatMode, CompatMode_traits>(
-        "--compat", options.compat, "Attempt to increase compatibility with the specified tool",
-        "<mode>");
-    cmdLine.addEnum<MinTypMax, MinTypMax_traits>(
-        "-T,--timing", options.minTypMax,
-        "Select which value to consider in min:typ:max expressions", "min|typ|max");
-    cmdLine.add("--timescale", options.timeScale,
-                "Default time scale to use for design elements that don't specify one explicitly",
-                "<base>/<precision>");
-
-    auto addCompFlag = [&](CompilationFlags flag, std::string_view name, std::string_view desc) {
-        auto [it, inserted] = options.compilationFlags.emplace(flag, std::nullopt);
-        SLANG_ASSERT(inserted);
-        cmdLine.add(name, it->second, desc);
-    };
-
-    addCompFlag(CompilationFlags::AllowUseBeforeDeclare, "--allow-use-before-declare",
-                "Don't issue an error for use of names before their declarations");
-    addCompFlag(CompilationFlags::IgnoreUnknownModules, "--ignore-unknown-modules",
-                "Don't issue an error for instantiations of unknown modules, "
-                "interface, and programs");
-    addCompFlag(CompilationFlags::RelaxEnumConversions, "--relax-enum-conversions",
-                "Allow all integral types to convert implicitly to enum types");
-    addCompFlag(CompilationFlags::RelaxStringConversions, "--relax-string-conversions",
-                "Allow string types to convert implicitly to integral types");
-    addCompFlag(CompilationFlags::AllowHierarchicalConst, "--allow-hierarchical-const",
-                "Allow hierarchical references in constant expressions");
-    addCompFlag(CompilationFlags::AllowTopLevelIfacePorts, "--allow-toplevel-iface-ports",
-                "Allow top-level modules to have interface ports");
-    addCompFlag(CompilationFlags::AllowRecursiveImplicitCall, "--allow-recursive-implicit-call",
-                "Allow implicit call expressions to be recursive function calls");
-    addCompFlag(CompilationFlags::AllowBareValParamAssignment, "--allow-bare-value-param-assigment",
-                "Allow module parameter assignments to elide the parentheses");
-    addCompFlag(CompilationFlags::AllowSelfDeterminedStreamConcat,
-                "--allow-self-determined-stream-concat",
-                "Allow self-determined streaming concatenation expressions");
-    addCompFlag(CompilationFlags::AllowMergingAnsiPorts, "--allow-merging-ansi-ports",
-                "Allow merging ANSI port declarations with nets and variables declared in the "
-                "instance body");
-    addCompFlag(CompilationFlags::LintMode, "--lint-only",
-                "Only perform linting of code, don't try to elaborate a full hierarchy");
-    addCompFlag(CompilationFlags::DisableInstanceCaching, "--disable-instance-caching",
-                "Disable the use of instance caching, which normally allows skipping duplicate "
-                "instance bodies to save time when elaborating");
-    addCompFlag(CompilationFlags::DisallowRefsToUnknownInstances,
-                "--disallow-refs-to-unknown-instances",
-                "When using --ignore-unknown-modules, explicitly disallow references to ignored "
-                "module instances by issuing an error");
-    addCompFlag(CompilationFlags::AllowUnnamedGenerate, "--allow-genblk-reference",
-                "Allow references to unnamed generate blocks via their external names "
-                "(e.g. genblk1)");
-
-    cmdLine.add("--top", options.topModules,
-                "One or more top-level modules to instantiate "
-                "(instead of figuring it out automatically)",
-                "<name>", CommandLineFlags::CommaList);
-    cmdLine.add("-G", options.paramOverrides,
-                "One or more parameter overrides to apply when instantiating top-level modules",
-                "<name>=<value>");
-    cmdLine.add("-L", options.libraryOrder,
-                "A list of library names that controls the priority order for module lookup",
-                "<library>", CommandLineFlags::CommaList);
-    cmdLine.add("--defaultLibName", options.defaultLibName, "Sets the name of the default library",
-                "<name>");
+    // Call base class to add core arguments
+    BaseDriver::addStandardArgs();
 
     // Diagnostics control
-    cmdLine.add("-W", options.warningOptions, "Control the specified warning", "<warning>");
-    cmdLine.add("--color-diagnostics", options.colorDiags,
+    cmdLine.add("--color-diagnostics", diagFormatOptions.colorDiags,
                 "Always print diagnostics in color. "
                 "If this option is unset, colors will be enabled if a color-capable "
                 "terminal is detected.");
-    cmdLine.add("--diag-column", options.diagColumn, "Show column numbers in diagnostic output");
-    cmdLine.addEnum<ColumnUnit, ColumnUnit_traits>("--diag-column-unit", options.diagColumnUnit,
+    cmdLine.add("--diag-column", diagFormatOptions.diagColumn,
+                "Show column numbers in diagnostic output");
+    cmdLine.addEnum<ColumnUnit, ColumnUnit_traits>("--diag-column-unit",
+                                                   diagFormatOptions.diagColumnUnit,
                                                    "Unit for column numbers in diagnostics",
                                                    "<unit>");
-    cmdLine.add("--diag-location", options.diagLocation,
+    cmdLine.add("--diag-location", diagFormatOptions.diagLocation,
                 "Show location information in diagnostic output");
-    cmdLine.add("--diag-source", options.diagSourceLine,
+    cmdLine.add("--diag-source", diagFormatOptions.diagSourceLine,
                 "Show source line or caret info in diagnostic output");
-    cmdLine.add("--diag-option", options.diagOptionName, "Show option names in diagnostic output");
-    cmdLine.add("--diag-include-stack", options.diagIncludeStack,
+    cmdLine.add("--diag-option", diagFormatOptions.diagOptionName,
+                "Show option names in diagnostic output");
+    cmdLine.add("--diag-include-stack", diagFormatOptions.diagIncludeStack,
                 "Show include stacks in diagnostic output");
-    cmdLine.add("--diag-macro-expansion", options.diagMacroExpansion,
+    cmdLine.add("--diag-macro-expansion", diagFormatOptions.diagMacroExpansion,
                 "Show macro expansion backtraces in diagnostic output");
-    cmdLine.add("--diag-abs-paths", options.diagAbsPaths,
+    cmdLine.add("--diag-abs-paths", diagFormatOptions.diagAbsPaths,
                 "Display absolute paths to files in diagnostic output");
     cmdLine.addEnum<ShowHierarchyPathOption, ShowHierarchyPathOption_traits>(
-        "--diag-hierarchy", options.diagHierarchy, "Show hierarchy locations in diagnostic output",
-        "always|never|auto");
-    cmdLine.add("--diag-json", options.diagJson,
+        "--diag-hierarchy", diagFormatOptions.diagHierarchy,
+        "Show hierarchy locations in diagnostic output", "always|never|auto");
+    cmdLine.add("--diag-json", diagFormatOptions.diagJson,
                 "Dump all diagnostics in JSON format to the specified file, or '-' for stdout",
                 "<file>", CommandLineFlags::FilePath);
-    cmdLine.add("--error-limit", options.errorLimit,
-                "Limit on the number of errors that will be printed. Setting this to zero will "
-                "disable the limit.",
-                "<limit>");
-
-    cmdLine.add(
-        "--suppress-warnings",
-        [this](std::string_view value) {
-            if (auto ec = diagEngine.addIgnorePaths(value))
-                printWarning(fmt::format("--suppress-warnings path '{}': {}", value, ec.message()));
-            return "";
-        },
-        "One or more paths in which to suppress warnings", "<file-pattern>[,...]",
-        CommandLineFlags::CommaList);
-
-    cmdLine.add(
-        "--suppress-macro-warnings",
-        [this](std::string_view value) {
-            if (auto ec = diagEngine.addIgnoreMacroPaths(value)) {
-                printWarning(
-                    fmt::format("--suppress-macro-warnings path '{}': {}", value, ec.message()));
-            }
-            return "";
-        },
-        "One or more paths in which to suppress warnings that "
-        "originate in macro expansions",
-        "<file-pattern>[,...]", CommandLineFlags::CommaList);
-
-    // File lists
-    cmdLine.add("--single-unit", options.singleUnit,
-                "Treat all input files as a single compilation unit");
-
-    cmdLine.add(
-        "-v,--libfile",
-        [this](std::string_view value) {
-            addLibraryFiles(value);
-            return "";
-        },
-        "One or more library files, which are separate compilation units "
-        "where modules are not automatically instantiated",
-        "<file-pattern>[,...]", CommandLineFlags::CommaList);
-
-    cmdLine.add(
-        "--libmap",
-        [this](std::string_view value) {
-            sourceLoader.addLibraryMaps(value, {}, createParseOptionBag());
-            return "";
-        },
-        "One or more library map files to parse "
-        "for library name mappings and file lists",
-        "<file-pattern>[,...]", CommandLineFlags::CommaList);
-
-    cmdLine.add(
-        "-y,--libdir",
-        [this](std::string_view value) {
-            sourceLoader.addSearchDirectories(value);
-            return "";
-        },
-        "Library search paths, which will be searched for missing modules", "<dir-pattern>[,...]",
-        CommandLineFlags::CommaList);
-
-    cmdLine.add(
-        "-Y,--libext,+libext",
-        [this](std::string_view value) {
-            sourceLoader.addSearchExtension(value);
-            return "";
-        },
-        "Additional library file extensions to search", "<ext>", CommandLineFlags::CommaList);
-
-    cmdLine.add(
-        "--exclude-ext",
-        [this](std::string_view value) {
-            options.excludeExts.emplace(std::string(value));
-            return "";
-        },
-        "Exclude provided source files with these extensions", "<ext>",
-        CommandLineFlags::CommaList);
-
-    cmdLine.setPositional(
-        [this](std::string_view value) {
-            if (!options.excludeExts.empty()) {
-                if (size_t extIndex = value.find_last_of('.'); extIndex != std::string_view::npos) {
-                    if (options.excludeExts.count(std::string(value.substr(extIndex + 1))))
-                        return "";
-                }
-            }
-
-            sourceLoader.addFiles(value);
-            return "";
-        },
-        "files");
-
-    cmdLine.add(
-        "-f",
-        [this](std::string_view value) {
-            processCommandFiles(value, /* makeRelative */ false, /* separateUnit */ false);
-            return "";
-        },
-        "One or more command files containing additional program options. "
-        "Paths in the file are considered relative to the current directory.",
-        "<file-pattern>[,...]", CommandLineFlags::CommaList);
-
-    cmdLine.add(
-        "-F",
-        [this](std::string_view value) {
-            processCommandFiles(value, /* makeRelative */ true, /* separateUnit */ false);
-            return "";
-        },
-        "One or more command files containing additional program options. "
-        "Paths in the file are considered relative to the file itself.",
-        "<file-pattern>[,...]", CommandLineFlags::CommaList);
 
     // Dependency files
-    cmdLine.add("--depfile-target", options.depfileTarget,
+    cmdLine.add("--depfile-target", depFileOptions.depfileTarget,
                 "Output depfile lists in makefile format, creating the file with "
                 "`<target>:` as the make target");
-    cmdLine.add("--Mall,--all-deps", options.allDepfile,
+    cmdLine.add("--Mall,--all-deps", depFileOptions.allDepfile,
                 "Generate dependency file list of all files used during parsing", "<file>",
                 CommandLineFlags::FilePath);
-    cmdLine.add("--Minclude,--include-deps", options.includeDepfile,
+    cmdLine.add("--Minclude,--include-deps", depFileOptions.includeDepfile,
                 "Generate dependency file list of just include files that were "
                 "used during parsing",
                 "<file>", CommandLineFlags::FilePath);
-    cmdLine.add("--Mmodule,--module-deps", options.moduleDepfile,
+    cmdLine.add("--Mmodule,--module-deps", depFileOptions.moduleDepfile,
                 "Generate dependency file list of source files parsed, excluding include files",
                 "<file>", CommandLineFlags::FilePath);
-    cmdLine.add("--depfile-trim", options.depfileTrim,
+    cmdLine.add("--depfile-trim", depFileOptions.depfileTrim,
                 "Trim unreferenced files before generating dependency lists "
                 "(also implies --depfile-sort)");
-    cmdLine.add("--depfile-sort", options.depfileSort,
+    cmdLine.add("--depfile-sort", depFileOptions.depfileSort,
                 "Topologically sort the emitted files in dependency lists");
-
-    // Analysis modifiers
-    auto addAnalysisFlag = [&](AnalysisFlags flag, std::string_view name, std::string_view desc) {
-        auto [it, inserted] = options.analysisFlags.emplace(flag, std::nullopt);
-        SLANG_ASSERT(inserted);
-        cmdLine.add(name, it->second, desc);
-    };
-
-    addAnalysisFlag(AnalysisFlags::FullCaseUniquePriority, "--dfa-unique-priority",
-                    "Respect the 'unique' and 'priority' keywords when analyzing data flow "
-                    "through case statements");
-    addAnalysisFlag(AnalysisFlags::FullCaseFourState, "--dfa-four-state",
-                    "Require that case items cover X and Z bits to assume full coverage "
-                    "in data flow analysis");
-    addAnalysisFlag(
-        AnalysisFlags::AllowMultiDrivenLocals, "--allow-multi-driven-locals",
-        "Allow subroutine local variables to be driven from multiple always_comb/_ff blocks");
-    addAnalysisFlag(AnalysisFlags::AllowDupInitialDrivers, "--allow-dup-initial-drivers",
-                    "Allow signals driven in an always_comb or always_ff block to also be driven "
-                    "by initial blocks");
-
-    cmdLine.add("--max-case-analysis-steps", options.maxCaseAnalysisSteps,
-                "Maximum number of steps that can occur during case analysis before giving up",
-                "<steps>");
-    cmdLine.add("--max-loop-analysis-steps", options.maxLoopAnalysisSteps,
-                "Maximum number of steps that can occur during loop analysis before giving up",
-                "<steps>");
-}
-
-[[nodiscard]] bool Driver::parseCommandLine(std::string_view argList,
-                                            CommandLine::ParseOptions parseOptions) {
-    if (!cmdLine.parse(argList, parseOptions)) {
-        for (auto& err : cmdLine.getErrors())
-            OS::printE(fmt::format("{}\n", err));
-        return false;
-    }
-    return !anyFailedLoads;
-}
-
-bool Driver::processCommandFiles(std::string_view pattern, bool makeRelative, bool separateUnit) {
-    auto onError = [this](const auto& name, std::error_code ec) {
-        printError(fmt::format("command file '{}': {}", name, ec.message()));
-        anyFailedLoads = true;
-        return false;
-    };
-
-    SmallVector<fs::path> files;
-    std::error_code globEc;
-    svGlob({}, pattern, GlobMode::Files, files, /* expandEnvVars */ false, globEc);
-    if (globEc)
-        return onError(pattern, globEc);
-
-    for (auto& path : files) {
-        SmallVector<char> buffer;
-        if (auto readEc = OS::readFile(path, buffer))
-            return onError(getU8Str(path), readEc);
-
-        if (!activeCommandFiles.insert(path).second) {
-            printError(
-                fmt::format("command file '{}' includes itself recursively", getU8Str(path)));
-            anyFailedLoads = true;
-            return false;
-        }
-
-        fs::path currPath;
-        std::error_code ec;
-        if (makeRelative) {
-            currPath = fs::current_path(ec);
-            fs::current_path(path.parent_path(), ec);
-        }
-
-        SLANG_ASSERT(!buffer.empty());
-        buffer.pop_back();
-        std::string_view argStr(buffer.data(), buffer.size());
-
-        bool result;
-        if (separateUnit) {
-            result = parseUnitListing(argStr);
-        }
-        else {
-            CommandLine::ParseOptions parseOpts;
-            parseOpts.expandEnvVars = true;
-            parseOpts.ignoreProgramName = true;
-            parseOpts.supportComments = true;
-            parseOpts.ignoreDuplicates = true;
-            result = parseCommandLine(argStr, parseOpts);
-        }
-
-        if (makeRelative)
-            fs::current_path(currPath, ec);
-
-        activeCommandFiles.erase(path);
-
-        if (!result) {
-            anyFailedLoads = true;
-            return false;
-        }
-    }
-
-    return true;
 }
 
 bool Driver::processOptions() {
+    // Set up diagnostic client configuration
     bool showColors;
-    if (options.colorDiags.has_value())
-        showColors = *options.colorDiags;
+    if (diagFormatOptions.colorDiags.has_value())
+        showColors = *diagFormatOptions.colorDiags;
     else
         showColors = OS::fileSupportsColors(stderr);
 
@@ -530,160 +112,33 @@ bool Driver::processOptions() {
             OS::setStdoutColorsEnabled(true);
     }
 
-    if (options.languageVersion.has_value()) {
-        if (options.languageVersion == "1800-2017")
-            languageVersion = LanguageVersion::v1800_2017;
-        else if (options.languageVersion == "1800-2023" || options.languageVersion == "latest")
-            languageVersion = LanguageVersion::v1800_2023;
-        else {
-            printError(
-                fmt::format("invalid value for --std option: '{}'", *options.languageVersion));
-            return false;
-        }
-    }
-
-    if (options.compat.has_value()) {
-        std::initializer_list<CompilationFlags> compFlags;
-        std::initializer_list<AnalysisFlags> analysisFlags;
-        if (options.compat == CompatMode::Vcs) {
-            compFlags = vcsCompFlags;
-            analysisFlags = vcsAnalysisFlags;
-        }
-        else {
-            compFlags = allCompFlags;
-            analysisFlags = allAnalysisFlags;
-        }
-
-        for (auto flag : compFlags) {
-            auto& option = options.compilationFlags.at(flag);
-            if (!option.has_value())
-                option = true;
-        }
-
-        for (auto flag : analysisFlags) {
-            auto& option = options.analysisFlags.at(flag);
-            if (!option.has_value())
-                option = true;
-        }
-    }
-
-    if (options.librariesInheritMacros == true && !options.singleUnit.value_or(false)) {
-        printError("--single-unit must be set when --libraries-inherit-macros is used");
-        return false;
-    }
-
-    if (options.timeScale.has_value() && !TimeScale::fromString(*options.timeScale)) {
-        printError(fmt::format("invalid value for time scale option: '{}'", *options.timeScale));
-        return false;
-    }
-
-    if (options.lintMode()) {
-        auto& opt = options.compilationFlags.at(CompilationFlags::IgnoreUnknownModules);
-        if (!opt.has_value())
-            opt = true;
-    }
-
-    if (!options.translateOffOptions.empty()) {
-        bool anyBad = false;
-        for (auto& fmtStr : options.translateOffOptions) {
-            bool bad = false;
-            auto parts = splitString(fmtStr, ',');
-            if (parts.size() != 3)
-                bad = true;
-
-            for (auto part : parts) {
-                if (part.empty())
-                    bad = true;
-
-                for (char c : part) {
-                    if (!isAlphaNumeric(c) && c != '_')
-                        bad = true;
-                }
-            }
-
-            if (bad)
-                printError(fmt::format("invalid format for translate-off-format: '{}'", fmtStr));
-            else
-                translateOffFormats.emplace_back(parts[0], parts[1], parts[2]);
-
-            anyBad |= bad;
-        }
-
-        if (anyBad)
-            return false;
-    }
-
-    if (options.disableLocalIncludes == true)
-        sourceManager.setDisableLocalIncludes(true);
-
-    if (!reportLoadErrors())
-        return false;
-
-    if (!sourceLoader.hasFiles()) {
-        printError("no input files");
-        return false;
-    }
-
-    if (options.diagJson.has_value()) {
+    if (diagFormatOptions.diagJson.has_value()) {
         jsonWriter = std::make_unique<JsonWriter>();
         jsonWriter->setPrettyPrint(true);
         jsonWriter->startArray();
 
         jsonDiagClient = std::make_shared<JsonDiagnosticClient>(*jsonWriter);
-        jsonDiagClient->showAbsPaths(options.diagAbsPaths.value_or(false));
-        jsonDiagClient->setColumnUnit(options.diagColumnUnit.value_or(ColumnUnit::Display));
+        jsonDiagClient->showAbsPaths(diagFormatOptions.diagAbsPaths.value_or(false));
+        jsonDiagClient->setColumnUnit(
+            diagFormatOptions.diagColumnUnit.value_or(ColumnUnit::Display));
         diagEngine.addClient(jsonDiagClient);
     }
 
+    if (!BaseDriver::processOptions())
+        return false;
+
     auto& tdc = *textDiagClient;
     tdc.showColors(showColors);
-    tdc.showColumn(options.diagColumn.value_or(true));
-    tdc.setColumnUnit(options.diagColumnUnit.value_or(ColumnUnit::Display));
-    tdc.showLocation(options.diagLocation.value_or(true));
-    tdc.showSourceLine(options.diagSourceLine.value_or(true));
-    tdc.showOptionName(options.diagOptionName.value_or(true));
-    tdc.showIncludeStack(options.diagIncludeStack.value_or(true));
-    tdc.showMacroExpansion(options.diagMacroExpansion.value_or(true));
-    tdc.showAbsPaths(options.diagAbsPaths.value_or(false));
-    tdc.showHierarchyInstance(options.diagHierarchy.value_or(ShowHierarchyPathOption::Auto));
-
-    diagEngine.setErrorLimit((int)options.errorLimit.value_or(20));
-
-    // Some tools violate the standard in various ways, but in order to allow
-    // compatibility with these tools we change the respective errors into a
-    // suppressible warning that we promote to an error by default. This allows
-    // the user to turn this back into a warning, or turn it off altogether.
-
-    if (options.compat != CompatMode::All) {
-        diagEngine.setSeverity(diag::DuplicateDefinition, DiagnosticSeverity::Error);
-        diagEngine.setSeverity(diag::BadProceduralForce, DiagnosticSeverity::Error);
-        diagEngine.setSeverity(diag::UnknownSystemName, DiagnosticSeverity::Error);
-    }
-
-    if (options.compat == CompatMode::Vcs || options.compat == CompatMode::All) {
-        diagEngine.setSeverity(diag::StaticInitializerMustBeExplicit, DiagnosticSeverity::Ignored);
-        diagEngine.setSeverity(diag::ImplicitConvert, DiagnosticSeverity::Ignored);
-        diagEngine.setSeverity(diag::BadFinishNum, DiagnosticSeverity::Ignored);
-        diagEngine.setSeverity(diag::NonstandardSysFunc, DiagnosticSeverity::Ignored);
-        diagEngine.setSeverity(diag::NonstandardForeach, DiagnosticSeverity::Ignored);
-        diagEngine.setSeverity(diag::NonstandardDist, DiagnosticSeverity::Ignored);
-    }
-    else {
-        // These warnings are set to Error severity by default, unless we're in vcs compat mode.
-        // The user can always downgrade via warning options, which get set after this.
-        diagEngine.setSeverity(diag::IndexOOB, DiagnosticSeverity::Error);
-        diagEngine.setSeverity(diag::RangeOOB, DiagnosticSeverity::Error);
-        diagEngine.setSeverity(diag::RangeWidthOOB, DiagnosticSeverity::Error);
-        diagEngine.setSeverity(diag::ImplicitNamedPortTypeMismatch, DiagnosticSeverity::Error);
-        diagEngine.setSeverity(diag::SplitDistWeightOp, DiagnosticSeverity::Error);
-        diagEngine.setSeverity(diag::DPIPureTask, DiagnosticSeverity::Error);
-        diagEngine.setSeverity(diag::SpecifyPathConditionExpr, DiagnosticSeverity::Error);
-        diagEngine.setSeverity(diag::SolveBeforeDisallowed, DiagnosticSeverity::Error);
-    }
-
-    Diagnostics optionDiags = diagEngine.setWarningOptions(options.warningOptions);
-    for (auto& diag : optionDiags)
-        diagEngine.issue(diag);
+    tdc.showColumn(diagFormatOptions.diagColumn.value_or(true));
+    tdc.setColumnUnit(diagFormatOptions.diagColumnUnit.value_or(ColumnUnit::Display));
+    tdc.showLocation(diagFormatOptions.diagLocation.value_or(true));
+    tdc.showSourceLine(diagFormatOptions.diagSourceLine.value_or(true));
+    tdc.showOptionName(diagFormatOptions.diagOptionName.value_or(true));
+    tdc.showIncludeStack(diagFormatOptions.diagIncludeStack.value_or(true));
+    tdc.showMacroExpansion(diagFormatOptions.diagMacroExpansion.value_or(true));
+    tdc.showAbsPaths(diagFormatOptions.diagAbsPaths.value_or(false));
+    tdc.showHierarchyInstance(
+        diagFormatOptions.diagHierarchy.value_or(ShowHierarchyPathOption::Auto));
 
     return true;
 }
@@ -800,115 +255,14 @@ void Driver::reportMacros() {
     }
 }
 
-static std::string getProximatePathStr(const fs::path& path) {
-    std::error_code ec;
-    auto file = fs::proximate(path, ec);
-    if (ec)
-        file = path;
-
-    return getU8Str(file);
-}
-
-static std::vector<const SyntaxTree*> getSortedDependencies(
-    Driver& driver, std::span<std::shared_ptr<SyntaxTree>> trees, bool trim) {
-
-    // Map all declared modules, classes, etc to their containing syntax trees.
-    flat_hash_map<std::string_view, const SyntaxTree*> nameToTree;
-    for (auto& tree : trees) {
-        for (auto name : tree->getMetadata().getDeclaredSymbols())
-            nameToTree.emplace(name, tree.get());
-    }
-
-    struct Deps {
-        std::vector<const SyntaxTree*> childTrees;
-        std::vector<std::string_view> missingNames;
-    };
-    flat_hash_map<const SyntaxTree*, Deps> treeToDeps;
-    flat_hash_map<std::string_view, const SyntaxTree*> missingToTree;
-
-    // For each syntax tree, build a list of child trees that depend on it
-    // based on references to modules, classes, etc.
-    for (auto& tree : trees) {
-        Deps deps;
-        flat_hash_set<const SyntaxTree*> seenTrees;
-        flat_hash_set<std::string_view> seenMissing;
-
-        for (auto ref : tree->getMetadata().getReferencedSymbols()) {
-            if (auto it = nameToTree.find(ref); it != nameToTree.end()) {
-                if (seenTrees.insert(it->second).second)
-                    deps.childTrees.push_back(it->second);
-            }
-            else if (seenMissing.insert(ref).second) {
-                deps.missingNames.push_back(ref);
-                missingToTree.emplace(ref, tree.get());
-            }
-        }
-
-        treeToDeps.emplace(tree.get(), std::move(deps));
-    }
-
-    // Topologically sort the trees based on their dependencies.
-    std::vector<const SyntaxTree*> results;
-    flat_hash_set<const SyntaxTree*> visited;
-    std::function<void(const SyntaxTree*)> dfsVisit = [&](const SyntaxTree* tree) {
-        if (!visited.insert(tree).second)
-            return;
-
-        if (auto it = treeToDeps.find(tree); it != treeToDeps.end()) {
-            for (auto dep : it->second.childTrees)
-                dfsVisit(dep);
-
-            for (auto name : it->second.missingNames) {
-                driver.printWarning(fmt::format("'{}' not found in any source file", name));
-
-                // Print one representative note for where this is referenced.
-                if (auto missingIt = missingToTree.find(name); missingIt != missingToTree.end()) {
-                    auto buffers = missingIt->second->getSourceBufferIds();
-                    if (!buffers.empty()) {
-                        driver.printNote(fmt::format(
-                            "referenced in file '{}'",
-                            getProximatePathStr(driver.sourceManager.getFullPath(buffers[0]))));
-                    }
-                }
-            }
-        }
-
-        results.push_back(tree);
-    };
-
-    // If we are trimming, the initial set of trees to traverse is based on
-    // the user specified set of top modules. Otherwise, we use all trees.
-    if (trim) {
-        if (driver.options.topModules.empty()) {
-            driver.printWarning("using --depfile-trim with no top modules specified will always "
-                                "result in an empty dependency file");
-        }
-
-        for (auto& name : driver.options.topModules) {
-            if (auto it = nameToTree.find(name); it != nameToTree.end()) {
-                dfsVisit(it->second);
-            }
-            else {
-                driver.printWarning(
-                    fmt::format("top module '{}' not found in any source file", name));
-            }
-        }
-    }
-    else {
-        for (auto& tree : trees)
-            dfsVisit(tree.get());
-    }
-
-    return results;
-}
-
 void Driver::optionallyWriteDepFiles() {
-    if (!options.includeDepfile && !options.moduleDepfile && !options.allDepfile)
+    if (!depFileOptions.includeDepfile && !depFileOptions.moduleDepfile &&
+        !depFileOptions.allDepfile)
         return;
 
     std::vector<const SyntaxTree*> depTrees;
-    if (options.depfileTrim == true || options.depfileSort == true) {
-        depTrees = getSortedDependencies(*this, syntaxTrees, options.depfileTrim == true);
+    if (depFileOptions.depfileTrim == true || depFileOptions.depfileSort == true) {
+        depTrees = getSortedDependencies(*this, syntaxTrees, depFileOptions.depfileTrim == true);
     }
     else {
         depTrees.reserve(syntaxTrees.size());
@@ -918,20 +272,20 @@ void Driver::optionallyWriteDepFiles() {
 
     auto writeDepFile = [&](const std::vector<std::string>& paths, std::string_view fileName) {
         FormatBuffer buffer;
-        if (options.depfileTarget)
-            buffer.format("{}: ", *options.depfileTarget);
+        if (depFileOptions.depfileTarget)
+            buffer.format("{}: ", *depFileOptions.depfileTarget);
 
         for (auto& path : paths) {
             buffer.append(path);
 
             // If depfileTarget is provided the delimiter is a space, otherwise a newline.
-            if (options.depfileTarget)
+            if (depFileOptions.depfileTarget)
                 buffer.append(" ");
             else
                 buffer.append("\n");
         }
 
-        if (options.depfileTarget) {
+        if (depFileOptions.depfileTarget) {
             buffer.pop_back();
             buffer.append("\n");
         }
@@ -941,7 +295,7 @@ void Driver::optionallyWriteDepFiles() {
 
     std::vector<std::string> includePaths;
     flat_hash_set<fs::path> seenPaths;
-    if (options.includeDepfile || options.allDepfile) {
+    if (depFileOptions.includeDepfile || depFileOptions.allDepfile) {
         for (auto& tree : depTrees) {
             for (auto& inc : tree->getIncludeDirectives()) {
                 if (inc.isSystem)
@@ -953,12 +307,12 @@ void Driver::optionallyWriteDepFiles() {
             }
         }
 
-        if (options.includeDepfile)
-            writeDepFile(includePaths, *options.includeDepfile);
+        if (depFileOptions.includeDepfile)
+            writeDepFile(includePaths, *depFileOptions.includeDepfile);
     }
 
     std::vector<std::string> modulePaths;
-    if (options.moduleDepfile || options.allDepfile) {
+    if (depFileOptions.moduleDepfile || depFileOptions.allDepfile) {
         for (auto& tree : depTrees) {
             for (auto bufferId : tree->getSourceBufferIds()) {
                 auto path = sourceManager.getFullPath(bufferId);
@@ -967,146 +321,15 @@ void Driver::optionallyWriteDepFiles() {
             }
         }
 
-        if (options.moduleDepfile)
-            writeDepFile(modulePaths, *options.moduleDepfile);
+        if (depFileOptions.moduleDepfile)
+            writeDepFile(modulePaths, *depFileOptions.moduleDepfile);
     }
 
-    if (options.allDepfile) {
+    if (depFileOptions.allDepfile) {
         includePaths.insert(includePaths.end(), modulePaths.begin(), modulePaths.end());
-        writeDepFile(includePaths, *options.allDepfile);
+        writeDepFile(includePaths, *depFileOptions.allDepfile);
     }
 }
-
-bool Driver::parseAllSources() {
-    syntaxTrees = sourceLoader.loadAndParseSources(createParseOptionBag());
-    if (!reportLoadErrors())
-        return false;
-
-    Diagnostics pragmaDiags = diagEngine.setMappingsFromPragmas();
-    for (auto& diag : pragmaDiags)
-        diagEngine.issue(diag);
-
-    return true;
-}
-
-Bag Driver::createParseOptionBag() const {
-    Bag bag;
-    addParseOptions(bag);
-    return bag;
-}
-
-Bag Driver::createOptionBag() const {
-    Bag bag;
-    addParseOptions(bag);
-    addCompilationOptions(bag);
-    return bag;
-}
-
-void Driver::addParseOptions(Bag& bag) const {
-    SourceOptions soptions;
-    soptions.numThreads = options.numThreads;
-    soptions.singleUnit = options.singleUnit == true;
-    soptions.onlyLint = options.lintMode();
-    soptions.librariesInheritMacros = options.librariesInheritMacros == true;
-
-    PreprocessorOptions ppoptions;
-    ppoptions.predefines = options.defines;
-    ppoptions.undefines = options.undefines;
-    ppoptions.predefineSource = "<command-line>";
-    ppoptions.languageVersion = languageVersion;
-    if (options.maxIncludeDepth.has_value())
-        ppoptions.maxIncludeDepth = *options.maxIncludeDepth;
-    for (const auto& d : options.ignoreDirectives)
-        ppoptions.ignoreDirectives.emplace(d);
-
-    LexerOptions loptions;
-    loptions.languageVersion = languageVersion;
-    loptions.enableLegacyProtect = options.enableLegacyProtect == true;
-    if (options.maxLexerErrors.has_value())
-        loptions.maxErrors = *options.maxLexerErrors;
-
-    if (loptions.enableLegacyProtect)
-        loptions.commentHandlers["pragma"]["protect"] = {CommentHandler::Protect};
-
-    for (auto& [common, start, end] : translateOffFormats)
-        loptions.commentHandlers[common][start] = {CommentHandler::TranslateOff, end};
-
-    loptions.commentHandlers["slang"]["lint_off"] = {CommentHandler::LintOff};
-    loptions.commentHandlers["slang"]["lint_on"] = {CommentHandler::LintOn};
-    loptions.commentHandlers["slang"]["lint_save"] = {CommentHandler::LintSave};
-    loptions.commentHandlers["slang"]["lint_restore"] = {CommentHandler::LintRestore};
-
-    ParserOptions poptions;
-    poptions.languageVersion = languageVersion;
-    if (options.maxParseDepth.has_value())
-        poptions.maxRecursionDepth = *options.maxParseDepth;
-
-    bag.set(soptions);
-    bag.set(ppoptions);
-    bag.set(loptions);
-    bag.set(poptions);
-}
-
-void Driver::addCompilationOptions(Bag& bag) const {
-    CompilationOptions coptions;
-    coptions.flags = CompilationFlags::None;
-    coptions.languageVersion = languageVersion;
-    if (options.maxInstanceDepth.has_value())
-        coptions.maxInstanceDepth = *options.maxInstanceDepth;
-    if (options.maxGenerateSteps.has_value())
-        coptions.maxGenerateSteps = *options.maxGenerateSteps;
-    if (options.maxConstexprDepth.has_value())
-        coptions.maxConstexprDepth = *options.maxConstexprDepth;
-    if (options.maxConstexprSteps.has_value())
-        coptions.maxConstexprSteps = *options.maxConstexprSteps;
-    if (options.maxConstexprBacktrace.has_value())
-        coptions.maxConstexprBacktrace = *options.maxConstexprBacktrace;
-    if (options.maxInstanceArray.has_value())
-        coptions.maxInstanceArray = *options.maxInstanceArray;
-    if (options.maxUDPCoverageNotes.has_value())
-        coptions.maxUDPCoverageNotes = *options.maxUDPCoverageNotes;
-    if (options.errorLimit.has_value())
-        coptions.errorLimit = *options.errorLimit * 2;
-    if (options.minTypMax.has_value())
-        coptions.minTypMax = *options.minTypMax;
-
-    for (auto& [flag, value] : options.compilationFlags) {
-        if (value == true)
-            coptions.flags |= flag;
-    }
-
-    for (auto& name : options.topModules)
-        coptions.topModules.emplace(name);
-    for (auto& opt : options.paramOverrides)
-        coptions.paramOverrides.emplace_back(opt);
-    for (auto& lib : options.libraryOrder)
-        coptions.defaultLiblist.emplace_back(lib);
-
-    if (options.timeScale.has_value())
-        coptions.defaultTimeScale = TimeScale::fromString(*options.timeScale);
-
-    bag.set(coptions);
-}
-
-std::unique_ptr<Compilation> Driver::createCompilation() {
-    SourceLibrary* defaultLib;
-    if (options.defaultLibName && !options.defaultLibName->empty())
-        defaultLib = sourceLoader.getOrAddLibrary(*options.defaultLibName);
-    else
-        defaultLib = sourceLoader.getOrAddLibrary("work");
-
-    SLANG_ASSERT(defaultLib);
-    defaultLib->isDefault = true;
-
-    auto compilation = std::make_unique<Compilation>(createOptionBag(), defaultLib);
-    for (auto& tree : sourceLoader.getLibraryMaps())
-        compilation->addSyntaxTree(tree);
-    for (auto& tree : syntaxTrees)
-        compilation->addSyntaxTree(tree);
-
-    return compilation;
-}
-
 bool Driver::reportParseDiags() {
     Diagnostics diags;
     for (auto& tree : sourceLoader.getLibraryMaps())
@@ -1137,41 +360,6 @@ void Driver::reportCompilation(Compilation& compilation, bool quiet) {
         diagEngine.issue(diag);
 }
 
-std::unique_ptr<AnalysisManager> Driver::runAnalysis(ast::Compilation& compilation) {
-    using namespace slang::analysis;
-
-    compilation.getAllDiagnostics();
-    compilation.freeze();
-
-    AnalysisOptions ao;
-    ao.numThreads = options.numThreads.value_or(0);
-    ao.flags |= AnalysisFlags::CheckUnused;
-    if (options.maxCaseAnalysisSteps)
-        ao.maxCaseAnalysisSteps = *options.maxCaseAnalysisSteps;
-    if (options.maxLoopAnalysisSteps)
-        ao.maxLoopAnalysisSteps = *options.maxLoopAnalysisSteps;
-
-    for (auto& [flag, value] : options.analysisFlags) {
-        if (value == true)
-            ao.flags |= flag;
-    }
-
-    auto analysisManager = std::make_unique<AnalysisManager>(ao);
-
-    // We can't / shouldn't run analysis in lint-only mode.
-    // We'll just return an empty analysis manager in that case.
-    if (!options.lintMode()) {
-        analysisManager->analyze(compilation);
-
-        for (auto& diag : analysisManager->getDiagnostics(compilation.getSourceManager()))
-            diagEngine.issue(diag);
-    }
-
-    compilation.unfreeze();
-
-    return analysisManager;
-}
-
 bool Driver::reportDiagnostics(bool quiet) {
     bool hasDiagsStdout = false;
     bool succeeded = diagEngine.getNumErrors() == 0;
@@ -1179,7 +367,7 @@ bool Driver::reportDiagnostics(bool quiet) {
     if (jsonWriter)
         jsonWriter->endArray();
 
-    if (options.diagJson == "-") {
+    if (diagFormatOptions.diagJson == "-") {
         // If we're printing JSON diagnostics to stdout don't also
         // print the text diagnostics.
         hasDiagsStdout = true;
@@ -1191,7 +379,7 @@ bool Driver::reportDiagnostics(bool quiet) {
         OS::printE(diagStr);
 
         if (jsonWriter)
-            OS::writeFile(*options.diagJson, jsonWriter->view());
+            OS::writeFile(*diagFormatOptions.diagJson, jsonWriter->view());
     }
 
     if (!quiet) {
@@ -1217,103 +405,6 @@ bool Driver::runFullCompilation(bool quiet) {
     reportCompilation(*compilation, quiet);
     runAnalysis(*compilation);
     return reportDiagnostics(quiet);
-}
-
-bool Driver::parseUnitListing(std::string_view text) {
-    CommandLine unitCmdLine;
-    std::vector<std::string> includes;
-    unitCmdLine.add("-I,--include-directory,+incdir", includes, "", "",
-                    CommandLineFlags::CommaList);
-
-    std::vector<std::string> defines;
-    unitCmdLine.add("-D,--define-macro,+define", defines, "");
-
-    std::optional<std::string> libraryName;
-    unitCmdLine.add("--library", libraryName, "");
-
-    unitCmdLine.add(
-        "-C",
-        [this](std::string_view value) {
-            processCommandFiles(value, /* makeRelative */ true, /* separateUnit */ true);
-            return "";
-        },
-        "", "", CommandLineFlags::CommaList);
-
-    std::vector<std::string> files;
-    unitCmdLine.setPositional(
-        [&](std::string_view value) {
-            if (!options.excludeExts.empty()) {
-                if (size_t extIndex = value.find_last_of('.'); extIndex != std::string_view::npos) {
-                    if (options.excludeExts.count(std::string(value.substr(extIndex + 1))))
-                        return "";
-                }
-            }
-
-            files.push_back(std::string(value));
-            return "";
-        },
-        "");
-
-    CommandLine::ParseOptions parseOpts;
-    parseOpts.expandEnvVars = true;
-    parseOpts.ignoreProgramName = true;
-    parseOpts.supportComments = true;
-    parseOpts.ignoreDuplicates = true;
-
-    if (!unitCmdLine.parse(text, parseOpts)) {
-        for (auto& err : unitCmdLine.getErrors())
-            OS::printE(fmt::format("{}\n", err));
-        return false;
-    }
-
-    sourceLoader.addSeparateUnit(files, includes, std::move(defines),
-                                 std::move(libraryName).value_or(std::string()));
-
-    return true;
-}
-
-void Driver::addLibraryFiles(std::string_view pattern) {
-    // Parse the pattern; there's an optional leading library name
-    // followed by an equals sign. If not there, we use the default
-    // library (represented by the empty string).
-    std::string_view libraryName;
-    auto index = pattern.find_first_of('=');
-    if (index != std::string_view::npos) {
-        libraryName = pattern.substr(0, index);
-        pattern = pattern.substr(index + 1);
-    }
-    sourceLoader.addLibraryFiles(libraryName, pattern);
-}
-
-bool Driver::reportLoadErrors() {
-    if (auto errors = sourceLoader.getErrors(); !errors.empty()) {
-        for (auto& err : errors)
-            printError(err);
-        return false;
-    }
-    return true;
-}
-
-void Driver::printError(const std::string& message) {
-    OS::printE(fg(textDiagClient->errorColor), "error: ");
-    OS::printE(message);
-    OS::printE("\n");
-}
-
-void Driver::printWarning(const std::string& message) {
-    OS::printE(fg(textDiagClient->warningColor), "warning: ");
-    OS::printE(message);
-    OS::printE("\n");
-}
-
-void Driver::printNote(const std::string& message) {
-    OS::printE(fg(textDiagClient->noteColor), "  note: ");
-    OS::printE(message);
-    OS::printE("\n");
-}
-
-bool Driver::Options::lintMode() const {
-    return compilationFlags.at(CompilationFlags::LintMode) == true;
 }
 
 } // namespace slang::driver

--- a/tests/unittests/DriverTests.cpp
+++ b/tests/unittests/DriverTests.cpp
@@ -50,12 +50,12 @@ TEST_CASE("Driver valid column unit") {
     const char* argv1[] = {"testfoo", "--diag-column-unit=byte", filePath.c_str()};
     CHECK(driver.parseCommandLine(3, argv1));
     CHECK(driver.processOptions());
-    CHECK(driver.options.diagColumnUnit == ColumnUnit::Byte);
+    CHECK(driver.diagFormatOptions.diagColumnUnit == ColumnUnit::Byte);
 
     const char* argv2[] = {"testfoo", "--diag-column-unit=display", filePath.c_str()};
     CHECK(driver.parseCommandLine(3, argv2));
     CHECK(driver.processOptions());
-    CHECK(driver.options.diagColumnUnit == ColumnUnit::Display);
+    CHECK(driver.diagFormatOptions.diagColumnUnit == ColumnUnit::Display);
 }
 
 TEST_CASE("Driver invalid column unit") {
@@ -789,8 +789,8 @@ TEST_CASE("Driver basic dependency pruning") {
     auto treeD = SyntaxTree::fromText("module moduleD; /* independent */ endmodule\n",
                                       driver.sourceManager, "source"sv, "moduleD.sv"sv);
 
-    driver.options.allDepfile = "-";
-    driver.options.depfileTrim = true;
+    driver.depFileOptions.allDepfile = "-";
+    driver.depFileOptions.depfileTrim = true;
     driver.syntaxTrees.push_back(treeA);
     driver.syntaxTrees.push_back(treeB);
     driver.syntaxTrees.push_back(treeC);
@@ -822,8 +822,8 @@ TEST_CASE("Driver basic dependency pruning") {
     // Test case 3: just sorting, no trimming
     {
         driver.options.topModules.clear();
-        driver.options.depfileTrim = false;
-        driver.options.depfileSort = true;
+        driver.depFileOptions.depfileTrim = false;
+        driver.depFileOptions.depfileSort = true;
 
         auto guard = OS::captureOutput();
         driver.optionallyWriteDepFiles();
@@ -836,7 +836,7 @@ TEST_CASE("Driver basic dependency pruning") {
     {
         driver.options.topModules.clear();
         driver.options.topModules.push_back("unknownModule");
-        driver.options.depfileTrim = true;
+        driver.depFileOptions.depfileTrim = true;
 
         auto guard = OS::captureOutput();
         driver.optionallyWriteDepFiles();
@@ -856,8 +856,8 @@ TEST_CASE("Driver deplist circular dependency handling") {
     auto treeCycleB = SyntaxTree::fromText("module cycleB; cycleA ca(); endmodule\n",
                                            driver.sourceManager, "source"sv, "cycleB.sv"sv);
 
-    driver.options.allDepfile = "-";
-    driver.options.depfileTrim = true;
+    driver.depFileOptions.allDepfile = "-";
+    driver.depFileOptions.depfileTrim = true;
     driver.syntaxTrees.push_back(treeCycleA);
     driver.syntaxTrees.push_back(treeCycleB);
 
@@ -883,8 +883,8 @@ TEST_CASE("Driver deplist partial dependency tree") {
     auto treeTop = SyntaxTree::fromText("module top; mid m(); endmodule\n", driver.sourceManager,
                                         "source"sv, "top.sv"sv);
 
-    driver.options.allDepfile = "-";
-    driver.options.depfileTrim = true;
+    driver.depFileOptions.allDepfile = "-";
+    driver.depFileOptions.depfileTrim = true;
     driver.syntaxTrees.push_back(treeLeafA);
     driver.syntaxTrees.push_back(treeLeafB);
     driver.syntaxTrees.push_back(treeMid);
@@ -906,8 +906,8 @@ TEST_CASE("Driver deplist missing dependencies") {
     auto treeA = SyntaxTree::fromText("module moduleA; missingModule m(); endmodule\n",
                                       driver.sourceManager, "source"sv, "moduleA.sv"sv);
 
-    driver.options.allDepfile = "-";
-    driver.options.depfileTrim = true;
+    driver.depFileOptions.allDepfile = "-";
+    driver.depFileOptions.depfileTrim = true;
     driver.syntaxTrees.push_back(treeA);
 
     driver.options.topModules.push_back("moduleA");
@@ -925,8 +925,8 @@ TEST_CASE("Driver deplist missing top modules") {
     auto treeA = SyntaxTree::fromText("module moduleA; missingModule m(); endmodule\n",
                                       driver.sourceManager, "source"sv, "moduleA.sv"sv);
 
-    driver.options.allDepfile = "-";
-    driver.options.depfileTrim = true;
+    driver.depFileOptions.allDepfile = "-";
+    driver.depFileOptions.depfileTrim = true;
     driver.syntaxTrees.push_back(treeA);
 
     auto guard = OS::captureOutput();

--- a/tests/unittests/parsing/DiagnosticTests.cpp
+++ b/tests/unittests/parsing/DiagnosticTests.cpp
@@ -419,6 +419,8 @@ TEST_CASE("DiagnosticEngine stuff") {
             lastMessage = diag.formattedMessage;
             lastSeverity = diag.severity;
         }
+
+        void reportMessage(DiagnosticSeverity, const std::string&) override {}
     };
 
     DiagnosticEngine engine(getSourceManager());

--- a/tools/driver/slang_main.cpp
+++ b/tools/driver/slang_main.cpp
@@ -182,8 +182,8 @@ int driverMain(int argc, TArgs argv) {
         }
 
         if ((onlyPreprocess || onlyMacros) &&
-            (driver.options.includeDepfile || driver.options.moduleDepfile ||
-             driver.options.allDepfile)) {
+            (driver.depFileOptions.includeDepfile || driver.depFileOptions.moduleDepfile ||
+             driver.depFileOptions.allDepfile)) {
             driver.printError(
                 "cannot use dependency file options with --preprocess or --macros-only");
             return 3;


### PR DESCRIPTION
This will allow non-text based clients to:
  - receive errors from the driver
  - Not add cli options specific to text formatting,  json output, or depfiles
  - Not instantiate text or json diag clients and have the engine spend runtime sending to those clients.
 
The constructor takes a single diagnostics client to ensure at least one client is seeing the cli parse errors.

In a followup pr, the json client will be amended  to emit these parse errors in its output.

This was done in two commits to more easily verify the split. The diff is best viewed from the second commit