### PR TITLE
Convert no implementation found to warning in vcs compat mode

### DIFF
--- a/scripts/diagnostics.txt
+++ b/scripts/diagnostics.txt
@@ -370,7 +370,6 @@ error MaxGenerateStepsExceeded "generate loop hit maximum step limit; possible i
 error MixingSubroutinePortKinds "port declarations not allowed when subroutine defines a formal argument list"
 error UnpackedArrayParamType "unpacked array parameter requires explicit data type"
 error AutomaticNotAllowed "automatic variables can only be declared in procedural contexts"
-error NoMemberImplFound "no implementation found in parent scope for '{}'"
 error MethodKindMismatch "mismatch between 'function' and 'task' declared in prototype"
 error MethodReturnMismatch "return type {} of method '{}' does not match {} declared in its prototype"
 error MethodArgCountMismatch "definition of method '{}' has different number of arguments from its prototype"
@@ -573,6 +572,7 @@ warning unused-config-instance UnusedConfigInstance "unused config rule -- insta
 warning static-init-order StaticInitOrder "initializer for static variable '{}' refers to another static variable '{}' which will be initialized in an indeterminate order"
 warning static-init-value StaticInitValue "initializer for static variable '{}' refers to '{}' which will not have a value at initialization time"
 warning unnamed-generate UnnamedGenerate "generate block is unnamed"
+warning member-impl-not-found MemberImplNotFound "implementation not found in parent scope for '{}'"
 
 subsystem Expressions
 error BadUnaryExpression "invalid operand type {} to unary expression"
@@ -1258,7 +1258,7 @@ group default = { real-underflow real-overflow vector-overflow int-overflow unco
                   seq-no-match case-too-complex nested-solve-before dynamic-non-procedural
                   nonstandard-string-concat nested-comment multi-write read-write mixed-var-assigns
                   multiple-cont-assigns multiple-always-assigns misplaced-trailing-separator
-                  qualifiers-on-out-of-block }
+                  qualifiers-on-out-of-block member-impl-not-found }
 
 group extra = { empty-member empty-stmt dup-import pointless-void-cast case-gen-none case-gen-dup
                 unused-result format-real ignored-slice task-ignored width-trunc dup-attr event-const

--- a/scripts/warning_docs.txt
+++ b/scripts/warning_docs.txt
@@ -1464,6 +1464,19 @@ module memMod();
 endmodule
 ```
 
+-Wmember-impl-not-found
+A class has the declaration for a member method, but the implementation of that member method is not
+found either in the class or as an out of body definition.
+This is an error by default but can be downgraded to a warning for compatibility with tools.
+```
+module m;
+class c;
+   extern function int f();
+endclass
+
+endmodule
+```
+
 @category Macros
 
 -Wignored-macro-paste

--- a/source/ast/symbols/ClassSymbols.cpp
+++ b/source/ast/symbols/ClassSymbols.cpp
@@ -1310,7 +1310,7 @@ const Constraint& ConstraintBlockSymbol::getConstraints() const {
         if (!declSyntax || declSyntax->kind != SyntaxKind::ConstraintDeclaration || name.empty()) {
             if (!flags.has(ConstraintBlockFlags::Pure) && !name.empty()) {
                 DiagCode code = flags.has(ConstraintBlockFlags::ExplicitExtern)
-                                    ? diag::NoMemberImplFound
+                                    ? diag::MemberImplNotFound
                                     : diag::NoConstraintBody;
                 outerScope.addDiag(code, location) << name;
             }

--- a/source/ast/symbols/SubroutineSymbols.cpp
+++ b/source/ast/symbols/SubroutineSymbols.cpp
@@ -1179,7 +1179,7 @@ const SubroutineSymbol* MethodPrototypeSymbol::getSubroutine() const {
 
     // Otherwise, there must be a body for any declared prototype.
     if (!syntax) {
-        outerScope.addDiag(diag::NoMemberImplFound, location) << name;
+        outerScope.addDiag(diag::MemberImplNotFound, location) << name;
         return nullptr;
     }
 

--- a/source/driver/Driver.cpp
+++ b/source/driver/Driver.cpp
@@ -716,6 +716,7 @@ bool Driver::processOptions() {
         diagEngine.setSeverity(diag::SolveBeforeDisallowed, DiagnosticSeverity::Error);
         diagEngine.setSeverity(diag::DynamicNotProcedural, DiagnosticSeverity::Error);
         diagEngine.setSeverity(diag::QualifiersOnOutOfBlock, DiagnosticSeverity::Error);
+        diagEngine.setSeverity(diag::MemberImplNotFound, DiagnosticSeverity::Error);
     }
 
     Diagnostics optionDiags = diagEngine.setWarningOptions(options.warningOptions);

--- a/tests/unittests/ast/ClassTests.cpp
+++ b/tests/unittests/ast/ClassTests.cpp
@@ -2058,7 +2058,7 @@ endclass
     REQUIRE(diags.size() == 11);
     CHECK(diags[0].code == diag::MemberDefinitionBeforeClass);
     CHECK(diags[1].code == diag::NoConstraintBody);
-    CHECK(diags[2].code == diag::NoMemberImplFound);
+    CHECK(diags[2].code == diag::MemberImplNotFound);
     CHECK(diags[3].code == diag::PureConstraintInAbstract);
     CHECK(diags[4].code == diag::ConstraintQualOutOfBlock);
     CHECK(diags[5].code == diag::Redefinition);


### PR DESCRIPTION
VCS considers this a warning instead of an error.