### PR TITLE
[fix] use `fs::weakly_canonical` for path normalization on windows

### DIFF
--- a/source/text/SourceManager.cpp
+++ b/source/text/SourceManager.cpp
@@ -393,7 +393,7 @@ SourceBuffer SourceManager::assignBuffer(std::string_view bufferPath, SmallVecto
     fs::path path(bufferPath);
 #ifdef _WIN32
     // this is necessary on windows because fs::path::string returns a backslashed `\\` path.
-    // however weakly_canonical returns a forward slashed `/` path. If we don't do this then 
+    // however weakly_canonical returns a forward slashed `/` path. If we don't do this then
     // it conflicts with the other uses of weakly_canonical (namely in `isCached` and `openCache`)
     auto pathStr = getU8Str(fs::weakly_canonical(path));
 #else


### PR DESCRIPTION
`SourceManager::openCached` and `SourceManager::isCached` both use `weakly_canonical` for the path resolution. On windows, weakly canonical will change a path that uses `\\` to one that uses `/`. Thus, there's a mismatch between these two functions and `assignBuffer` when they go to assign/lookup in the `lookupCache` (since `fs::path::string` returns a backward slashed string).

Both `openCached` and `isCached` functions use `weakly_canonical(path, ec)`. I chose not to implement the error code (as done in the two aforementioned functions) since its unnecessary (the path doesn't exist yet and if it does then its caught a few lines down) and doing so would require a change in the return type and thus public API.

Thanks,
Evan