### PR TITLE
Add lookup table visitor support to pyslang bindings

### DIFF
--- a/bindings/python/ASTBindings.cpp
+++ b/bindings/python/ASTBindings.cpp
@@ -242,7 +242,8 @@ void registerAST(py::module_& m) {
         .def_readonly("sourceRange", &TimingControl::sourceRange)
         .def_property_readonly("bad", &TimingControl::bad)
         .def("isEquivalentTo", &TimingControl::isEquivalentTo, "other"_a)
-        .def("visit", &pyASTVisit<TimingControl>, "f"_a = py::none(), "lookup_table"_a = py::none(), PyASTVisitor::doc)
+        .def("visit", &pyASTVisit<TimingControl>, "f"_a = py::none(), "lookup_table"_a = py::none(),
+             PyASTVisitor::doc)
         .def("__repr__", [](const TimingControl& self) {
             return fmt::format("TimingControl(TimingControlKind.{})", toString(self.kind));
         });

--- a/bindings/python/ExpressionBindings.cpp
+++ b/bindings/python/ExpressionBindings.cpp
@@ -36,7 +36,8 @@ void registerExpressions(py::module_& m) {
         .def("getSymbolReference", &Expression::getSymbolReference, byrefint,
              "allowPacked"_a = true)
         .def("isEquivalentTo", &Expression::isEquivalentTo, "other"_a)
-        .def("visit", &pyASTVisit<Expression>, "f"_a = py::none(), "lookup_table"_a = py::none(), PyASTVisitor::doc)
+        .def("visit", &pyASTVisit<Expression>, "f"_a = py::none(), "lookup_table"_a = py::none(),
+             PyASTVisitor::doc)
         .def("__repr__", [](const Expression& self) {
             return fmt::format("Expression(ExpressionKind.{})", toString(self.kind));
         });

--- a/bindings/python/PyVisitors.h
+++ b/bindings/python/PyVisitors.h
@@ -35,8 +35,8 @@ struct PyVisitorBase : public BaseVisitor<TDerived, baseArgs...> {
         "Python boundary, calling only the matching handler. Nodes not in the table are "
         "traversed without invoking Python. `f` is not called in this mode.";
 
-    explicit PyVisitorBase(py::object f, std::optional<py::dict> lt = std::nullopt)
-        : f{f}, lookup_table{std::move(lt)} {}
+    explicit PyVisitorBase(py::object f, std::optional<py::dict> lt = std::nullopt) :
+        f{f}, lookup_table{std::move(lt)} {}
 
     template<typename T>
     void handle(const T& t) {
@@ -45,20 +45,22 @@ struct PyVisitorBase : public BaseVisitor<TDerived, baseArgs...> {
 
         py::object result;
         if (this->lookup_table) {
-            // Lookup table filtering 
+            // Lookup table filtering
             if constexpr (requires { t.kind; }) {
                 auto kind_py = py::cast(t.kind);
                 if (!this->lookup_table->contains(kind_py)) {
-                    this->visitDefault(t); 
+                    this->visitDefault(t);
                     return;
                 }
                 py::object handler{(*this->lookup_table)[kind_py]};
                 result = handler(&t);
-            } else {
+            }
+            else {
                 this->visitDefault(t);
                 return;
             }
-        } else {
+        }
+        else {
             result = this->f(&t);
         }
 

--- a/bindings/python/StatementBindings.cpp
+++ b/bindings/python/StatementBindings.cpp
@@ -22,7 +22,8 @@ void registerStatements(py::module_& m) {
         .def_readonly("sourceRange", &Statement::sourceRange)
         .def_property_readonly("bad", &Statement::bad)
         .def("eval", &Statement::eval, "context"_a)
-        .def("visit", &pyASTVisit<Statement>, "f"_a = py::none(), "lookup_table"_a = py::none(), PyASTVisitor::doc)
+        .def("visit", &pyASTVisit<Statement>, "f"_a = py::none(), "lookup_table"_a = py::none(),
+             PyASTVisitor::doc)
         .def("__repr__", [](const Statement& self) {
             return fmt::format("Statement(StatementKind.{})", toString(self.kind));
         });

--- a/bindings/python/SymbolBindings.cpp
+++ b/bindings/python/SymbolBindings.cpp
@@ -124,7 +124,8 @@ void registerSymbols(py::module_& m) {
              py::overload_cast<const Symbol&>(&Symbol::isDeclaredBefore, py::const_), "target"_a)
         .def("isDeclaredBefore",
              py::overload_cast<LookupLocation>(&Symbol::isDeclaredBefore, py::const_), "location"_a)
-        .def("visit", &pyASTVisit<Symbol>, "f"_a = py::none(), "lookup_table"_a = py::none(), PyASTVisitor::doc)
+        .def("visit", &pyASTVisit<Symbol>, "f"_a = py::none(), "lookup_table"_a = py::none(),
+             PyASTVisitor::doc)
         .def("__repr__", [](const Symbol& self) {
             return fmt::format("Symbol(SymbolKind.{}, \"{}\")", toString(self.kind), self.name);
         });

--- a/bindings/python/SyntaxBindings.cpp
+++ b/bindings/python/SyntaxBindings.cpp
@@ -82,7 +82,8 @@ struct PySyntaxVisitor : public PyVisitorBase<PySyntaxVisitor, SyntaxVisitor> {
     }
 };
 
-void pySyntaxVisit(const SyntaxNode& sn, py::object f = py::none(), py::object lookup_table = py::none()) {
+void pySyntaxVisit(const SyntaxNode& sn, py::object f = py::none(),
+                   py::object lookup_table = py::none()) {
     if (f.is_none() && lookup_table.is_none())
         throw py::type_error("visit() requires 'f' or 'lookup_table' (both are None)");
     std::optional<py::dict> lt;
@@ -363,7 +364,8 @@ void registerSyntax(py::module_& syntax, py::module_& parsing) {
         .def("getFirstToken", &SyntaxNode::getFirstToken)
         .def("getLastToken", &SyntaxNode::getLastToken)
         .def("isEquivalentTo", &SyntaxNode::isEquivalentTo, "other"_a)
-        .def("visit", &pySyntaxVisit, "f"_a = py::none(), "lookup_table"_a = py::none(), PySyntaxVisitor::doc)
+        .def("visit", &pySyntaxVisit, "f"_a = py::none(), "lookup_table"_a = py::none(),
+             PySyntaxVisitor::doc)
         .def_property_readonly("sourceRange", &SyntaxNode::sourceRange)
         .def("__getitem__",
              [](const SyntaxNode& self, size_t i) -> py::object {

--- a/pyslang/tests/test_visitors.py
+++ b/pyslang/tests/test_visitors.py
@@ -148,7 +148,11 @@ endmodule
 
     # Baseline: old API with isinstance filter
     old_matches = []
-    c.getRoot().visit(lambda n: old_matches.append(n) if isinstance(n, ProceduralBlockSymbol) else None)
+    c.getRoot().visit(
+        lambda n: (
+            old_matches.append(n) if isinstance(n, ProceduralBlockSymbol) else None
+        )
+    )
 
     # New API: C++-side kind filter
     new_matches = []
@@ -174,14 +178,21 @@ endmodule
 
     # Baseline: old API with kind check
     old_matches = []
+
     def count_old(node):
-        if isinstance(node, Statement) and node.kind == StatementKind.ExpressionStatement:
+        if (
+            isinstance(node, Statement)
+            and node.kind == StatementKind.ExpressionStatement
+        ):
             old_matches.append(node)
+
     c.getRoot().visit(count_old)
 
     # New API
     new_matches = []
-    c.getRoot().visit(lookup_table={StatementKind.ExpressionStatement: new_matches.append})
+    c.getRoot().visit(
+        lookup_table={StatementKind.ExpressionStatement: new_matches.append}
+    )
 
     assert len(new_matches) == len(old_matches)
     assert len(new_matches) == 2
@@ -207,9 +218,11 @@ endmodule
 
     # Baseline: old API with kind check
     old_matches = []
+
     def count_old(node):
         if hasattr(node, "kind") and node.kind == ExpressionKind.NamedValue:
             old_matches.append(node)
+
     c.getRoot().visit(count_old)
 
     # New API
@@ -246,11 +259,14 @@ def test_timing_control_visit_lookup_table():
     timing_control = always_block.body.timing
 
     sensitivity_vars = []
+
     def handle_signal_event(node):
         assert isinstance(node.expr, NamedValueExpression)
         sensitivity_vars.append(node.expr.getSymbolReference())
 
-    timing_control.visit(lookup_table={TimingControlKind.SignalEvent: handle_signal_event})
+    timing_control.visit(
+        lookup_table={TimingControlKind.SignalEvent: handle_signal_event}
+    )
 
     assert [v.name for v in sensitivity_vars] == ["clk", "rstn"]
 
@@ -292,15 +308,19 @@ endmodule
 
     # Without skip: ExpressionStatement inside always block is visited
     no_skip_matches = []
-    c.getRoot().visit(lookup_table={StatementKind.ExpressionStatement: no_skip_matches.append})
+    c.getRoot().visit(
+        lookup_table={StatementKind.ExpressionStatement: no_skip_matches.append}
+    )
     assert len(no_skip_matches) == 1
 
     # With skip on ProceduralBlock: children (including the ExpressionStatement) are not visited
     skip_matches = []
-    c.getRoot().visit(lookup_table={
-        SymbolKind.ProceduralBlock: lambda n: VisitAction.Skip,
-        StatementKind.ExpressionStatement: skip_matches.append,
-    })
+    c.getRoot().visit(
+        lookup_table={
+            SymbolKind.ProceduralBlock: lambda n: VisitAction.Skip,
+            StatementKind.ExpressionStatement: skip_matches.append,
+        }
+    )
     assert len(skip_matches) == 0
 
 
@@ -316,6 +336,7 @@ endmodule
     c.addSyntaxTree(tree)
 
     matches = []
+
     def interrupt_on_first(node):
         matches.append(node)
         return VisitAction.Interrupt
@@ -349,15 +370,19 @@ endmodule
 
     # Without skip: both expression statements are visited
     no_skip_matches = []
-    c.getRoot().visit(lookup_table={StatementKind.ExpressionStatement: no_skip_matches.append})
+    c.getRoot().visit(
+        lookup_table={StatementKind.ExpressionStatement: no_skip_matches.append}
+    )
     assert len(no_skip_matches) == 2
 
     # Skipping the Conditional prevents the nested ExpressionStatement from being visited
     skip_matches = []
-    c.getRoot().visit(lookup_table={
-        StatementKind.Conditional: lambda n: VisitAction.Skip,
-        StatementKind.ExpressionStatement: skip_matches.append,
-    })
+    c.getRoot().visit(
+        lookup_table={
+            StatementKind.Conditional: lambda n: VisitAction.Skip,
+            StatementKind.ExpressionStatement: skip_matches.append,
+        }
+    )
     assert len(skip_matches) == 1
 
 
@@ -372,10 +397,12 @@ def test_lookup_table_skip_in_syntax_visitor():
 
     # Skipping ModuleDeclaration prevents traversal into its children
     skip_matches = []
-    tree.root.visit(lookup_table={
-        SyntaxKind.ModuleDeclaration: lambda n: VisitAction.Skip,
-        SyntaxKind.DataDeclaration: skip_matches.append,
-    })
+    tree.root.visit(
+        lookup_table={
+            SyntaxKind.ModuleDeclaration: lambda n: VisitAction.Skip,
+            SyntaxKind.DataDeclaration: skip_matches.append,
+        }
+    )
     assert len(skip_matches) == 0
 
 
@@ -395,16 +422,21 @@ endmodule
 
     # Without interrupt: both expression statements are visited
     no_interrupt_matches = []
-    c.getRoot().visit(lookup_table={StatementKind.ExpressionStatement: no_interrupt_matches.append})
+    c.getRoot().visit(
+        lookup_table={StatementKind.ExpressionStatement: no_interrupt_matches.append}
+    )
     assert len(no_interrupt_matches) == 2
 
     # Interrupt on the first ExpressionStatement: second never reached
     interrupt_matches = []
+
     def interrupt_on_first_stmt(node):
         interrupt_matches.append(node)
         return VisitAction.Interrupt
 
-    c.getRoot().visit(lookup_table={StatementKind.ExpressionStatement: interrupt_on_first_stmt})
+    c.getRoot().visit(
+        lookup_table={StatementKind.ExpressionStatement: interrupt_on_first_stmt}
+    )
     assert len(interrupt_matches) == 1
 
 
@@ -414,30 +446,35 @@ def test_lookup_table_interrupt_in_syntax_visitor():
 
     # Without interrupt: all tokens are visited
     all_tokens = []
-    tree.root.visit(lookup_table={
-        TokenKind.AlwaysKeyword: all_tokens.append,
-        TokenKind.At: all_tokens.append,
-        TokenKind.OpenParenthesis: all_tokens.append,
-        TokenKind.Star: all_tokens.append,
-        TokenKind.CloseParenthesis: all_tokens.append,
-        TokenKind.Semicolon: all_tokens.append,
-    })
+    tree.root.visit(
+        lookup_table={
+            TokenKind.AlwaysKeyword: all_tokens.append,
+            TokenKind.At: all_tokens.append,
+            TokenKind.OpenParenthesis: all_tokens.append,
+            TokenKind.Star: all_tokens.append,
+            TokenKind.CloseParenthesis: all_tokens.append,
+            TokenKind.Semicolon: all_tokens.append,
+        }
+    )
     assert len(all_tokens) == 6
 
     # Interrupt on AlwaysKeyword: remaining tokens never visited
     interrupted_tokens = []
+
     def interrupt_on_always(token):
         interrupted_tokens.append(token)
         return VisitAction.Interrupt
 
-    tree.root.visit(lookup_table={
-        TokenKind.AlwaysKeyword: interrupt_on_always,
-        TokenKind.At: interrupted_tokens.append,
-        TokenKind.OpenParenthesis: interrupted_tokens.append,
-        TokenKind.Star: interrupted_tokens.append,
-        TokenKind.CloseParenthesis: interrupted_tokens.append,
-        TokenKind.Semicolon: interrupted_tokens.append,
-    })
+    tree.root.visit(
+        lookup_table={
+            TokenKind.AlwaysKeyword: interrupt_on_always,
+            TokenKind.At: interrupted_tokens.append,
+            TokenKind.OpenParenthesis: interrupted_tokens.append,
+            TokenKind.Star: interrupted_tokens.append,
+            TokenKind.CloseParenthesis: interrupted_tokens.append,
+            TokenKind.Semicolon: interrupted_tokens.append,
+        }
+    )
     assert len(interrupted_tokens) == 1
     assert interrupted_tokens[0].kind == TokenKind.AlwaysKeyword
 
@@ -456,10 +493,12 @@ endmodule
 
     proc_matches = []
     var_matches = []
-    c.getRoot().visit(lookup_table={
-        SymbolKind.ProceduralBlock: proc_matches.append,
-        SymbolKind.Variable: var_matches.append,
-    })
+    c.getRoot().visit(
+        lookup_table={
+            SymbolKind.ProceduralBlock: proc_matches.append,
+            SymbolKind.Variable: var_matches.append,
+        }
+    )
 
     assert len(proc_matches) == 1
     assert len(var_matches) == 2
@@ -484,10 +523,12 @@ endmodule
 
     proc_matches = []
     stmt_matches = []
-    c.getRoot().visit(lookup_table={
-        SymbolKind.ProceduralBlock: proc_matches.append,
-        StatementKind.ExpressionStatement: stmt_matches.append,
-    })
+    c.getRoot().visit(
+        lookup_table={
+            SymbolKind.ProceduralBlock: proc_matches.append,
+            StatementKind.ExpressionStatement: stmt_matches.append,
+        }
+    )
 
     assert len(proc_matches) == 1
     assert len(stmt_matches) == 1


### PR DESCRIPTION
This PR addresses the discussion #1704 by adding a lookup table named argument to the pyslang bindings for the .visit() method. This allows a dictionary lookup table mapping the various "node kinds" to a callback to decrease the number of times the cpp/python boundary is crossed when the visitor only needs to visit a subset of nodes in the AST or Sytnax Tree. Example usage is as follows 

```Python
import pyslang.ast as ps_ast
import pyslang.driver as ps_driver

def handle_instancebody_sym(node):
    print(f"--- Entering Instance Body: {node.definition.name} ---")

    ast_ctx = ps_ast.ASTContext(node, ps_ast.LookupLocation.max)
    context = ps_ast.EvalContext(ast_ctx)
    for param in node.parameters:
        param_name = param.name
        
        if hasattr(param, "initializer") and param.initializer:
            param_val = param.initializer.eval(context)
            print(f"  Parameter: {param_name} = {param_val.value}")

def main():
    path, relative = CVA6_FLIST_PATH_CFG

    driver = ps_driver.Driver()
    driver.addStandardArgs()
    driver.processCommandFiles(path, relative, False)
    driver.processOptions()
    driver.parseAllSources()
    c = driver.createCompilation()

    lookup_table = {
            ps_ast.SymbolKind.InstanceBody: handle_instancebody_sym
    }
    c.getRoot().visit(lookup_table=lookup_table)
```

The old usage where a callback is provided to the visit method still works, so this is not a breaking change. If both the singular callback and the lookup_table are provided, the lookup_table is used and the visitor is in "filter mode". if neither the old callback or the lookup table are provided by the caller (they are both none) then an error is thrown. 

I have also added tests to the pyslang/tests/test_visitor.py suite to make sure that both the old and new functionality works. 

I Tested the new lookup table approach against the `DirectDispatchVisitor` listed at the top of #1704 and found that there was a ~10X speedup on average across several runs when finding and evaluating all of the parameters for the instances of modules in [CVA6](https://github.com/openhwgroup/cva6/tree/master/core). 

This PR was assisted by [Claude Code](https://claude.com/claude-code)