### PR TITLE
Add maybe_uknown attribute for module instantiations.

### DIFF
--- a/docs/command-line-ref.dox
+++ b/docs/command-line-ref.dox
@@ -671,6 +671,7 @@ disable the limit. The default is 64.
 `--ignore-unknown-modules`
 
 Don't issue an error for instantiations of unknown modules, interface, and programs.
+Alternatively, selected instantiations of unknown modules can be ignore with the `(* maybe_unknown *)` attribute.
 
 `--disallow-refs-to-unknown-instances`
 

--- a/include/slang/ast/Compilation.h
+++ b/include/slang/ast/Compilation.h
@@ -406,9 +406,11 @@ public:
     DefinitionLookupResult tryGetDefinition(std::string_view name, const Scope& scope) const;
 
     /// Gets the definition with the given name, or nullptr if there is no such definition.
-    /// If no definition is found an appropriate diagnostic will be issued.
-    DefinitionLookupResult getDefinition(std::string_view name, const Scope& scope,
-                                         SourceRange sourceRange, DiagCode code) const;
+    /// If no definition is found an appropriate diagnostic will be issued, unless the
+    /// instantiation has a maybe_unknown attribute.
+    DefinitionLookupResult getDefinition(
+        std::string_view name, const Scope& scope, SourceRange sourceRange, DiagCode code,
+        std::span<syntax::AttributeInstanceSyntax* const> attributes = {}) const;
 
     /// Gets the definition indicated by the given config rule, or nullptr if it does not exist.
     /// If no definition is found an appropriate diagnostic will be issued.

--- a/source/ast/Compilation.cpp
+++ b/source/ast/Compilation.cpp
@@ -616,12 +616,18 @@ static Token getExternNameToken(const SyntaxNode& sn) {
                                                    : sn.as<ExternUdpDeclSyntax>().name;
 }
 
-Compilation::DefinitionLookupResult Compilation::getDefinition(std::string_view name,
-                                                               const Scope& scope,
-                                                               SourceRange sourceRange,
-                                                               DiagCode code) const {
+Compilation::DefinitionLookupResult Compilation::getDefinition(
+    std::string_view name, const Scope& scope, SourceRange sourceRange, DiagCode code,
+    std::span<syntax::AttributeInstanceSyntax* const> attributes) const {
     if (auto result = tryGetDefinition(name, scope); result.definition)
         return result;
+
+    for (auto attrInst : attributes) {
+        for (auto spec : attrInst->specs) {
+            if (spec->name.valueText() == "maybe_unknown"sv)
+                return {};
+        }
+    }
 
     errorMissingDef(name, scope, sourceRange, code);
     return {};

--- a/source/ast/symbols/InstanceSymbols.cpp
+++ b/source/ast/symbols/InstanceSymbols.cpp
@@ -718,7 +718,7 @@ void InstanceSymbol::fromSyntax(Compilation& comp, const HierarchyInstantiationS
 
     // Simple case: look up the definition and create all instances in one go.
     auto defResult = comp.getDefinition(defName, *context.scope, syntax.type.range(),
-                                        diag::UnknownModule);
+                                        diag::UnknownModule, syntax.attributes);
     createInstances(defResult, nullptr);
 }
 

--- a/tests/unittests/ast/HierarchyTests.cpp
+++ b/tests/unittests/ast/HierarchyTests.cpp
@@ -2128,6 +2128,28 @@ endmodule
     NO_COMPILATION_ERRORS;
 }
 
+TEST_CASE("maybe_unknown attribute suppresses unknown module errors") {
+    auto tree = SyntaxTree::fromText(R"(
+module top;
+    // This should error - unknown module without attribute
+    unknown_ip u1();
+
+    // This should NOT error - has maybe_unknown attribute
+    (* maybe_unknown *) unknown_ip2 u2();
+
+    // This should also work with multiple attributes
+    (* other_attr, maybe_unknown *) unknown_ip3 u3();
+endmodule
+)");
+
+    Compilation compilation;
+    compilation.addSyntaxTree(tree);
+
+    auto& diags = compilation.getAllDiagnostics();
+    REQUIRE(diags.size() == 1);
+    CHECK(diags[0].code == diag::UnknownModule);
+}
+
 TEST_CASE("Package ordering dependency 1 -- GH #1424") {
     auto tree = SyntaxTree::fromText(R"(
 package A_pkg;


### PR DESCRIPTION
This is preferred to a cli flag because:
- IP cores defined outside of sv are typically instantiated once in a wrapper, so just one of these attributes is needed per module.
- Many designs can reference the ip core / wrapper, so the selective ignore would have to be duplicated across those builds and specified in the build info.