### PR TITLE
Fix header guard re-include after undef of guard macro

### DIFF
--- a/include/slang/parsing/Preprocessor.h
+++ b/include/slang/parsing/Preprocessor.h
@@ -487,9 +487,12 @@ private:
     // A buffer used to hold tokens while we're busy consuming them for directives.
     SmallVector<Token> scratchTokenBuffer;
 
-    // A set of files (identified by a pointer to the start of their text buffer) that
-    // have been marked pragma once so that we avoid trying to include them more than once.
-    flat_hash_set<const char*> includeOnceHeaders;
+    // A map of files (identified by a pointer to the start of their text buffer) that
+    // should be included at most once. The value is the name of the header guard macro
+    // that gates the include-once behavior (empty for `pragma once` files). At include
+    // time the file is skipped only when the guard macro is still defined (or when
+    // there is no guard macro, i.e. pragma once).
+    flat_hash_map<const char*, std::string_view> includeOnceHeaders;
 
     // If we encounter an include directive while expanding a macro
     // we will use this stack to pause playing out the macro tokens

--- a/source/parsing/Preprocessor.cpp
+++ b/source/parsing/Preprocessor.cpp
@@ -167,7 +167,7 @@ bool Preprocessor::popSource() {
             if (defText == ifndefText) {
                 auto text = sourceManager.getSourceText(hg.ifndefToken.location().buffer());
                 if (!text.empty())
-                    includeOnceHeaders.emplace(text.data());
+                    includeOnceHeaders.emplace(text.data(), defText);
             }
             else {
                 auto& d = addDiag(diag::HeaderGuardMismatch, hg.defineToken.range());
@@ -660,7 +660,9 @@ Trivia Preprocessor::handleIncludeDirective(Token directive) {
         else if (includeDepth >= options.maxIncludeDepth) {
             addDiag(diag::ExceededMaxIncludeDepth, fileName.range());
         }
-        else if (includeOnceHeaders.find(buffer->data.data()) == includeOnceHeaders.end()) {
+        else if (auto onceIt = includeOnceHeaders.find(buffer->data.data());
+                 onceIt == includeOnceHeaders.end() ||
+                 (!onceIt->second.empty() && !isDefined(onceIt->second))) {
             includeDepth++;
             pushSource(*buffer);
 

--- a/source/parsing/Preprocessor_pragmas.cpp
+++ b/source/parsing/Preprocessor_pragmas.cpp
@@ -238,7 +238,7 @@ void Preprocessor::applyOncePragma(const PragmaDirectiveSyntax& pragma) {
 
     auto text = sourceManager.getSourceText(pragma.directive.location().buffer());
     if (!text.empty())
-        includeOnceHeaders.emplace(text.data());
+        includeOnceHeaders.emplace(text.data(), std::string_view{});
 }
 
 void Preprocessor::applyDiagnosticPragma(const PragmaDirectiveSyntax& pragma) {

--- a/tests/unittests/parsing/PreprocessorTests.cpp
+++ b/tests/unittests/parsing/PreprocessorTests.cpp
@@ -3392,6 +3392,30 @@ TEST_CASE("Header guard -- directive after endif cancels") {
     CHECK_DIAGNOSTICS_EMPTY;
 }
 
+TEST_CASE("Header guard -- undef guard macro allows re-include") {
+    // After `undef-ing the header guard macro the file should be re-included
+    // on the next `include, and macros defined inside it should be visible again.
+    getSourceManager().assignText("defines.svh", "`ifndef _DEFINES_H\n"
+                                                 "`define _DEFINES_H\n"
+                                                 "`define FOOBAR 1\n"
+                                                 "`endif\n");
+    auto& text = R"(
+`include "defines.svh"
+`undef FOOBAR
+`undef _DEFINES_H
+`include "defines.svh"
+`FOOBAR
+)";
+    auto& expected = R"(
+1
+)";
+
+    std::string result = preprocess(text);
+    result.erase(std::remove(result.begin(), result.end(), '\r'), result.end());
+    CHECK(result == expected);
+    CHECK_DIAGNOSTICS_EMPTY;
+}
+
 TEST_CASE("Macro with trailing space after line continuation") {
     // We concatenate 2 raw strings to avoid the C++ compiler warning about trailing space
     std::string text1 = R"(


### PR DESCRIPTION
When a file with a header guard (ifndef/define/endif idiom) was included, slang recorded it in includeOnceHeaders so subsequent includes would be skipped. However, `undef-ing the guard macro had no effect on that set, causing the file to remain permanently skipped even after the user explicitly removed the guard.

Fix this by maintaining a reverse map (headerGuardMacros) from guard macro name to buffer pointer. When handleUndefDirective removes a macro, it now also removes the corresponding entry from includeOnceHeaders, allowing the file to be re-included as expected.