### PR TITLE
Allow package import declarations inside class bodies in VCS compat mode

### DIFF
--- a/scripts/diagnostics.txt
+++ b/scripts/diagnostics.txt
@@ -320,6 +320,7 @@ warning nested-solve-before SolveBeforeDisallowed "constraint ordering directive
 warning misplaced-trailing-separator MisplacedTrailingSeparator "misplaced trailing '{}'"
 warning qualifiers-on-out-of-block QualifiersOnOutOfBlock "qualifiers are not allowed on out-of-block method definitions"
 warning initializer-required InitializerRequired "initializer expression required"
+warning package-import-in-class PackageImportInClass "package import not allowed in class declaration"
 note NoteToMatchThis "to match this '{}'"
 note NoteLastBlockStarted "last complete block started here"
 note NoteLastBlockEnded "and ended here"
@@ -1284,7 +1285,7 @@ group default = { real-underflow real-overflow vector-overflow int-overflow unco
                   nonstandard-string-concat nested-comment multi-write read-write mixed-var-assigns
                   multiple-cont-assigns multiple-always-assigns misplaced-trailing-separator
                   qualifiers-on-out-of-block member-impl-not-found shift-count-overflow shift-count-negative
-                  initializer-required }
+                  initializer-required package-import-in-class }
 
 group extra = { empty-member empty-stmt dup-import pointless-void-cast case-gen-none case-gen-dup
                 unused-result format-real ignored-slice task-ignored width-trunc dup-attr event-const

--- a/scripts/warning_docs.txt
+++ b/scripts/warning_docs.txt
@@ -1763,6 +1763,19 @@ module m;
 endmodule
 ```
 
+-Wpackage-import-in-class
+A package import declaration was found inside a class body. This is not allowed by the SystemVerilog
+LRM but is supported by some tools. In VCS compatibility mode this is a warning; otherwise it is an
+error that can be downgraded to a warning.
+```
+package p;
+  int x;
+endpackage
+class c;
+  import p::*;
+endclass
+```
+
 -Wmember-impl-not-found
 A class has the declaration for a member method, but the implementation of that member method is not
 found either in the class or as an out of body definition.

--- a/source/ast/Scope.cpp
+++ b/source/ast/Scope.cpp
@@ -433,6 +433,9 @@ void Scope::addMembers(const SyntaxNode& syntax) {
                         addMember(*param);
                     break;
                 }
+                case SyntaxKind::PackageImportDeclaration:
+                    addMembers(*cpd.declaration);
+                    break;
                 default:
                     // All other possible member kinds here are illegal and will
                     // be diagnosed in the parser, so just ignore them.

--- a/source/driver/CompatSettings.cpp
+++ b/source/driver/CompatSettings.cpp
@@ -128,6 +128,7 @@ void CompatSettings::configureDiagnostics(DiagnosticEngine& diagEngine) const {
                  diag::DynamicNotProcedural,
                  diag::QualifiersOnOutOfBlock,
                  diag::MemberImplNotFound,
+                 diag::PackageImportInClass,
              }) {
             diagEngine.setBaselineSeverity(d, DiagnosticSeverity::Error);
         }

--- a/source/parsing/Parser_members.cpp
+++ b/source/parsing/Parser_members.cpp
@@ -1367,10 +1367,14 @@ MemberSyntax* Parser::parseClassMember(bool isIfaceClass, bool hasBaseClass) {
 
             errorIfIface(decl);
         }
-        else if (decl.kind == SyntaxKind::PackageImportDeclaration ||
-                 decl.kind == SyntaxKind::NetTypeDeclaration ||
+        else if (decl.kind == SyntaxKind::PackageImportDeclaration) {
+            // Package imports are not allowed in classes per the LRM but are supported
+            // by some tools (e.g. VCS); emit a separate downgradable diagnostic.
+            addDiag(diag::PackageImportInClass, decl.sourceRange());
+        }
+        else if (decl.kind == SyntaxKind::NetTypeDeclaration ||
                  decl.kind == SyntaxKind::LetDeclaration) {
-            // Nettypes and package imports are disallowed in classes.
+            // Nettypes and let declarations are disallowed in classes.
             addDiag(diag::NotAllowedInClass, decl.sourceRange());
         }
         else {

--- a/tests/unittests/ast/ClassTests.cpp
+++ b/tests/unittests/ast/ClassTests.cpp
@@ -167,7 +167,7 @@ endfunction
     CHECK(diags[11].code == diag::InvalidMethodQualifier);
     CHECK(diags[12].code == diag::MethodStaticLifetime);
     CHECK(diags[13].code == diag::InvalidQualifierForMember);
-    CHECK(diags[14].code == diag::NotAllowedInClass);
+    CHECK(diags[14].code == diag::PackageImportInClass);
     CHECK(diags[15].code == diag::InvalidQualifierForConstructor);
     CHECK(diags[16].code == diag::InvalidQualifierForConstructor);
     CHECK(diags[17].code == diag::QualifiersOnOutOfBlock);
@@ -3874,4 +3874,29 @@ endpackage
     Compilation compilation;
     compilation.addSyntaxTree(tree);
     NO_COMPILATION_ERRORS;
+}
+
+TEST_CASE("Package import inside class") {
+    auto tree = SyntaxTree::fromText(R"(
+package p1;
+  bit b;
+endpackage
+
+package p2;
+  class c;
+    import p1::*;
+    int i;
+    function void f;
+      i = b ? 1 : 0;
+    endfunction
+  endclass
+endpackage
+)");
+
+    // Package imports in classes are non-standard but allowed with a warning.
+    Compilation compilation;
+    compilation.addSyntaxTree(tree);
+    auto& diags = compilation.getAllDiagnostics();
+    REQUIRE(diags.size() == 1);
+    CHECK(diags[0].code == diag::PackageImportInClass);
 }


### PR DESCRIPTION
IEEE 1800-2023 Clause 26, Syntax 26-2, note 15 explicitly states: "It shall be illegal to have an import statement directly within a class scope."

Some tools (e.g. VCS) support it anyway. Add a new downgradable diagnostic PackageImportInClass (warning in VCS compat mode, error otherwise) so users can control the severity.

Also fix the AST ClassPropertyDeclaration handler in Scope::addMembers, which silently dropped PackageImportDeclaration in its default case since it had only ever seen illegal members there. Now it delegates to the generic PackageImportDeclaration handler so wildcard and explicit imports are resolved from inside class method bodies.