### PR TITLE
Fix parseTimingControl for struct assignment

### DIFF
--- a/include/slang/parsing/Parser.h
+++ b/include/slang/parsing/Parser.h
@@ -57,9 +57,12 @@ enum class ExpressionOptions {
     AllowDist = 1 << 7,
 
     /// Attribute instances are disallowed in expression context.
-    DisallowAttrs = 1 << 8
+    DisallowAttrs = 1 << 8,
+
+    /// Assignment patterns are disallowed in this context.
+    DisallowPatterns = 1 << 9
 };
-SLANG_BITMASK(ExpressionOptions, DisallowAttrs)
+SLANG_BITMASK(ExpressionOptions, DisallowPatterns)
 
 /// Various options for parsing names.
 enum class NameOptions {

--- a/tests/unittests/ast/StatementTests.cpp
+++ b/tests/unittests/ast/StatementTests.cpp
@@ -679,6 +679,35 @@ endmodule
     NO_COMPILATION_ERRORS;
 }
 
+TEST_CASE("Intra-assignment timing control with assignment pattern") {
+    auto tree = SyntaxTree::fromText(R"(
+module m;
+    typedef struct packed {
+        logic one;
+        logic two;
+        logic three;
+        logic four;
+    } protocol_t;
+
+    parameter TP = 1;
+    logic clk_i;
+    logic reset_ni;
+    protocol_t proto_i, proto_o;
+
+    always_ff @(posedge clk_i or negedge reset_ni) begin
+        if (!reset_ni)
+            proto_o <= #TP '{ default: '0, one: 1'b1 };
+        else
+            proto_o <= #TP proto_i;
+    end
+endmodule
+)");
+
+    Compilation compilation;
+    compilation.addSyntaxTree(tree);
+    NO_COMPILATION_ERRORS;
+}
+
 TEST_CASE("Intra-assignment timing control errors") {
     auto tree = SyntaxTree::fromText(R"(
 module m;


### PR DESCRIPTION
This commit prevents parseTimingControl greedily eating a struct assignment of the form '{} following a #t timing delay.