### PR TITLE
Use previous declaration over later declaration of variables

### DIFF
--- a/source/ast/Lookup.cpp
+++ b/source/ast/Lookup.cpp
@@ -1856,6 +1856,23 @@ void Lookup::unqualifiedImpl(const Scope& scope, std::string_view name, LookupLo
                     if (symbol->as<EnumValueSymbol>().isEvaluating())
                         flags &= ~LookupFlags::AllowDeclaredAfter;
                     break;
+                case SymbolKind::Variable:
+                case SymbolKind::FormalArgument:
+                    // If we find a variable that's declared before use, then use that instead of
+                    // the one that's declared after use. We only need to do this if
+                    // AllowDeclaredAfter is enabled because if it's not, then we end up looking
+                    // up the chain anyway.
+                    if (flags.has(LookupFlags::AllowDeclaredAfter)) {
+                        LookupLocation parentLocation = LookupLocation::after(scope.asSymbol());
+                        if (parentLocation.getScope()) {
+                            unqualifiedImpl(*parentLocation.getScope(), name, parentLocation,
+                                            sourceRange, flags, outOfBlockIndex, result,
+                                            originalScope, originalSyntax);
+                            if (result.found)
+                                return;
+                        }
+                    }
+                    break;
                 default:
                     break;
             }

--- a/tests/unittests/ast/LookupTests.cpp
+++ b/tests/unittests/ast/LookupTests.cpp
@@ -2635,3 +2635,45 @@ endmodule
     compilation.addSyntaxTree(tree);
     NO_COMPILATION_ERRORS;
 }
+
+TEST_CASE("Pick correct variable with use before declaration over local var") {
+    auto tree = SyntaxTree::fromText(R"(
+module m;
+    localparam K = 4;
+
+    function automatic int f;
+        bit [K:0] width; // Should use localparam K
+        int K;
+        f = 12;
+    endfunction
+endmodule
+)");
+
+    CompilationOptions options;
+    options.flags |= CompilationFlags::AllowUseBeforeDeclare;
+
+    Compilation compilation(options);
+    compilation.addSyntaxTree(tree);
+    NO_COMPILATION_ERRORS;
+}
+
+TEST_CASE("Pick correct variable with use before declaration over param") {
+    auto tree = SyntaxTree::fromText(R"(
+module m;
+    localparam K = 4;
+
+    function automatic bit[K:0] f;
+        input bit [K:0] width; // Should use localparam K
+        input int K;
+        f = 12;
+    endfunction
+endmodule
+)");
+
+    CompilationOptions options;
+    options.flags |= CompilationFlags::AllowUseBeforeDeclare;
+
+    Compilation compilation(options);
+    compilation.addSyntaxTree(tree);
+    NO_COMPILATION_ERRORS;
+}


### PR DESCRIPTION
--allow-use-before-declare leads to an issue where the incorrect variable is picked when there are 2 declared (compared to vcs). In the following example:
    module m;
        localparam K = 4;

        function automatic int f;
            bit [K:0] width; // Should use localparam K
            int K;
            f = 12;
        endfunction
    endmodule

using --allow-use-before-declare ends up resolving the 'K' in width to the local int 'K' instead of the previously declared localparam.

With this change, we will now pick a previously declared variable over any variable declared after it's use.