### PR TITLE
Fix the error in parsing nested macro with multiline args in nested define

### DIFF
--- a/source/parsing/Preprocessor_macros.cpp
+++ b/source/parsing/Preprocessor_macros.cpp
@@ -510,8 +510,10 @@ bool Preprocessor::expandMacro(MacroDef macro, MacroExpansion& expansion,
     bool inDefineDirective = false;
 
     auto handleToken = [&](Token token) {
-        if (inDefineDirective && !token.isOnSameLine())
+        if (inDefineDirective &&
+            (!token.isOnSameLine() || token.kind == TokenKind::LineContinuation)) {
             inDefineDirective = false;
+        }
 
         if (token.kind != TokenKind::Identifier && !LF::isKeyword(token.kind) &&
             token.kind != TokenKind::Directive) {

--- a/tests/unittests/parsing/PreprocessorTests.cpp
+++ b/tests/unittests/parsing/PreprocessorTests.cpp
@@ -748,6 +748,26 @@ TEST_CASE("Nested macro with different body locations") {
     CHECK_DIAGNOSTICS_EMPTY;
 }
 
+TEST_CASE("Nested macro with multiline arg") {
+    auto& text = R"(
+`define MACRO_PARENT(code) \
+  `define MACRO_FOOBAR 1 \
+  code
+
+`define MACRO_CHILD reg r;
+
+module top;
+`MACRO_PARENT(
+  logic foobar;
+  `MACRO_CHILD
+);
+endmodule
+)";
+
+    std::string result = preprocess(text);
+    CHECK_DIAGNOSTICS_EMPTY;
+}
+
 TEST_CASE("Macro arg location bug") {
     auto& text = R"(
 `define FOO(name) name \


### PR DESCRIPTION
Fixes #1693
when a macro body contains a nested `define and is invoked with a multi-line argument, the preprocessor badly kept inDefineDirective set through LineContinuation tokens from the outer macro body, which caused weird LineContinuation tokens to be inserted into the expanded argument, triggering a MacroOpsOutsideDefinition error. should instead reset inDefineDirective when a LineContinuation token is encountered, since it marks a physical line boundary that ends the inner define's scope.