### PR TITLE
Install boost_concurrent if Boost is not found

### DIFF
--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -243,6 +243,7 @@ if(SLANG_INCLUDE_INSTALL)
       COMPONENT slang_Development)
     install(
       FILES ${PROJECT_SOURCE_DIR}/external/boost_unordered.hpp
+            ${PROJECT_SOURCE_DIR}/external/boost_concurrent.hpp
       DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
       COMPONENT slang_Development)
   endif()


### PR DESCRIPTION
If you are interested, I can try to add a CMake target that runs a simple program with the installed files similar to what simdjson is doing https://github.com/simdjson/simdjson/blob/0112be86b0dec7fd979d10f0cf405c1197181769/tests/installation_tests/find/CMakeLists.txt