### PR TITLE
Allow super.new() as first statement inside a begin/end constructor b…

### DIFF
--- a/include/slang/parsing/Parser.h
+++ b/include/slang/parsing/Parser.h
@@ -233,7 +233,7 @@ private:
     syntax::ConcurrentAssertionStatementSyntax& parseConcurrentAssertion(syntax::NamedLabelSyntax* label, AttrList attributes);
     syntax::PropertySpecSyntax& parsePropertySpec();
     syntax::ActionBlockSyntax& parseActionBlock();
-    syntax::BlockStatementSyntax& parseBlock(syntax::SyntaxKind blockKind, TokenKind endKind, syntax::NamedLabelSyntax* label, AttrList attributes);
+    syntax::BlockStatementSyntax& parseBlock(syntax::SyntaxKind blockKind, TokenKind endKind, syntax::NamedLabelSyntax* label, AttrList attributes, bool inConstructor = false);
     syntax::StatementSyntax& parseWaitStatement(syntax::NamedLabelSyntax* label, AttrList attributes);
     syntax::WaitOrderStatementSyntax& parseWaitOrderStatement(syntax::NamedLabelSyntax* label, AttrList attributes);
     syntax::RandCaseStatementSyntax& parseRandCaseStatement(syntax::NamedLabelSyntax* label, AttrList attributes);

--- a/source/parsing/Parser_statements.cpp
+++ b/source/parsing/Parser_statements.cpp
@@ -95,7 +95,7 @@ StatementSyntax& Parser::parseStatement(bool allowEmpty, bool allowSuperNew) {
             return parseDisableStatement(label, attributes);
         case TokenKind::BeginKeyword:
             return parseBlock(SyntaxKind::SequentialBlockStatement, TokenKind::EndKeyword, label,
-                              attributes);
+                              attributes, allowSuperNew);
         case TokenKind::ForkKeyword:
             return parseBlock(SyntaxKind::ParallelBlockStatement, TokenKind::JoinKeyword, label,
                               attributes);
@@ -734,12 +734,13 @@ std::span<SyntaxNode*> Parser::parseBlockItems(TokenKind endKind, Token& end, bo
 }
 
 BlockStatementSyntax& Parser::parseBlock(SyntaxKind blockKind, TokenKind endKind,
-                                         NamedLabelSyntax* label, AttrList attributes) {
+                                         NamedLabelSyntax* label, AttrList attributes,
+                                         bool inConstructor) {
     auto begin = consume();
     auto name = parseNamedBlockClause();
 
     Token end;
-    auto items = parseBlockItems(endKind, end, /* inConstructor */ false);
+    auto items = parseBlockItems(endKind, end, inConstructor);
     auto endName = parseNamedBlockClause();
 
     checkBlockNames(name, endName, label);

--- a/tests/unittests/parsing/MemberParsingTests.cpp
+++ b/tests/unittests/parsing/MemberParsingTests.cpp
@@ -517,6 +517,49 @@ endclass
     CHECK(diagnostics[1].code == diag::InvalidSuperNew);
 }
 
+TEST_CASE("super.new inside begin/end block -- valid") {
+    auto& text = R"(
+class A;
+    function new;
+    endfunction
+endclass
+
+class B extends A;
+    function new;
+        begin
+            super.new();
+        end
+    endfunction
+endclass
+)";
+
+    parseCompilationUnit(text);
+    CHECK_DIAGNOSTICS_EMPTY;
+}
+
+TEST_CASE("super.new inside begin/end block -- not first statement") {
+    auto& text = R"(
+class A;
+    function new;
+    endfunction
+endclass
+
+class B extends A;
+    function new;
+        begin
+            $display("Test");
+            super.new();
+        end
+    endfunction
+endclass
+)";
+
+    parseCompilationUnit(text);
+
+    REQUIRE(diagnostics.size() == 1);
+    CHECK(diagnostics[0].code == diag::InvalidSuperNew);
+}
+
 TEST_CASE("Bind directive parsing") {
     auto& text = R"(
 module m1 #(parameter int i)(input logic f);


### PR DESCRIPTION
…lock

The 'first statement' check for super.new() was implemented in parseBlockItems via the inConstructor flag, but parseBlock always passed inConstructor=false to parseBlockItems. This caused super.new() to be rejected when the constructor body began with a begin...end block, even though it was the first statement within that block.

Fix by threading the inConstructor flag through parseBlock so that when a begin block is itself the first statement of a constructor, the constructor context is propagated into the block's item list.

Add unit tests for the valid case (super.new() first inside begin/end) and the invalid case (super.new() after another statement in begin/end).