### PR TITLE
Allow function calls in foreach array expression

### DIFF
--- a/include/slang/parsing/Parser.h
+++ b/include/slang/parsing/Parser.h
@@ -195,6 +195,7 @@ private:
     syntax::SelectorSyntax* parseElementSelector();
     syntax::NameSyntax& parseName(bitmask<NameOptions> options);
     syntax::NameSyntax& parseNamePart(bitmask<NameOptions> options);
+    syntax::ExpressionSyntax& parseForeachArrayExpression();
     syntax::ParameterValueAssignmentSyntax* parseParameterValueAssignment();
     syntax::ArgumentListSyntax& parseArgumentList();
     syntax::ParamAssignmentSyntax& parseParamValue();

--- a/scripts/diagnostics.txt
+++ b/scripts/diagnostics.txt
@@ -310,6 +310,7 @@ warning nonstandard-generate NonStandardGenBlock "standalone generate block with
 warning empty-pattern EmptyAssignmentPattern "empty assignment patterns are disallowed by SystemVerilog"
 warning nonstandard-foreach NonstandardForeach "non-standard foreach loop variable list"
 warning non-standard-hierarchical-cross NonstandardHierarchicalCross "non-standard hierarchical reference in cover cross item"
+warning foreach-call-expr ForeachCallExpr "foreach array expression is not a name"
 warning lifetime-prototype LifetimeForPrototype "lifetime specifier is not allowed on prototype declaration"
 warning nonstandard-dist NonstandardDist "use of parentheses around 'dist' expression is non-standard"
 warning empty-body EmptyBody "{} has empty body (put the semicolon on a separate line to silence this warning)"
@@ -1287,7 +1288,7 @@ group default = { real-underflow real-overflow vector-overflow int-overflow unco
                   nonstandard-string-concat nested-comment multi-write read-write mixed-var-assigns
                   multiple-cont-assigns multiple-always-assigns misplaced-trailing-separator
                   qualifiers-on-out-of-block member-impl-not-found shift-count-overflow shift-count-negative
-                  initializer-required package-import-in-class }
+                  initializer-required package-import-in-class foreach-call-expr }
 
 group extra = { empty-member empty-stmt dup-import pointless-void-cast case-gen-none case-gen-dup
                 unused-result format-real ignored-slice task-ignored width-trunc dup-attr event-const

--- a/scripts/syntax.txt
+++ b/scripts/syntax.txt
@@ -861,7 +861,7 @@ Statement statement
 
 ForeachLoopList
 token openParen
-Name arrayName
+Expression arrayName
 token openBracket
 separated_list<Name> loopVariables
 token closeBracket

--- a/scripts/warning_docs.txt
+++ b/scripts/warning_docs.txt
@@ -1982,6 +1982,21 @@ SystemVerilog but are supported by some tools.
 int foo[] = '{};
 ```
 
+-Wforeach-call-expr
+The array expression in a foreach loop must be a hierarchical name, not a
+function call or other arbitrary expression. This is not allowed by the
+SystemVerilog LRM but is supported by some tools. In VCS compatibility mode
+this is ignored; otherwise it is an error that can be downgraded to a warning.
+```
+module top;
+    int arr[4];
+    function automatic int get_arr(); endfunction
+    initial begin
+        foreach (get_arr()[i]) begin end
+    end
+endmodule
+```
+
 -Wnonstandard-foreach
 foreach loops are not allowed to have multidimensional brackets when declaring
 loop variables, but most tools allow it as an extension.

--- a/source/driver/CompatSettings.cpp
+++ b/source/driver/CompatSettings.cpp
@@ -108,6 +108,7 @@ void CompatSettings::configureDiagnostics(DiagnosticEngine& diagEngine) const {
                  diag::BadFinishNum,
                  diag::NonstandardSysFunc,
                  diag::NonstandardForeach,
+                 diag::ForeachCallExpr,
                  diag::NonstandardDist,
                  diag::NestedBlockComment,
              }) {
@@ -126,6 +127,7 @@ void CompatSettings::configureDiagnostics(DiagnosticEngine& diagEngine) const {
                  diag::DPIPureTask,
                  diag::SpecifyPathConditionExpr,
                  diag::SolveBeforeDisallowed,
+                 diag::ForeachCallExpr,
                  diag::DynamicNotProcedural,
                  diag::QualifiersOnOutOfBlock,
                  diag::MemberImplNotFound,

--- a/source/parsing/Parser_expressions.cpp
+++ b/source/parsing/Parser_expressions.cpp
@@ -787,6 +787,51 @@ NameSyntax& Parser::parseName(bitmask<NameOptions> options) {
     return *name;
 }
 
+ExpressionSyntax& Parser::parseForeachArrayExpression() {
+    // Parse the base name portion (handles ::, ., and intermediate [..] selectors).
+    // ForeachName stops before the final [loop_variables] bracket and before any
+    // function call argument list '('.
+    ExpressionSyntax* expr = &parseName(NameOptions::ForeachName);
+
+    // After the initial name, handle any trailing postfix operators that parseName
+    // cannot represent: invocation '()', member access '.', and intermediate selectors
+    // '[..]' that are followed by more of the expression (not the loop-variable bracket).
+    while (true) {
+        switch (peek().kind) {
+            case TokenKind::OpenParenthesis: {
+                auto& args = parseArgumentList();
+                expr = &factory.invocationExpression(*expr, nullptr, &args);
+                break;
+            }
+            case TokenKind::Dot: {
+                auto dot = consume();
+                auto name = expect(TokenKind::Identifier);
+                expr = &factory.memberAccessExpression(*expr, dot, name);
+                break;
+            }
+            case TokenKind::OpenBracket: {
+                // Scan past the [..] to see what follows. If what follows is
+                // another '[', '(', or '.', this bracket is an intermediate array
+                // selector (not the foreach loop-variable list) and should be consumed.
+                uint32_t index = 1;
+                scanTypePart<isSemicolon>(index, TokenKind::OpenBracket, TokenKind::CloseBracket);
+                auto next = peek(index).kind;
+                if (next == TokenKind::OpenBracket || next == TokenKind::Dot ||
+                    next == TokenKind::OpenParenthesis) {
+                    expr = &factory.elementSelectExpression(*expr, parseElementSelect());
+                }
+                else {
+                    // This is the loop-variable bracket — leave it for parseForeachLoopVariables.
+                    return *expr;
+                }
+                break;
+            }
+            default:
+                return *expr;
+        }
+    }
+}
+
 NameSyntax& Parser::parseNamePart(bitmask<NameOptions> options) {
     auto kind = getKeywordNameExpression(peek().kind);
     if (kind != SyntaxKind::Unknown) {

--- a/source/parsing/Parser_statements.cpp
+++ b/source/parsing/Parser_statements.cpp
@@ -438,10 +438,12 @@ NameSyntax& Parser::parseForeachLoopVariable() {
 
 ForeachLoopListSyntax& Parser::parseForeachLoopVariables() {
     auto openParen = expect(TokenKind::OpenParenthesis);
-    auto& arrayName = parseName(NameOptions::ForeachName);
+    auto& arrayName = parseForeachArrayExpression();
 
     if (arrayName.kind == SyntaxKind::IdentifierSelectName)
         addDiag(diag::NonstandardForeach, arrayName.sourceRange());
+    else if (!NameSyntax::isKind(arrayName.kind))
+        addDiag(diag::ForeachCallExpr, arrayName.sourceRange());
 
     std::span<TokenOrSyntax> list;
     Token openBracket;

--- a/tests/unittests/ast/StatementTests.cpp
+++ b/tests/unittests/ast/StatementTests.cpp
@@ -1577,6 +1577,60 @@ endclass
     CHECK(diags[0].code == diag::NonstandardForeach);
 }
 
+TEST_CASE("foreach loop with function call as array name") {
+    auto tree = SyntaxTree::fromText(R"(
+module top;
+  typedef struct packed {
+    bit [5:0] c;
+    bit [0:0] b;
+    bit [1:0] p;
+  } ps;
+
+  class c1;
+    ps da1[$];
+  endclass
+
+  class c2;
+    static local c2 m_self;
+    c1 da2[$];
+    static function c2 self();
+      return m_self;
+    endfunction: self
+  endclass
+
+  task t;
+    ps da3[$];
+    foreach(c2::self().da2[t_id]) begin
+      da3 = {da3, c2::self().da2[t_id].da1};
+    end
+  endtask
+endmodule
+)");
+
+    Compilation compilation;
+    compilation.addSyntaxTree(tree);
+    auto& diags = compilation.getAllDiagnostics();
+    REQUIRE(diags.size() == 1);
+    CHECK(diags[0].code == diag::ForeachCallExpr);
+}
+
+TEST_CASE("foreach loop intermediate bracket followed by invocation") {
+    // Covers the OpenParenthesis branch in parseForeachArrayExpression's OpenBracket
+    // handler.  Non-name foreach expressions emit ForeachCallExpr at parse time.
+    auto tree = SyntaxTree::fromText(R"(
+module m;
+    initial begin
+        foreach(f()[0]()[i]) begin
+        end
+    end
+endmodule
+)");
+
+    auto& diags = tree->diagnostics();
+    REQUIRE(diags.size() == 1);
+    CHECK(diags[0].code == diag::ForeachCallExpr);
+}
+
 TEST_CASE("for loop expression error checking") {
     auto tree = SyntaxTree::fromText(R"(
 module m;


### PR DESCRIPTION
The foreach loop's array name was parsed using parseName() which only handles identifiers, class scopes, and member selectors. It had no support for function call argument lists '()', so a foreach with an invocation in the array expression (e.g. foreach(c2::self().da2[i])) failed with spurious parse errors.

Introduce parseForeachArrayExpression() which first calls parseName(ForeachName) for the base name, then extends it in a loop to handle '()' invocations, '.' member accesses, and intermediate '[]' selectors, stopping before the final '[loop_variables]' bracket. Change ForeachLoopList.arrayName from Name to Expression in syntax.txt so the syntax node can hold the resulting ExpressionSyntax tree.