### PR TITLE
Print the filename and line number in the preprocessor output

### DIFF
--- a/bindings/python/CompBindings.cpp
+++ b/bindings/python/CompBindings.cpp
@@ -202,7 +202,8 @@ void registerCompilation(py::module_& m, py::module_& ast, py::module_& driver) 
              "separateUnit"_a)
         .def("processOptions", &Driver::processOptions)
         .def("runPreprocessor", &Driver::runPreprocessor, "includeComments"_a,
-             "includeDirectives"_a, "obfuscateIds"_a, "useFixedObfuscationSeed"_a = false)
+             "includeDirectives"_a, "obfuscateIds"_a, "useFixedObfuscationSeed"_a = false,
+             "showSource"_a = false)
         .def("reportMacros", &Driver::reportMacros)
         .def("optionallyWriteDepFiles", &Driver::optionallyWriteDepFiles)
         .def("parseAllSources", &Driver::parseAllSources)

--- a/docs/command-line-ref.dox
+++ b/docs/command-line-ref.dox
@@ -234,6 +234,11 @@ Available keyword versions are:
 Causes all identifiers in the preprocessed output to be replaced with obfuscated
 alphanumeric strings.
 
+`--preprocess-source`
+
+Prints the source filename and linenumber in the preprocessor output stream with --process.
+Only prints the source filename and linenumber when there is a change in source filename.
+
 @section clr-parsing Parsing
 
 `--max-parse-depth <depth>`

--- a/include/slang/driver/Driver.h
+++ b/include/slang/driver/Driver.h
@@ -376,9 +376,11 @@ public:
     /// @param useFixedObfuscationSeed If true, obfuscated identifiers will be generated with
     ///                                a fixed randomization seed, meaning they will be the
     ///                                same every time the program is run. Used for testing.
+    /// @param showSource If true, preprocessor output will contain source line information.
     /// @returns true on success and false if errors were encountered.
     [[nodiscard]] bool runPreprocessor(bool includeComments, bool includeDirectives,
-                                       bool obfuscateIds, bool useFixedObfuscationSeed = false);
+                                       bool obfuscateIds, bool useFixedObfuscationSeed = false,
+                                       bool showSource = false);
 
     /// Prints all macros from all loaded buffers to stdout.
     void reportMacros();

--- a/include/slang/syntax/SyntaxPrinter.h
+++ b/include/slang/syntax/SyntaxPrinter.h
@@ -64,6 +64,15 @@ public:
     /// @return a reference to this object, to allow chaining additional method calls.
     SyntaxPrinter& print(const SyntaxTree& tree);
 
+    /// If no source manager is provided or if this flag is set, print tokens from any location.
+    /// Otherwise, filter out tokens based on other flags that control inclusion or exclusion of
+    /// preprocesses macros, includes, etc.
+    /// @return a reference to this object, to allow chaining additional method calls.
+    SyntaxPrinter& setIncludeAllLocations(bool include) {
+        includeAllLocations = include;
+        return *this;
+    }
+
     /// Sets whether to include trivia when printing syntax.
     /// @return a reference to this object, to allow chaining additional method calls.
     SyntaxPrinter& setIncludeTrivia(bool include) {
@@ -115,6 +124,13 @@ public:
         return *this;
     }
 
+    /// Sets whether to include source information when printing syntax.
+    /// @return a reference to this object, to allow chaining additional method calls.
+    SyntaxPrinter& setIncludeSource(bool include) {
+        includeSource = include;
+        return *this;
+    }
+
     /// Sets whether to squash adjacent newlines down into one when printing syntax.
     /// @return a reference to this object, to allow chaining additional method calls.
     SyntaxPrinter& setSquashNewlines(bool include) {
@@ -135,7 +151,9 @@ private:
     bool shouldPrint(SourceLocation loc) const;
 
     std::string buffer;
+    std::string_view currentFileName;
     const SourceManager* sourceManager = nullptr;
+    bool includeAllLocations = false;
     bool includeTrivia = true;
     bool includeMissing = false;
     bool includeSkipped = false;
@@ -143,6 +161,7 @@ private:
     bool expandIncludes = false;
     bool expandMacros = false;
     bool includeComments = true;
+    bool includeSource = false;
     bool squashNewlines = true;
 };
 

--- a/source/driver/Driver.cpp
+++ b/source/driver/Driver.cpp
@@ -655,7 +655,7 @@ static std::string generateRandomAlphaString(TGenerator& gen, size_t len) {
 }
 
 bool Driver::runPreprocessor(bool includeComments, bool includeDirectives, bool obfuscateIds,
-                             bool useFixedObfuscationSeed) {
+                             bool useFixedObfuscationSeed, bool includeSource) {
     BumpAllocator alloc;
     Diagnostics diagnostics;
     Preprocessor preprocessor(sourceManager, alloc, diagnostics, createParseOptionBag());
@@ -664,9 +664,11 @@ bool Driver::runPreprocessor(bool includeComments, bool includeDirectives, bool 
     for (auto it = buffers.rbegin(); it != buffers.rend(); it++)
         preprocessor.pushSource(*it);
 
-    SyntaxPrinter output;
+    SyntaxPrinter output(sourceManager);
     output.setIncludeComments(includeComments);
     output.setIncludeDirectives(includeDirectives);
+    output.setIncludeSource(includeSource);
+    output.setIncludeAllLocations(true);
 
     std::optional<std::mt19937> rng;
     flat_hash_map<std::string, std::string> obfuscationMap;

--- a/source/syntax/SyntaxPrinter.cpp
+++ b/source/syntax/SyntaxPrinter.cpp
@@ -7,6 +7,8 @@
 //------------------------------------------------------------------------------
 #include "slang/syntax/SyntaxPrinter.h"
 
+#include "fmt/format.h"
+
 #include "slang/parsing/ParserMetadata.h"
 #include "slang/parsing/Token.h"
 #include "slang/syntax/SyntaxNode.h"
@@ -62,10 +64,20 @@ SyntaxPrinter& SyntaxPrinter::print(Trivia trivia) {
 }
 
 SyntaxPrinter& SyntaxPrinter::print(Token token) {
-    bool excluded = !shouldPrint(token.location());
+    auto location = token.location();
+    bool excluded = !shouldPrint(location);
+
+    if (!excluded && sourceManager && includeSource) {
+        std::string_view fileName = sourceManager->getFileName(location);
+        if (fileName != currentFileName) {
+            auto lineNumber = sourceManager->getLineNumber(location);
+            append(fmt::format("\n// {}:{}\n", fileName, lineNumber));
+            currentFileName = fileName;
+        }
+    }
 
     if (includeTrivia) {
-        if (!sourceManager) {
+        if (includeAllLocations || !sourceManager) {
             for (const auto& t : token.trivia())
                 print(t);
         }
@@ -237,6 +249,8 @@ SyntaxPrinter& SyntaxPrinter::append(std::string_view text) {
         for (; i < text.length(); i++) {
             if (text[i] == '\r' || text[i] == '\n')
                 i++;
+            else
+                break;
         }
 
         text = text.substr(i);
@@ -254,7 +268,7 @@ SyntaxPrinter& SyntaxPrinter::append(std::string_view text) {
 }
 
 bool SyntaxPrinter::shouldPrint(SourceLocation loc) const {
-    if (!sourceManager)
+    if (includeAllLocations || !sourceManager)
         return true;
 
     if (sourceManager->isMacroLoc(loc)) {
@@ -277,7 +291,7 @@ bool SyntaxPrinter::shouldPrint(SourceLocation loc) const {
 }
 
 bool SyntaxPrinter::shouldPrint(const SyntaxNode& syntax) const {
-    if (!sourceManager)
+    if (includeAllLocations || !sourceManager)
         return includeDirectives;
 
     if (syntax.kind == SyntaxKind::MacroUsage) {

--- a/tests/unittests/DriverTests.cpp
+++ b/tests/unittests/DriverTests.cpp
@@ -1254,3 +1254,22 @@ TEST_CASE("Driver dir prefix multiple, first wins") {
     CHECK(driver.runFullCompilation());
     CHECK(stdoutContains("Build succeeded"));
 }
+
+TEST_CASE("Driver file preprocess with source info") {
+    auto guard = OS::captureOutput();
+
+    Driver driver;
+    driver.addStandardArgs();
+
+    auto args = fmt::format("testfoo \"{0}test.sv\" -DFOOBAR -I{0}libtest", findTestDir());
+    CHECK(driver.parseCommandLine(args));
+    CHECK(driver.processOptions());
+    CHECK(driver.runPreprocessor(false, false, false, false, true));
+
+    auto output = OS::capturedStdout;
+    output = std::regex_replace(output, std::regex("\r\n"), "\n");
+
+    CHECK(contains(output, "test.sv:4\nmodule m;"));
+    CHECK(contains(output, "mod1.sv:1\nmodule mod1"));
+    CHECK(contains(output, "test.sv:15\n"));
+}

--- a/tools/driver/slang_main.cpp
+++ b/tools/driver/slang_main.cpp
@@ -113,12 +113,15 @@ int driverMain(int argc, TArgs argv) {
         std::optional<bool> includeComments;
         std::optional<bool> includeDirectives;
         std::optional<bool> obfuscateIds;
+        std::optional<bool> includeSource;
         driver.cmdLine.add("--comments", includeComments,
                            "Include comments in preprocessed output (with -E)");
         driver.cmdLine.add("--directives", includeDirectives,
                            "Include compiler directives in preprocessed output (with -E)");
         driver.cmdLine.add("--obfuscate-ids", obfuscateIds,
                            "Randomize all identifiers in preprocessed output (with -E)");
+        driver.cmdLine.add("--preprocess-source", includeSource,
+                           "Show source line information with preprocessor output");
 
         std::optional<std::string> astJsonFile;
         driver.cmdLine.add(
@@ -198,7 +201,7 @@ int driverMain(int argc, TArgs argv) {
             bool ok = true;
             if (onlyPreprocess == true) {
                 return driver.runPreprocessor(includeComments == true, includeDirectives == true,
-                                              obfuscateIds == true);
+                                              obfuscateIds == true, false, includeSource == true);
             }
 
             if (onlyMacros == true) {


### PR DESCRIPTION
This is very helpful when dealing with codebases with nested includes.