### PR TITLE
Add Verilog compatibility option

### DIFF
--- a/bindings/python/CompBindings.cpp
+++ b/bindings/python/CompBindings.cpp
@@ -170,6 +170,7 @@ void registerCompilation(py::module_& m) {
         .def_readwrite("ignoreDuplicates", &CommandLine::ParseOptions::ignoreDuplicates);
 
     py::native_enum<LanguageVersion>(m, "LanguageVersion", "enum.Enum")
+        .value("v1364_2005", LanguageVersion::v1364_2005)
         .value("v1800_2017", LanguageVersion::v1800_2017)
         .value("v1800_2023", LanguageVersion::v1800_2023)
         .value("Default", LanguageVersion::Default)

--- a/docs/command-line-ref.dox
+++ b/docs/command-line-ref.dox
@@ -17,12 +17,15 @@ Display slang version information and exit.
 
 Don't print non-essential output status.
 
-`--std (1800-2017 | 1800-2023 | latest)`
+`--std (1364-2005 | 1800-2017 | 1800-2023 | latest)`
 
-Sets the version of the SystemVerilog language to use. This changes how the code is parsed
+Sets the version of the Verilog or SystemVerilog language to use. This changes how the code is parsed
 and elaborated and which language features are available to use. The current default is
 1800-2017, though this may change in the future. Using "latest" will use the latest available
 version, currently 1800-2023.
+
+The 1364-2005 option is provided for compatibility with Verilog. Setting it does not disable all
+SystemVerilog features and as such the option isn't suitable for linting.
 
 `positional arguments`
 

--- a/include/slang/util/LanguageVersion.h
+++ b/include/slang/util/LanguageVersion.h
@@ -11,11 +11,13 @@
 
 namespace slang {
 
-/// Specifies SystemVerilog language versions.
-enum class LanguageVersion { v1800_2017, v1800_2023, Default = v1800_2017 };
+/// Specifies Verilog/SystemVerilog language versions.
+enum class LanguageVersion { v1364_2005, v1800_2017, v1800_2023, Default = v1800_2017 };
 
 inline std::string_view toString(LanguageVersion lv) {
     switch (lv) {
+        case LanguageVersion::v1364_2005:
+            return "1364-2005";
         case LanguageVersion::v1800_2017:
             return "1800-2017";
         case LanguageVersion::v1800_2023:

--- a/source/driver/Driver.cpp
+++ b/source/driver/Driver.cpp
@@ -78,8 +78,8 @@ Driver::~Driver() = default;
 
 void Driver::addStandardArgs() {
     cmdLine.add("--std", options.languageVersion,
-                "The version of the SystemVerilog language to use",
-                "(1800-2017 | 1800-2023 | latest)");
+                "The version of the Verilog or SystemVerilog language to use",
+                "(1364-2005 | 1800-2017 | 1800-2023 | latest)");
 
     // Include paths
     cmdLine.add(
@@ -531,7 +531,9 @@ bool Driver::processOptions() {
     }
 
     if (options.languageVersion.has_value()) {
-        if (options.languageVersion == "1800-2017")
+        if (options.languageVersion == "1364-2005")
+            languageVersion = LanguageVersion::v1364_2005;
+        else if (options.languageVersion == "1800-2017")
             languageVersion = LanguageVersion::v1800_2017;
         else if (options.languageVersion == "1800-2023" || options.languageVersion == "latest")
             languageVersion = LanguageVersion::v1800_2023;

--- a/source/parsing/LexerFacts.cpp
+++ b/source/parsing/LexerFacts.cpp
@@ -665,6 +665,8 @@ SyntaxKind LexerFacts::getDirectiveKind(std::string_view directive, bool enableL
 
 KeywordVersion LexerFacts::getDefaultKeywordVersion(LanguageVersion languageVersion) {
     switch (languageVersion) {
+        case LanguageVersion::v1364_2005:
+            return KeywordVersion::v1364_2005;
         case LanguageVersion::v1800_2017:
             return KeywordVersion::v1800_2017;
         case LanguageVersion::v1800_2023:


### PR DESCRIPTION
Currently this disables all keywords which were introduced in the 2005 SystemVerilog standard and later. Other semantic differences need to be addressed as they are found.

So far the closest I found to a semantic difference between SV and Verilog is the following (6.4. in 1800-2005):

> In Verilog, an initialization value specified as part of the declaration is executed as if the assignment were
made from an initial block, after simulation has started. In SystemVerilog, setting the initial value of a
static variable as part of the variable declaration (including static class members) shall occur before any
initial or always blocks are started.

which I believe doesn't matter for slang.

Closes #1568