### PR TITLE
[compat][allow-use-before-declare] Add support for parameters and emit a warning instead of error or nothing

### DIFF
--- a/docs/command-line-ref.dox
+++ b/docs/command-line-ref.dox
@@ -484,12 +484,15 @@ rules about assigning to lvalues with loop indices used to select subsets of a v
 
 @section compat-option Compatibility
 
-`--compat vcs|all`
+`--compat vcs|vivado|yosys|all`
 
 Attempt to increase compatibility with the specified tool. Various options will
 be set and some warnings will be silenced to mimic the given tool as closely as possible.
-Supported values are 'vcs' to match compatibility with Synopsys VCS, and 'all' to enable
-all possible compatibility options included with slang.
+Supported values are:
+ - 'vcs' to match compatibility with Synopsys VCS
+ - 'vivado' to match compatibility with AMD Vivado
+ - 'yosys' to match compatibility with Yosys logic synthesis tool
+ - 'all' to enable all possible compatibility options included with slang.
 
 `--allow-use-before-declare`
 

--- a/include/slang/driver/Driver.h
+++ b/include/slang/driver/Driver.h
@@ -50,7 +50,7 @@ enum class AnalysisFlags;
 
 namespace slang::driver {
 
-#define COMPAT(x) x(Vcs) x(All)
+#define COMPAT(x) x(Vcs) x(Vivado) x(Yosys) x(All)
 SLANG_ENUM(CompatMode, COMPAT)
 #undef COMPAT
 

--- a/scripts/diagnostics.txt
+++ b/scripts/diagnostics.txt
@@ -932,7 +932,6 @@ error ImportNameCollision "import of '{}' collides with an existing declaration"
 error UndeclaredIdentifier "use of undeclared identifier '{}'"
 error TypoIdentifier "use of undeclared identifier '{}'; did you mean '{}'?"
 error UnknownClassOrPackage "unknown class or package '{}'"
-error UsedBeforeDeclared "identifier '{}' used before its declaration"
 error NotAType "'{}' is not a type"
 error NotAValue "'{}' cannot be used in an expression"
 error NotAHierarchicalScope "cannot use dot operator on '{}'; it is not a variable or hierarchical scope"
@@ -991,6 +990,7 @@ error CompilationUnitFromPackage "cannot reference compilation unit item from wi
 error InvalidHierarchicalIfacePortConn "cannot connect interface port hierarchically through a generate block or instance array"
 error UnnamedGenerateReference "cannot reference unnamed generate block via external name '{}' (use --allow-genblk-reference to allow this)"
 warning unknown-sys-name UnknownSystemName "unknown system name '{}'"
+warning used-before-declared UsedBeforeDeclared "identifier '{}' used before its declaration"
 warning dup-import DuplicateImport "duplicate import declaration is redundant"
 warning duplicate-definition DuplicateDefinition "duplicate definition of '{}'"
 
@@ -1228,7 +1228,7 @@ group default = { real-underflow real-overflow vector-overflow int-overflow unco
                   negative-timing-limit bad-procedural-force duplicate-defparam implicit-port-type-mismatch
                   split-distweight-op dpi-pure-task multibit-edge unknown-sys-name unknown-library
                   dup-config-rule unused-config-cell unused-config-instance specify-condition-expr
-                  seq-no-match case-too-complex nested-solve-before dynamic-non-procedural }
+                  seq-no-match case-too-complex nested-solve-before dynamic-non-procedural used-before-declared }
 
 group extra = { empty-member empty-stmt dup-import pointless-void-cast case-gen-none case-gen-dup
                 unused-result format-real ignored-slice task-ignored width-trunc dup-attr event-const

--- a/scripts/warning_docs.txt
+++ b/scripts/warning_docs.txt
@@ -1276,6 +1276,16 @@ module m;
 endmodule
 ```
 
+-Wused-before-declared
+A variable or parameter is used but declared later. This is not allowed in SystemVerilog
+but can be downgraded to a warning for compatibility with other tools.
+```
+module m();
+    parameter A = B;
+    parameter B = 1;
+endmodule
+```
+
 @category Macros
 
 -Wignored-macro-paste

--- a/source/driver/Driver.cpp
+++ b/source/driver/Driver.cpp
@@ -558,7 +558,7 @@ bool Driver::processOptions() {
             compFlags = vcsCompFlags;
             analysisFlags = vcsAnalysisFlags;
         }
-        else {
+        else if (options.compat != CompatMode::Vivado && options.compat != CompatMode::Yosys) {
             compFlags = allCompFlags;
             analysisFlags = allAnalysisFlags;
         }
@@ -668,6 +668,10 @@ bool Driver::processOptions() {
         diagEngine.setSeverity(diag::BadProceduralForce, DiagnosticSeverity::Error);
         diagEngine.setSeverity(diag::UnknownSystemName, DiagnosticSeverity::Error);
     }
+
+    if (options.compat != CompatMode::Vivado && options.compat != CompatMode::Yosys &&
+        options.compat != CompatMode::All)
+        diagEngine.setSeverity(diag::UsedBeforeDeclared, DiagnosticSeverity::Error);
 
     if (options.compat == CompatMode::Vcs || options.compat == CompatMode::All) {
         diagEngine.setSeverity(diag::StaticInitializerMustBeExplicit, DiagnosticSeverity::Ignored);

--- a/tests/unittests/DriverTests.cpp
+++ b/tests/unittests/DriverTests.cpp
@@ -936,6 +936,38 @@ TEST_CASE("Driver deplist missing top modules") {
     CHECK(stderrContains("warning: using --depfile-trim with no top modules"));
 }
 
+TEST_CASE("Driver compat vivado") {
+    auto testDir = findTestDir();
+
+    {
+        Driver driver;
+        driver.addStandardArgs();
+        auto guard = OS::captureOutput();
+        // Check compatibility with parameters which are used before declared
+        auto args = fmt::format("testfoo \"{0}test8.sv\" --compat=vivado", testDir);
+        CHECK(driver.parseCommandLine(args));
+        CHECK(driver.processOptions());
+        CHECK(driver.parseAllSources());
+        CHECK(driver.runFullCompilation());
+        CHECK(stdoutContains("Build succeeded"));
+        CHECK(stdoutContains("0 errors, 10 warnings"));
+    }
+
+    {
+        Driver driver;
+        driver.addStandardArgs();
+        auto guard = OS::captureOutput();
+        // Check compatibility on parameters usage with self-dependancy errors
+        auto args = fmt::format("testfoo \"{0}test9.sv\" --compat=vivado", testDir);
+        CHECK(driver.parseCommandLine(args));
+        CHECK(driver.processOptions());
+        CHECK(driver.parseAllSources());
+        CHECK(!driver.runFullCompilation());
+        CHECK(stdoutContains("Build failed"));
+        CHECK(stdoutContains("7 errors, 8 warnings"));
+    }
+}
+
 TEST_CASE("Driver compat mode all") {
     auto guard = OS::captureOutput();
 

--- a/tests/unittests/FileTests.cpp
+++ b/tests/unittests/FileTests.cpp
@@ -127,7 +127,8 @@ static void globAndCheck(const fs::path& basePath, std::string_view pattern, Glo
 TEST_CASE("File globbing") {
     auto testDir = findTestDir();
     globAndCheck(testDir, "*st?.sv", GlobMode::Files, GlobRank::WildcardName, {},
-                 {"test2.sv", "test3.sv", "test4.sv", "test5.sv", "test6.sv", "test7.sv"});
+                 {"test2.sv", "test3.sv", "test4.sv", "test5.sv", "test6.sv", "test7.sv",
+                  "test8.sv", "test9.sv"});
     globAndCheck(testDir, "system", GlobMode::Files, GlobRank::ExactPath,
                  make_error_code(std::errc::is_a_directory), {});
     globAndCheck(testDir, "system/", GlobMode::Files, GlobRank::Directory, {},

--- a/tests/unittests/ast/LookupTests.cpp
+++ b/tests/unittests/ast/LookupTests.cpp
@@ -1972,7 +1972,7 @@ task t;
     x = 5 + $unit::b; // illegal - $unit adds no special forward referencing
 endtask
 
-bit b;
+int b;
 )");
 
     Compilation compilation;

--- a/tests/unittests/data/test8.sv
+++ b/tests/unittests/data/test8.sv
@@ -1,0 +1,35 @@
+module paramTest1 ();
+    parameter P = P1;
+    parameter P1 = 1;
+    wire p = w;
+    wire w = 1;
+
+    specparam tAC = tBC;
+    specparam tBC = 10;
+endmodule
+
+module paramTest2 #(parameter W = WIDTH) ();
+    parameter WIDTH = BITS * 2;
+    localparam BITS = (DEPTH * DEPTH) - 1;
+    parameter DEPTH = 2;
+endmodule
+
+module paramTest3(input logic [3-1:0] a, logic [$bits(a)-1:0] b);
+    logic [3:0] c;
+    function int foo;
+        return $bits(b);
+    endfunction
+    parameter W = $bits(c) + foo();
+    parameter C = W + foo();
+endmodule
+
+module paramTest4(input logic [C-1:0] a, logic [$bits(a)-1:0] b);
+    logic [3:0] c;
+    function int foo;
+        parameter W = C;
+        return $bits(b) + W;
+    endfunction
+    parameter W = $bits(c) + foo();
+    parameter A = C + W;
+    parameter C = 1;
+endmodule

--- a/tests/unittests/data/test9.sv
+++ b/tests/unittests/data/test9.sv
@@ -1,0 +1,33 @@
+module paramTest1 ();
+    parameter P = P;
+endmodule
+
+module paramTest2 ();
+    parameter P = P1;
+    parameter P1 = P;
+endmodule
+
+module paramTest3 #(parameter W = WIDTH) ();
+    parameter WIDTH = BITS * W;
+    localparam BITS = (WIDTH * DEPTH) - 1;
+    parameter DEPTH = 2;
+endmodule
+
+module paramTest4(input logic [W-1:0] a, logic [$bits(a)-1:0] b);
+    logic [3:0] c;
+    function int foo;
+        return $bits(b);
+    endfunction
+    parameter W = $bits(c) + foo();
+endmodule
+
+module paramTest5(input logic [W-1:0] a, logic [$bits(a)-1:0] b);
+    logic [3:0] c;
+    function int foo;
+        parameter W = C;
+        return $bits(b) + W;
+    endfunction
+    parameter W = $bits(c) + foo();
+
+    parameter C = W + foo();
+endmodule


### PR DESCRIPTION
Hi, @MikePopoloski 

Currently, this PR may not fully address the issue (https://github.com/MikePopoloski/slang/issues/1611), and therefore may not be ready for closure. There are several aspects that are still unclear to me, and I would appreciate feedback based on your experience.

Current state:

1. I observed that `Xilinx Vivado` emits a warning for use-before-declaration of parameters and variables, rather than an error (or no diagnostic at all), whereas slang currently emits nothing unless the `--allow-use-before-declare` option is enabled.
2. Based on this observation, I chose to make slang emit a warning when `--allow-use-before-declare` is enabled, instead of remaining silent. At this point, this is not implemented as a dedicated warning category (e.g. `-W…`), since it is still unclear whether emitting a warning is the right behavior, or whether emitting nothing would be preferable - You can help with clarification of this for me.
3.  I disabled the `--allow-use-before-declare` compiler flag by default for `VCS` compatibility. In my testing with variables and nets, `VCS` reports errors for such cases. This change can be reverted if you prefer a different default.
4. I added an explicit check for self-dependent parameters when the option is enabled and tested it on several examples involving self-referential parameter definitions. I believe having a dedicated check for this case improves usability when --allow-use-before-declare is in effect.
5. I did not add a separate tool-compatibility mode (e.g. for `Vivado` or `Yosys`), as I assumed the behavior could be sufficiently controlled via the `--allow-use-before-declare` option. However, I can add such compatibility options if you think they are necessary.