### PR TITLE
Allow implicit conversion from integral to string for methods

### DIFF
--- a/source/ast/expressions/ConversionExpression.cpp
+++ b/source/ast/expressions/ConversionExpression.cpp
@@ -98,6 +98,11 @@ bool Expression::isImplicitlyAssignableTo(Compilation& compilation, const Type& 
         return true;
     }
 
+    if (targetType.isString() && type->isIntegral() &&
+        compilation.hasFlag(CompilationFlags::RelaxStringConversions)) {
+        return true;
+    }
+
     return false;
 }
 

--- a/tests/unittests/ast/TypeTests.cpp
+++ b/tests/unittests/ast/TypeTests.cpp
@@ -2187,6 +2187,33 @@ endmodule
     NO_COMPILATION_ERRORS;
 }
 
+TEST_CASE("Implicit string conversion for methods compat flag") {
+    auto tree = SyntaxTree::fromText(R"(
+module m;
+    reg [31:0] r;
+
+    function void f(string s);
+    endfunction
+
+    task t(string s);
+    endtask
+
+    initial begin
+        f(r);
+        t(r);
+        void'($fopen(r, "r"));
+    end
+endmodule
+)");
+
+    CompilationOptions options;
+    options.flags |= CompilationFlags::RelaxStringConversions;
+
+    Compilation compilation(options);
+    compilation.addSyntaxTree(tree);
+    NO_COMPILATION_ERRORS;
+}
+
 TEST_CASE("Forward typedef restriction regress") {
     auto tree = SyntaxTree::fromText(R"(
 typedef struct s;


### PR DESCRIPTION
Only under --relax-string-conversion.
VCS allows the conversion from string to packed array (reg/bit). This is quite common in old IP code, like calls to $fopen for example.