### PR TITLE
tidy: AlwaysFFAssignment test wasn't returning its proper diag

### DIFF
--- a/tools/tidy/src/synthesis/AlwaysFFAssignmentOutsideConditional.cpp
+++ b/tools/tidy/src/synthesis/AlwaysFFAssignmentOutsideConditional.cpp
@@ -96,7 +96,7 @@ public:
         return diagnostics.empty();
     }
 
-    DiagCode diagCode() const override { return diag::RegisterNotAssignedOnReset; }
+    DiagCode diagCode() const override { return diag::AlwaysFFAssignmentOutsideConditional; }
 
     std::string diagString() const override {
         return "register '{}' has an assignment outside a conditional block with reset. Consider "


### PR DESCRIPTION
Minor fix on existing test (using proper diag).