### PR TITLE
Make for loop missing initializer downgradable to a warning

### DIFF
--- a/scripts/diagnostics.txt
+++ b/scripts/diagnostics.txt
@@ -221,7 +221,6 @@ error IfaceMethodPure "method in interface class must be marked 'pure'"
 error NestedIface "interface classes cannot be nested"
 error RegAfterNettype "net type keyword cannot be followed by the 'reg' keyword"
 error ChargeWithTriReg "charge strength can only be specified for 'trireg' nets"
-error InitializerRequired "initializer expression required"
 error DriveStrengthInvalid "combination of drive strengths is invalid; need one for value '0' and one for '1'"
 error DriveStrengthHighZ "combination of drive strengths is invalid; cannot combine 'highz0' and 'highz1'"
 error PullStrengthHighZ "pullup and pulldown strengths cannot be 'highz0' or 'highz1'"
@@ -320,6 +319,7 @@ warning split-distweight-op SplitDistWeightOp "split dist weight operator is not
 warning nested-solve-before SolveBeforeDisallowed "constraint ordering directive is not allowed within a nested constraint block"
 warning misplaced-trailing-separator MisplacedTrailingSeparator "misplaced trailing '{}'"
 warning qualifiers-on-out-of-block QualifiersOnOutOfBlock "qualifiers are not allowed on out-of-block method definitions"
+warning initializer-required InitializerRequired "initializer expression required"
 note NoteToMatchThis "to match this '{}'"
 note NoteLastBlockStarted "last complete block started here"
 note NoteLastBlockEnded "and ended here"
@@ -1282,7 +1282,8 @@ group default = { real-underflow real-overflow vector-overflow int-overflow unco
                   seq-no-match case-too-complex nested-solve-before dynamic-non-procedural
                   nonstandard-string-concat nested-comment multi-write read-write mixed-var-assigns
                   multiple-cont-assigns multiple-always-assigns misplaced-trailing-separator
-                  qualifiers-on-out-of-block member-impl-not-found shift-count-overflow shift-count-negative }
+                  qualifiers-on-out-of-block member-impl-not-found shift-count-overflow shift-count-negative
+                  initializer-required }
 
 group extra = { empty-member empty-stmt dup-import pointless-void-cast case-gen-none case-gen-dup
                 unused-result format-real ignored-slice task-ignored width-trunc dup-attr event-const

--- a/scripts/warning_docs.txt
+++ b/scripts/warning_docs.txt
@@ -1750,6 +1750,19 @@ module memMod();
 endmodule
 ```
 
+-Winitializer-required
+A variable declared in a for loop initializer does not have an initializer expression. SystemVerilog
+requires that such variables be initialized at the point of declaration.
+This is an error by default but can be downgraded to a warning for compatibility with tools.
+```
+module m;
+    initial begin
+        for (int i; i < 4; i++) begin
+        end
+    end
+endmodule
+```
+
 -Wmember-impl-not-found
 A class has the declaration for a member method, but the implementation of that member method is not
 found either in the class or as an out of body definition.

--- a/source/driver/CompatSettings.cpp
+++ b/source/driver/CompatSettings.cpp
@@ -93,6 +93,7 @@ void CompatSettings::configureDiagnostics(DiagnosticEngine& diagEngine) const {
                  diag::MultipleContAssigns,
                  diag::MultipleAlwaysAssigns,
                  diag::MisplacedTrailingSeparator,
+                 diag::InitializerRequired,
              }) {
             diagEngine.setBaselineSeverity(d, DiagnosticSeverity::Error);
         }
@@ -127,6 +128,7 @@ void CompatSettings::configureDiagnostics(DiagnosticEngine& diagEngine) const {
                  diag::DynamicNotProcedural,
                  diag::QualifiersOnOutOfBlock,
                  diag::MemberImplNotFound,
+                 diag::InitializerRequired,
              }) {
             diagEngine.setBaselineSeverity(d, DiagnosticSeverity::Error);
         }


### PR DESCRIPTION
The 'initializer expression required' diagnostic (issued when a for loop variable declaration lacks an initializer, e.g. 'for (int i; ...)') is now a warning promoted to error by default, consistent with similar diagnostics. Users can suppress it with -Wno-initializer-required for compatibility with tools that accept this construct.

Make it a warning by default in compat mode.