### PR TITLE
Allow hierarchical names as cover cross targets

### DIFF
--- a/include/slang/ast/symbols/CoverSymbols.h
+++ b/include/slang/ast/symbols/CoverSymbols.h
@@ -195,6 +195,7 @@ public:
     static CoverpointSymbol& fromSyntax(const Scope& scope, const syntax::CoverpointSyntax& syntax);
     static CoverpointSymbol& fromImplicit(const Scope& scope,
                                           const syntax::IdentifierNameSyntax& syntax);
+    static CoverpointSymbol& fromImplicit(const Scope& scope, const syntax::NameSyntax& syntax);
 
     const Type& getType() const { return declaredType.getType(); }
 

--- a/scripts/syntax.txt
+++ b/scripts/syntax.txt
@@ -1932,7 +1932,7 @@ token semi
 CoverCross base=Member
 NamedLabel? label
 token cross
-separated_list<IdentifierName> items
+separated_list<Name> items
 CoverageIffClause? iff
 token openBrace
 list<Member> members

--- a/source/ast/symbols/CoverSymbols.cpp
+++ b/source/ast/symbols/CoverSymbols.cpp
@@ -836,6 +836,30 @@ CoverpointSymbol& CoverpointSymbol::fromImplicit(const Scope& scope,
     return *result;
 }
 
+CoverpointSymbol& CoverpointSymbol::fromImplicit(const Scope& scope, const NameSyntax& syntax) {
+    // For a dotted name like "port_cfg.m_lane_pol_inv", use the rightmost identifier
+    // as the coverpoint name. For a simple identifier name, delegate to the other overload.
+    if (syntax.kind == SyntaxKind::IdentifierName)
+        return fromImplicit(scope, syntax.as<IdentifierNameSyntax>());
+
+    // Extract the rightmost name token from a scoped/hierarchical name
+    const NameSyntax* cur = &syntax;
+    while (cur->kind == SyntaxKind::ScopedName)
+        cur = cur->as<ScopedNameSyntax>().right.get();
+
+    SourceLocation loc = syntax.getFirstToken().location();
+    std::string_view name;
+    if (cur->kind == SyntaxKind::IdentifierName)
+        name = cur->as<IdentifierNameSyntax>().identifier.valueText();
+
+    auto& comp = scope.getCompilation();
+    auto result = comp.emplace<CoverpointSymbol>(comp, name, loc);
+    result->isImplicit = true;
+    result->declaredType.setTypeSyntax(comp.createEmptyTypeSyntax(loc));
+    result->declaredType.setInitializerSyntax(syntax, loc);
+    return *result;
+}
+
 const Expression* CoverpointSymbol::getIffExpr() const {
     if (!iffExpr) {
         auto scope = getParentScope();
@@ -925,23 +949,29 @@ CoverCrossSymbol& CoverCrossSymbol::fromSyntax(const Scope& scope, const CoverCr
 
     SmallVector<const CoverpointSymbol*> targets;
     for (auto item : syntax.items) {
-        auto symbol = scope.find(item->identifier.valueText());
-        if (symbol && symbol->kind == SymbolKind::Coverpoint) {
-            targets.push_back(&symbol->as<CoverpointSymbol>());
+        // For simple identifiers, try to look up an existing coverpoint or cross.
+        // For dotted names (e.g. port_cfg.m_lane_pol_inv), fall through to implicit.
+        if (item->kind == SyntaxKind::IdentifierName) {
+            auto& idName = item->as<IdentifierNameSyntax>();
+            auto symbol = scope.find(idName.identifier.valueText());
+            if (symbol && symbol->kind == SymbolKind::Coverpoint) {
+                targets.push_back(&symbol->as<CoverpointSymbol>());
+                continue;
+            }
+            else if (symbol && symbol->kind == SymbolKind::CoverCross) {
+                // If it's a cross, then we'll add all the targets of the cross.
+                auto& cross = symbol->as<CoverCrossSymbol>();
+                for (auto cp : cross.targets)
+                    targets.push_back(cp);
+                continue;
+            }
         }
-        else if (symbol && symbol->kind == SymbolKind::CoverCross) {
-            // If it's a cross, then we'll add all the targets of the cross.
-            auto& cross = symbol->as<CoverCrossSymbol>();
-            for (auto cp : cross.targets)
-                targets.push_back(cp);
-        }
-        else {
-            // If we didn't find a coverpoint, create one implicitly
-            // that will be initialized with this expression.
-            auto& newPoint = CoverpointSymbol::fromImplicit(scope, *item);
-            targets.push_back(&newPoint);
-            implicitMembers.push_back(&newPoint);
-        }
+
+        // If we didn't find a coverpoint (or this is a hierarchical/dotted name),
+        // create one implicitly that will be initialized with this expression.
+        auto& newPoint = CoverpointSymbol::fromImplicit(scope, *item);
+        targets.push_back(&newPoint);
+        implicitMembers.push_back(&newPoint);
     }
 
     auto& comp = scope.getCompilation();

--- a/source/parsing/Parser_members.cpp
+++ b/source/parsing/Parser_members.cpp
@@ -1904,8 +1904,7 @@ CoverCrossSyntax* Parser::parseCoverCross(AttrList attributes, NamedLabelSyntax*
 
     SmallVector<TokenOrSyntax, 8> buffer;
     while (true) {
-        auto name = expect(TokenKind::Identifier);
-        buffer.push_back(&factory.identifierName(name));
+        buffer.push_back(&parseName());
         if (!peek(TokenKind::Comma))
             break;
 

--- a/tests/unittests/ast/CoverTests.cpp
+++ b/tests/unittests/ast/CoverTests.cpp
@@ -823,3 +823,27 @@ endmodule
     compilation.addSyntaxTree(tree);
     NO_COMPILATION_ERRORS;
 }
+
+TEST_CASE("Cover cross with dotted name as target") {
+    auto tree = SyntaxTree::fromText(R"(
+package pkg;
+
+class port_cfg_t;
+    rand bit m_lane_pol_inv;
+    bit [2:0] m_cbp_id;
+endclass
+
+class port_cov_t;
+    covergroup cg with function sample(port_cfg_t port_cfg);
+        cp_cbp_id : coverpoint port_cfg.m_cbp_id;
+        cx : cross port_cfg.m_lane_pol_inv, cp_cbp_id;
+    endgroup
+endclass
+
+endpackage
+)");
+
+    Compilation compilation;
+    compilation.addSyntaxTree(tree);
+    NO_COMPILATION_ERRORS;
+}


### PR DESCRIPTION
Cover cross items were restricted to simple identifiers, causing a parse failure when a class member was used as a target (e.g. port_cfg.m_lane_pol_inv).