### PR TITLE
Remove recently added extends clauses from parser metadata references

### DIFF
--- a/source/parsing/ParserMetadata.cpp
+++ b/source/parsing/ParserMetadata.cpp
@@ -206,14 +206,6 @@ void ParserMetadata::visitReferencedSymbols(function_ref<void(std::string_view)>
             func(name);
     }
 
-    for (auto classDecl : classDecls) {
-        if (classDecl->extendsClause) {
-            auto name = classDecl->extendsClause->getFirstToken().valueText();
-            if (!name.empty())
-                func(name);
-        }
-    }
-
     for (auto importDecl : packageImports) {
         for (auto importItem : importDecl->items) {
             std::string_view name = importItem->package.valueText();


### PR DESCRIPTION
Removing for now, as we most likely will not need this.