### PR TITLE
Allow implicit extern or pure function return in vcs compat mode

### DIFF
--- a/source/parsing/Parser_members.cpp
+++ b/source/parsing/Parser_members.cpp
@@ -1414,6 +1414,7 @@ MemberSyntax* Parser::parseClassMember(bool isIfaceClass, bool hasBaseClass) {
 
         // Pure or extern functions don't have bodies.
         if (isPureOrExtern) {
+            funcOptions |= FunctionOptions::AllowImplicitReturn;
             auto& proto = parseFunctionPrototype(SyntaxKind::ClassDeclaration,
                                                  funcOptions | FunctionOptions::IsPrototype);
             checkProto(proto, false);

--- a/tests/unittests/parsing/MemberParsingTests.cpp
+++ b/tests/unittests/parsing/MemberParsingTests.cpp
@@ -181,6 +181,22 @@ endfunction : new
     CHECK_DIAGNOSTICS_EMPTY;
 }
 
+TEST_CASE("Extern/Pure implicit function parsing") {
+    auto& text = R"(
+module memMod();
+    class C;
+        extern static function f();
+    endclass
+
+    function C::f();
+    endfunction
+endmodule
+)";
+
+    parseCompilationUnit(text);
+    CHECK_DIAGNOSTICS_EMPTY;
+}
+
 TEST_CASE("Property declarations") {
     auto& text = R"(
 property p3;


### PR DESCRIPTION
VCS allows the same.