### PR TITLE
Allow resolving method calls to methods declared in hierarchical parents

### DIFF
--- a/source/ast/Expression.cpp
+++ b/source/ast/Expression.cpp
@@ -1006,10 +1006,10 @@ Expression& Expression::bindName(Compilation& comp, const NameSyntax& syntax,
                                  const ArrayOrRandomizeMethodExpressionSyntax* withClause,
                                  const ASTContext& context) {
     bitmask<LookupFlags> flags = LookupFlags::None;
-    if ((invocation && invocation->arguments) ||
-        comp.hasFlag(CompilationFlags::AllowUseBeforeDeclare)) {
+    if (invocation && invocation->arguments)
+        flags |= LookupFlags::AllowDeclaredAfter | LookupFlags::AlwaysAllowUpward;
+    if (comp.hasFlag(CompilationFlags::AllowUseBeforeDeclare))
         flags |= LookupFlags::AllowDeclaredAfter;
-    }
 
     if (context.flags.has(ASTFlags::StaticInitializer))
         flags |= LookupFlags::StaticInitializer;

--- a/source/ast/Lookup.cpp
+++ b/source/ast/Lookup.cpp
@@ -1170,8 +1170,11 @@ void Lookup::name(const NameSyntax& syntax, const ASTContext& context, bitmask<L
 
     if (!result.found) {
         if (flags.has(LookupFlags::AlwaysAllowUpward)) {
+            LookupResult originalResult = result;
             if (!lookupUpward({}, name, context, flags, result))
                 return;
+            if (!result.found)
+                result = originalResult;
         }
 
         if (!result.found && !result.hasError())

--- a/tests/unittests/ast/LookupTests.cpp
+++ b/tests/unittests/ast/LookupTests.cpp
@@ -2677,3 +2677,35 @@ endmodule
     compilation.addSyntaxTree(tree);
     NO_COMPILATION_ERRORS;
 }
+
+TEST_CASE("Method lookup within parent modules") {
+    auto tree = SyntaxTree::fromText(R"(
+module top;
+    child ch();
+
+    function automatic int f;
+        return 12;
+    endfunction
+
+    task t;
+    endtask
+endmodule
+
+module child;
+    grandchild gc();
+
+    initial $display(f());
+endmodule
+
+module grandchild;
+    initial begin
+        $display(f());
+        t();
+    end
+endmodule
+)");
+
+    Compilation compilation;
+    compilation.addSyntaxTree(tree);
+    NO_COMPILATION_ERRORS;
+}


### PR DESCRIPTION
VCS allows a child module instance to refer to a method declared in a parent module (as long as all parents of that child module have a definition of that method).