### PR TITLE
Support for cross as a target of another cross

### DIFF
--- a/source/ast/symbols/CoverSymbols.cpp
+++ b/source/ast/symbols/CoverSymbols.cpp
@@ -929,6 +929,12 @@ CoverCrossSymbol& CoverCrossSymbol::fromSyntax(const Scope& scope, const CoverCr
         if (symbol && symbol->kind == SymbolKind::Coverpoint) {
             targets.push_back(&symbol->as<CoverpointSymbol>());
         }
+        else if (symbol && symbol->kind == SymbolKind::CoverCross) {
+            // If it's a cross, then we'll add all the targets of the cross.
+            auto& cross = symbol->as<CoverCrossSymbol>();
+            for (auto cp : cross.targets)
+                targets.push_back(cp);
+        }
         else {
             // If we didn't find a coverpoint, create one implicitly
             // that will be initialized with this expression.

--- a/tests/unittests/ast/CoverTests.cpp
+++ b/tests/unittests/ast/CoverTests.cpp
@@ -799,3 +799,27 @@ endclass
     compilation.addSyntaxTree(tree);
     NO_COMPILATION_ERRORS;
 }
+
+TEST_CASE("Cover cross of crosses") {
+    auto tree = SyntaxTree::fromText(R"(
+module top;
+
+class c;
+   bit [1:0] m1;
+   bit [1:0] m2;
+   bit [1:0] m3;
+
+  covergroup cg;
+    cp1 : coverpoint m1;
+    cx1 : cross cp1, m2;
+    cx2 : cross m3, cx1;
+  endgroup
+endclass
+
+endmodule
+)");
+
+    Compilation compilation;
+    compilation.addSyntaxTree(tree);
+    NO_COMPILATION_ERRORS;
+}


### PR DESCRIPTION
All major vendors support this, even though it's not part of the LRM. This is not necessarily the best approach (inlining the targets of the cross).