### PR TITLE
Add file kind tracking and debug output when parsing files

### DIFF
--- a/docs/command-line-ref.dox
+++ b/docs/command-line-ref.dox
@@ -111,6 +111,13 @@ printing all macros in a single flat sorted list. Each group is preceded by a co
 of the form `//<filename>:` so the originating file is clearly visible. Has no effect when
 used without `--macros-only`.
 
+`--show-parsed-files`
+
+Print the name and kind of each file as it is parsed. For each file, the output includes
+whether it is a design, library, library map, or include file, and indicates when the preprocessor
+returns to a previously active file after finishing an include. This is useful for tracing which
+files are parsed and in what order.
+
 `--parse-only`
 
 Perform parsing of all input files but don't perform type checking and elaboration.

--- a/include/slang/driver/Driver.h
+++ b/include/slang/driver/Driver.h
@@ -17,6 +17,8 @@
 #include "slang/text/SourceManager.h"
 #include "slang/util/Bag.h"
 #include "slang/util/CommandLine.h"
+#include "slang/util/ConcurrentMap.h"
+#include "slang/util/Function.h"
 #include "slang/util/LanguageVersion.h"
 #include "slang/util/OS.h"
 #include "slang/util/Util.h"
@@ -175,6 +177,10 @@ public:
         /// If true, the preprocessor will allow trailing spaces after the continuation character
         /// in macro definitions.
         std::optional<bool> allowMacroTrailingSpace;
+
+        /// If true, the preprocessor will print the name and kind of each file
+        /// as it is parsed.
+        std::optional<bool> showParsedFiles;
 
         /// @}
         /// @name Parsing
@@ -467,7 +473,8 @@ private:
     bool parseUnitListing(std::string_view text);
     std::string parseMapKeywordVersion(std::string_view value);
     void addLibraryFiles(std::string_view pattern);
-    void addParseOptions(Bag& bag) const;
+    void addParseOptions(Bag& bag,
+                         function_ref<void(BufferID, bool, bool)> bufferChangeCB = nullptr) const;
     void addCompilationOptions(Bag& bag) const;
     bool reportLoadErrors();
 
@@ -476,6 +483,9 @@ private:
     std::vector<std::tuple<std::string_view, std::string_view, std::string_view>>
         translateOffFormats;
     std::unique_ptr<JsonWriter> jsonWriter;
+
+    /// For storing the list of file parsing strings, keyed by thread index.
+    concurrent_map<size_t, std::vector<std::string>> parsedFiles;
 };
 
 } // namespace slang::driver

--- a/include/slang/parsing/Lexer.h
+++ b/include/slang/parsing/Lexer.h
@@ -118,6 +118,9 @@ public:
     /// Returns the library with which the lexer's source buffer is associated.
     const SourceLibrary* getLibrary() const { return library; }
 
+    /// Returns the BufferID of the source buffer being lexed.
+    BufferID getBufferId() const { return bufferId; }
+
     /// Concatenates two tokens together. This may result in more than one output token
     /// if the right hand token being concatenated ends up splitting and being re-lexed.
     /// Returns true if the concatenation succeeded and false otherwise.

--- a/include/slang/parsing/Preprocessor.h
+++ b/include/slang/parsing/Preprocessor.h
@@ -16,6 +16,7 @@
 #include "slang/text/SourceLocation.h"
 #include "slang/text/SourceManager.h"
 #include "slang/util/Bag.h"
+#include "slang/util/Function.h"
 #include "slang/util/SmallMap.h"
 #include "slang/util/SmallVector.h"
 
@@ -63,6 +64,12 @@ struct SLANG_EXPORT PreprocessorOptions {
 
     /// A list of mappings from file patterns to language keyword versions.
     std::vector<std::pair<std::string, KeywordVersion>> keywordMapping;
+
+    /// Optional callback invoked whenever the preprocessor pushes or pops a source
+    /// file (including include files and skipped headers). The arguments are the
+    /// BufferID of the affected file, whether we are returning to a file (isBack),
+    /// and whether the file is being skipped as an already-included header (isSkip).
+    function_ref<void(BufferID, bool, bool)> bufferChangeCB;
 };
 
 /// Metadata about an include directive that was invoked.

--- a/include/slang/text/SourceManager.h
+++ b/include/slang/text/SourceManager.h
@@ -93,6 +93,24 @@ public:
     /// or nullptr if it's not explicitly part of any library.
     const SourceLibrary* getLibraryFor(BufferID buffer) const;
 
+    /// Describes the origin of a source buffer.
+    enum class BufferKind {
+        Unknown,
+        DesignFile,
+        LibraryFile,
+        LibraryMap,
+        IncludeFile,
+        Macro,
+        MacroArg
+    };
+
+    /// Gets the kind for the given buffer. Returns BufferKind::Macro or BufferKind::MacroArg
+    /// for macro expansion buffers, and the appropriate file kind for source file buffers.
+    BufferKind getBufferKind(BufferID buffer) const;
+
+    /// Marks the given source file buffer as the specified kind.
+    void setBufferKind(BufferID buffer, BufferKind kind);
+
     /// Attempts to get the name of the macro represented by a macro location.
     /// If no macro name can be found, returns an empty string view.
     std::string_view getMacroName(SourceLocation location) const;
@@ -272,12 +290,15 @@ private:
         const SourceLibrary* library = nullptr;
         SourceLocation includedFrom;
         uint64_t sortKey = 0;
+        BufferKind bufferKind = BufferKind::DesignFile;
         std::vector<LineDirectiveInfo> lineDirectives;
 
         FileInfo() {}
+
         FileInfo(FileData* data, const SourceLibrary* library, SourceLocation includedFrom,
                  uint64_t sortKey) :
-            data(data), library(library), includedFrom(includedFrom), sortKey(sortKey) {}
+            data(data), library(library), includedFrom(includedFrom), sortKey(sortKey),
+            bufferKind(includedFrom.valid() ? BufferKind::IncludeFile : BufferKind::DesignFile) {}
 
         // Returns a pointer to the LineDirectiveInfo for the nearest enclosing
         // line directive of the given raw line number, or nullptr if there is none

--- a/source/driver/Driver.cpp
+++ b/source/driver/Driver.cpp
@@ -105,6 +105,8 @@ void Driver::addStandardArgs() {
     cmdLine.add("--allow-macro-trailing-space", options.allowMacroTrailingSpace,
                 "If true, the preprocessor will allow trailing whitespaces after the continuation "
                 "character in a macro definition");
+    cmdLine.add("--show-parsed-files", options.showParsedFiles,
+                "Print the name and kind of each file as it is parsed.");
 
     // Legacy vendor commands support
     cmdLine.add(
@@ -954,13 +956,68 @@ void Driver::optionallyWriteDepFiles() {
 }
 
 bool Driver::parseAllSources() {
+    Bag bag;
+
+    std::function<void(BufferID, bool, bool)> cb;
+    if (options.showParsedFiles == true) {
+        cb = [&](BufferID buf, bool isBack, bool isSkip) {
+            std::string_view kind;
+            switch (sourceManager.getBufferKind(buf)) {
+                case SourceManager::BufferKind::LibraryFile:
+                    kind = "library";
+                    break;
+                case SourceManager::BufferKind::LibraryMap:
+                    kind = "libmap";
+                    break;
+                case SourceManager::BufferKind::DesignFile:
+                    kind = "design";
+                    break;
+                case SourceManager::BufferKind::IncludeFile:
+                    kind = "include";
+                    break;
+                default:
+                    kind = "";
+                    break;
+            }
+            auto path = sourceManager.getFullPath(buf).string();
+            std::string msg;
+            if (isBack)
+                msg = fmt::format("Back to file '{}'.\n", path);
+            else
+                msg = fmt::format("{} {} file '{}'.\n", isSkip ? "Skipping" : "Parsing", kind,
+                                  path);
+#if defined(SLANG_USE_THREADS)
+            size_t idx = BS::this_thread::get_index().value_or(0);
+#else
+            size_t idx = 0;
+#endif
+            auto appendMsg = [&](auto& entry) { entry.second.push_back(std::move(msg)); };
+            parsedFiles.try_emplace_and_visit(idx, appendMsg, appendMsg);
+        };
+        addParseOptions(bag, cb);
+    }
+    else {
+        addParseOptions(bag);
+    }
+
     if (!threadPool) {
         const auto numThreads = options.numThreads.value_or(0u);
         if (numThreads != 1u)
             threadPool = std::make_shared<ThreadPool>(numThreads);
     }
 
-    syntaxTrees = sourceLoader.loadAndParseSources(createParseOptionBag(), threadPool.get());
+    syntaxTrees = sourceLoader.loadAndParseSources(bag, threadPool.get());
+
+    std::vector<std::pair<size_t, std::vector<std::string>>> threadOutputs;
+    parsedFiles.cvisit_all(
+        [&](const auto& entry) { threadOutputs.emplace_back(entry.first, entry.second); });
+    std::sort(threadOutputs.begin(), threadOutputs.end(),
+              [](const auto& a, const auto& b) { return a.first < b.first; });
+    for (auto& [idx, msgs] : threadOutputs) {
+        for (auto& msg : msgs)
+            OS::print(msg);
+    }
+
     if (!reportLoadErrors())
         return false;
 
@@ -987,7 +1044,8 @@ Bag Driver::createOptionBag() const {
     return bag;
 }
 
-void Driver::addParseOptions(Bag& bag) const {
+void Driver::addParseOptions(Bag& bag,
+                             function_ref<void(BufferID, bool, bool)> bufferChangeCB) const {
     SourceOptions soptions;
     soptions.numThreads = options.numThreads;
     soptions.singleUnit = options.singleUnit == true;
@@ -1004,6 +1062,8 @@ void Driver::addParseOptions(Bag& bag) const {
         ppoptions.maxIncludeDepth = *options.maxIncludeDepth;
     for (const auto& d : options.ignoreDirectives)
         ppoptions.ignoreDirectives.emplace(d);
+    if (bufferChangeCB)
+        ppoptions.bufferChangeCB = bufferChangeCB;
 
     LexerOptions loptions;
     loptions.languageVersion = languageVersion;

--- a/source/driver/SourceLoader.cpp
+++ b/source/driver/SourceLoader.cpp
@@ -556,6 +556,11 @@ SourceLoader::LoadResult SourceLoader::loadAndParse(const FileEntry& entry, cons
     if (!buffer)
         return std::pair{&entry, buffer.error()};
 
+    if (entry.isLibraryFile)
+        sourceManager.setBufferKind(buffer->id, SourceManager::BufferKind::LibraryFile);
+    else
+        sourceManager.setBufferKind(buffer->id, SourceManager::BufferKind::DesignFile);
+
     if (entry.unit) {
         return std::pair{*buffer, entry.unit};
     }

--- a/source/parsing/Preprocessor.cpp
+++ b/source/parsing/Preprocessor.cpp
@@ -126,6 +126,8 @@ void Preprocessor::pushSource(SourceBuffer buffer) {
         }
     }
 
+    if (options.bufferChangeCB && includeDepth > 0)
+        options.bufferChangeCB(buffer.id, false, false);
     lexerStack.emplace_back(
         std::make_unique<Lexer>(buffer, alloc, diagnostics, sourceManager, lexerOptions));
 
@@ -149,6 +151,7 @@ void Preprocessor::pushSource(SourceBuffer buffer) {
 }
 
 bool Preprocessor::popSource() {
+    auto prevIncludeDepth = includeDepth;
     if (includeDepth)
         includeDepth--;
 
@@ -180,6 +183,8 @@ bool Preprocessor::popSource() {
     headerGuardStack.pop_back();
 
     lexerStack.pop_back();
+    if (options.bufferChangeCB && !lexerStack.empty())
+        options.bufferChangeCB(lexerStack.back()->getBufferId(), prevIncludeDepth > 0, false);
 
     if (!pendingMacroFrames.empty() && lexerStack.size() == pendingMacroFrames.back().lexerDepth) {
         auto& frame = pendingMacroFrames.back();
@@ -673,6 +678,9 @@ Trivia Preprocessor::handleIncludeDirective(Token directive) {
                 .buffer = *buffer,
                 .isSystem = isSystem,
             });
+        }
+        else if (options.bufferChangeCB) {
+            options.bufferChangeCB(buffer->id, false, true);
         }
     }
 

--- a/source/syntax/SyntaxTree.cpp
+++ b/source/syntax/SyntaxTree.cpp
@@ -165,6 +165,10 @@ std::shared_ptr<SyntaxTree> SyntaxTree::create(SourceManager& sourceManager,
         library = it->library;
     }
 
+    const auto ppOpts = options.getOrDefault<PreprocessorOptions>();
+    if (ppOpts.bufferChangeCB)
+        ppOpts.bufferChangeCB(sources.front().id, false, false);
+
     Parser parser(preprocessor, options);
 
     SyntaxNode* root;
@@ -215,6 +219,8 @@ std::shared_ptr<SyntaxTree> SyntaxTree::fromLibraryMapText(std::string_view text
 std::shared_ptr<SyntaxTree> SyntaxTree::fromLibraryMapBuffer(const SourceBuffer& buffer,
                                                              SourceManager& sourceManager,
                                                              const Bag& options) {
+    sourceManager.setBufferKind(buffer.id, SourceManager::BufferKind::LibraryMap);
+
     BumpAllocator alloc;
     Diagnostics diagnostics;
     Preprocessor preprocessor(sourceManager, alloc, diagnostics, options);

--- a/source/text/SourceManager.cpp
+++ b/source/text/SourceManager.cpp
@@ -193,6 +193,26 @@ const SourceLibrary* SourceManager::getLibraryFor(BufferID buffer) const {
     return info->library;
 }
 
+SourceManager::BufferKind SourceManager::getBufferKind(BufferID buffer) const {
+    std::shared_lock<std::shared_mutex> lock(mutex);
+    if (buffer && buffer.getId() < bufferEntries.size()) {
+        if (auto* exp = std::get_if<ExpansionInfo>(&bufferEntries[buffer.getId()]))
+            return exp->isMacroArg ? BufferKind::MacroArg : BufferKind::Macro;
+    }
+    auto info = getFileInfo(buffer, lock);
+    if (!info)
+        return BufferKind::Unknown;
+
+    return info->bufferKind;
+}
+
+void SourceManager::setBufferKind(BufferID buffer, BufferKind kind) {
+    std::unique_lock<std::shared_mutex> lock(mutex);
+    auto info = getFileInfo(buffer, lock);
+    if (info)
+        info->bufferKind = kind;
+}
+
 std::string_view SourceManager::getMacroName(SourceLocation location) const {
     std::shared_lock<std::shared_mutex> lock(mutex);
     while (isMacroArgLocImpl(location, lock))

--- a/tests/unittests/DriverTests.cpp
+++ b/tests/unittests/DriverTests.cpp
@@ -9,6 +9,7 @@
 #include "slang/ast/symbols/CompilationUnitSymbols.h"
 #include "slang/ast/symbols/InstanceSymbols.h"
 #include "slang/driver/Driver.h"
+#include "slang/text/SourceManager.h"
 
 using namespace slang::driver;
 
@@ -660,6 +661,57 @@ TEST_CASE("Driver load library maps") {
     }
 
     CHECK(driver.sourceLoader.getLibraryMaps().size() == 2);
+}
+
+TEST_CASE("Driver file kind tracking") {
+    auto guard = OS::captureOutput();
+
+    Driver driver;
+    driver.addStandardArgs();
+
+    auto testDir = findTestDir();
+    auto args = fmt::format("testfoo \"{0}test6.sv\" --libmap \"{0}/library/lib.map\" -v "
+                            "\"{0}test5.sv\" \"{0}test6.sv\"",
+                            testDir);
+    CHECK(driver.parseCommandLine(args));
+    CHECK(driver.processOptions());
+    CHECK(driver.parseAllSources());
+
+    auto& sm = driver.sourceManager;
+    for (auto buf : sm.getAllBuffers()) {
+        if (sm.isMacroLoc(SourceLocation(buf, 0)) || sm.getIncludedFrom(buf))
+            continue;
+
+        auto name = sm.getRawFileName(buf);
+        auto kind = sm.getBufferKind(buf);
+        if (contains(name, ".map"))
+            CHECK(kind == SourceManager::BufferKind::LibraryMap);
+        else if (contains(name, "test5.sv"))
+            CHECK(kind == SourceManager::BufferKind::LibraryFile);
+        else if (contains(name, "test6.sv"))
+            CHECK(kind == SourceManager::BufferKind::DesignFile);
+        else if (contains(name, "macro.svh"))
+            CHECK(kind == SourceManager::BufferKind::IncludeFile);
+    }
+}
+
+TEST_CASE("Driver show parsed files output") {
+    auto guard = OS::captureOutput();
+
+    Driver driver;
+    driver.addStandardArgs();
+
+    auto testDir = findTestDir();
+    auto args = fmt::format(
+        "testfoo \"{0}test5.sv\" \"{0}test6.sv\" --single-unit --show-parsed-files", testDir);
+    CHECK(driver.parseCommandLine(args));
+    CHECK(driver.processOptions());
+    CHECK(driver.parseAllSources());
+
+    CHECK(stdoutContains("Parsing design file"));
+    CHECK(stdoutContains("test5.sv"));
+    CHECK(stdoutContains("test6.sv"));
+    CHECK(stdoutContains("macro.svh"));
 }
 
 TEST_CASE("Driver library map in compilation") {


### PR DESCRIPTION
Adds a FileKind enum (Design, LibraryFile, LibraryMap) to SourceManager so that callers can determine how a buffer was originally loaded. SourceLoader sets the kind when reading buffers: LibraryMap for files loaded via --libmap, and LibraryFile for files loaded via -v/--libfile.

Adds a --show-parsed-files option to the preprocessor that prints the name and kind of each file as it is pushed onto or popped from the lexer stack, making it easier to trace which files are parsed and in what order. The first file processed is printed before the first pop so that it is not silently skipped.