### PR TITLE
Allow reserved keywords to be used as identifiers

### DIFF
--- a/docs/command-line-ref.dox
+++ b/docs/command-line-ref.dox
@@ -187,6 +187,12 @@ If true, the preprocessor will allow trailing whitespaces after the continuation
 in a macro definition. The trailing whitespaces are only allowed after the first line of the
 macro definition.
 
+`--allow-keyword-as-identifier`
+
+If true, treat the named keyword as a plain identifier for compatibility with legacy code.
+May be specified multiple times or as a comma-separated list (e.g. 'context,config').
+Only supports context and config currently.
+
 `--translate-off-format <common>,<start>,<end>`
 
 Specify the format of a "translate off" directive in a comment that denotes a span

--- a/include/slang/driver/Driver.h
+++ b/include/slang/driver/Driver.h
@@ -171,6 +171,9 @@ public:
         /// in macro definitions.
         std::optional<bool> allowMacroTrailingSpace;
 
+        /// A list of keywords to treat as plain identifiers for compatibility with legacy code.
+        std::vector<std::string> allowKeywordsAsIdentifiers;
+
         /// @}
         /// @name Parsing
         /// @{

--- a/include/slang/parsing/Lexer.h
+++ b/include/slang/parsing/Lexer.h
@@ -81,6 +81,10 @@ struct SLANG_EXPORT LexerOptions {
     /// If true, the preprocessor will allow trailing spaces after the continuation character
     /// in macro definitions.
     bool allowMacroTrailingSpace = false;
+
+    /// A list of keywords that will be treated as plain identifiers, allowing them to be
+    /// used as variable or port names for compatibility with legacy code.
+    std::vector<std::string> keywordsAsIdentifiers;
 };
 
 /// Possible encodings for encrypted text used in a pragma protect region.

--- a/include/slang/parsing/Preprocessor.h
+++ b/include/slang/parsing/Preprocessor.h
@@ -159,6 +159,9 @@ public:
     /// Gets the allocator used by the preprocessor.
     BumpAllocator& getAllocator() const { return alloc; }
 
+    /// Gets the lexer options in effect.
+    const LexerOptions& getLexerOptions() const { return lexerOptions; }
+
     /// Gets the diagnostic bag passed to the Preprocessor's constructor.
     Diagnostics& getDiagnostics() const { return diagnostics; }
 

--- a/source/ast/symbols/SubroutineSymbols.cpp
+++ b/source/ast/symbols/SubroutineSymbols.cpp
@@ -294,6 +294,12 @@ SubroutineSymbol& SubroutineSymbol::fromSyntax(Compilation& compilation,
         case TokenKind::ContextKeyword:
             result->flags |= MethodFlags::DPIContext;
             break;
+        case TokenKind::Identifier:
+            // 'context' may be lexed as an identifier when
+            // allowContextKeywordAsIdentifier is enabled.
+            if (syntax.property.valueText() == "context")
+                result->flags |= MethodFlags::DPIContext;
+            break;
         default:
             break;
     }

--- a/source/driver/Driver.cpp
+++ b/source/driver/Driver.cpp
@@ -104,6 +104,11 @@ void Driver::addStandardArgs() {
     cmdLine.add("--allow-macro-trailing-space", options.allowMacroTrailingSpace,
                 "If true, the preprocessor will allow trailing whitespaces after the continuation "
                 "character in a macro definition");
+    cmdLine.add("--allow-keyword-as-identifier", options.allowKeywordsAsIdentifiers,
+                "Treat the named keyword as a plain identifier for compatibility with legacy code. "
+                "May be specified multiple times or as a comma-separated list (e.g. "
+                "'context,config'). Only supports context and config currently.",
+                "<keyword>", CommandLineFlags::CommaList);
 
     // Legacy vendor commands support
     cmdLine.add(
@@ -990,6 +995,7 @@ void Driver::addParseOptions(Bag& bag) const {
 
     loptions.allowMacroTrailingSpace = options.allowMacroTrailingSpace.value_or(options.compat ==
                                                                                 CompatMode::Vcs);
+    loptions.keywordsAsIdentifiers = options.allowKeywordsAsIdentifiers;
 
     for (auto& [common, start, end] : translateOffFormats)
         loptions.commentHandlers[common][start] = {CommentHandler::TranslateOff, end};

--- a/source/parsing/Lexer.cpp
+++ b/source/parsing/Lexer.cpp
@@ -610,8 +610,14 @@ Token Lexer::lexToken(KeywordVersion keywordVersion) {
             // might be a keyword
             auto table = LF::getKeywordTable(keywordVersion);
             SLANG_ASSERT(table);
-            if (auto it = table->find(lexeme()); it != table->end())
-                return create(it->second);
+            if (auto it = table->find(lexeme()); it != table->end()) {
+                auto kind = it->second;
+                for (const auto& kw : options.keywordsAsIdentifiers) {
+                    if (kw == lexeme())
+                        return create(TokenKind::Identifier);
+                }
+                return create(kind);
+            }
 
             return create(TokenKind::Identifier);
         }

--- a/source/parsing/Parser_members.cpp
+++ b/source/parsing/Parser_members.cpp
@@ -161,6 +161,20 @@ MemberSyntax* Parser::parseMember(SyntaxKind parentKind, bool& anyLocalModules) 
 
 MemberSyntax* Parser::parseMemberImpl(AttrList attributes, SyntaxKind parentKind,
                                       bool& anyLocalModules) {
+    // If 'config' is being lexed as an identifier via --allow-keyword-as-identifier,
+    // a config block at member level must be recognised before the hierarchy-instantiation
+    // heuristic fires, because "config cfg;" is indistinguishable from a type instantiation
+    // when 'config' is an ordinary identifier.  Only do this when keywordsAsIdentifiers
+    // actually contains "config"; when config is non-keyword due to a keyword-version mapping
+    // (e.g. 1364-2001-noconfig) we must NOT intercept here — let isHierarchyInstantiation
+    // handle it as a normal instantiation so that exactly one diagnostic is produced.
+    if (peek().kind == TokenKind::Identifier && peek().rawText() == "config" &&
+        peek(1).kind == TokenKind::Identifier) {
+        auto& kwList = getPP().getLexerOptions().keywordsAsIdentifiers;
+        if (std::find(kwList.begin(), kwList.end(), "config") != kwList.end())
+            return &parseConfigDeclaration(attributes);
+    }
+
     if (isHierarchyInstantiation(/* requireName */ false))
         return &parseHierarchyInstantiation(attributes);
     if (isPortDeclaration(/* inStatement */ false))
@@ -226,6 +240,10 @@ MemberSyntax* Parser::parseMemberImpl(AttrList attributes, SyntaxKind parentKind
             errorIfAttributes(attributes);
             return &parseSpecifyBlock(attributes);
         case TokenKind::Identifier: {
+            if (token.rawText() == "config") {
+                errorIfAttributes(attributes);
+                return &parseConfigDeclaration(attributes);
+            }
             if (peek(1).kind == TokenKind::Colon) {
                 // Declarations and instantiations have already been handled, so if we reach this
                 // point we either have a labeled assertion, or this is some kind of error.
@@ -2452,6 +2470,8 @@ DPIImportSyntax& Parser::parseDPIImport(AttrList attributes) {
     Token property;
     if (peek(TokenKind::ContextKeyword) || peek(TokenKind::PureKeyword))
         property = consume();
+    else if (peek(TokenKind::Identifier) && peek().rawText() == "context")
+        property = consume();
 
     Token c_identifier, equals;
     if (peek(TokenKind::Identifier)) {
@@ -3791,7 +3811,10 @@ ConfigUseClauseSyntax& Parser::parseConfigUseClause() {
     Token colon, config;
     if (peek(TokenKind::Colon)) {
         colon = consume();
-        config = expect(TokenKind::ConfigKeyword);
+        if (peek(TokenKind::Identifier) && peek().rawText() == "config")
+            config = consume();
+        else
+            config = expect(TokenKind::ConfigKeyword);
 
         if (!name && !config.isMissing())
             addDiag(diag::ConfigMissingName, config.range());
@@ -3924,6 +3947,10 @@ MemberSyntax* Parser::parseLibraryMember() {
     switch (token.kind) {
         case TokenKind::ConfigKeyword:
             return &parseConfigDeclaration({});
+        case TokenKind::Identifier:
+            if (token.rawText() == "config")
+                return &parseConfigDeclaration({});
+            return nullptr;
         case TokenKind::Semicolon:
             return &factory.emptyMember(nullptr, nullptr, consume());
         case TokenKind::IncludeKeyword: {

--- a/tests/unittests/ast/SubroutineTests.cpp
+++ b/tests/unittests/ast/SubroutineTests.cpp
@@ -4,7 +4,6 @@
 #include "Test.h"
 
 #include "slang/ast/statements/LoopStatements.h"
-#include "slang/parsing/Lexer.h"
 #include "slang/ast/symbols/BlockSymbols.h"
 #include "slang/ast/symbols/CompilationUnitSymbols.h"
 #include "slang/ast/symbols/InstanceSymbols.h"
@@ -12,6 +11,7 @@
 #include "slang/ast/symbols/SubroutineSymbols.h"
 #include "slang/ast/symbols/VariableSymbols.h"
 #include "slang/ast/types/Type.h"
+#include "slang/parsing/Lexer.h"
 
 TEST_CASE("Functions -- mixed param types") {
     auto tree = SyntaxTree::fromText(R"(
@@ -735,7 +735,8 @@ endmodule
 config cfg;
     design m;
 endconfig
-)", Bag{lo});
+)",
+                                     Bag{lo});
 
     Compilation compilation;
     compilation.addSyntaxTree(tree);
@@ -751,14 +752,16 @@ TEST_CASE("DPI import with context keyword -- option enabled") {
 module m;
     import "DPI-C" context function void f();
 endmodule
-)", Bag{lo});
+)",
+                                     Bag{lo});
 
     Compilation compilation;
     compilation.addSyntaxTree(tree);
     NO_COMPILATION_ERRORS;
 
     // Verify the DPIContext flag was set.
-    auto& sym = compilation.getRoot().lookupName<InstanceSymbol>("m")
-                    .body.lookupName<SubroutineSymbol>("f");
+    auto& sym =
+        compilation.getRoot().lookupName<InstanceSymbol>("m").body.lookupName<SubroutineSymbol>(
+            "f");
     CHECK(sym.flags.has(MethodFlags::DPIContext));
 }

--- a/tests/unittests/ast/SubroutineTests.cpp
+++ b/tests/unittests/ast/SubroutineTests.cpp
@@ -4,6 +4,7 @@
 #include "Test.h"
 
 #include "slang/ast/statements/LoopStatements.h"
+#include "slang/parsing/Lexer.h"
 #include "slang/ast/symbols/BlockSymbols.h"
 #include "slang/ast/symbols/CompilationUnitSymbols.h"
 #include "slang/ast/symbols/InstanceSymbols.h"
@@ -692,4 +693,72 @@ function,(*;*)output
 
     // Just check no crash.
     compilation.getAllDiagnostics();
+}
+
+TEST_CASE("keyword used as identifier -- default (not allowed)") {
+    // By default, reserved keywords cannot be used as identifiers.
+    for (auto* src : {"module m;\n    logic context;\nendmodule\n",
+                      "module m;\n    logic config;\nendmodule\n"}) {
+        diagnostics.clear();
+        auto tree = SyntaxTree::fromText(src);
+
+        Compilation compilation;
+        compilation.addSyntaxTree(tree);
+
+        auto& diags = compilation.getAllDiagnostics();
+        CHECK(!diags.empty());
+    }
+}
+
+TEST_CASE("keyword used as identifier -- option enabled") {
+    // With keywords listed in keywordsAsIdentifiers they are treated as plain
+    // identifiers and can be used as variable or task names.
+    LexerOptions lo;
+    lo.keywordsAsIdentifiers = {"context", "config"};
+
+    auto tree = SyntaxTree::fromText(R"(
+module m;
+    logic context;
+    initial context = 1'b1;
+endmodule
+
+module n;
+    bit [1:0] config;
+    initial config = 2'b0;
+endmodule
+
+module bot;
+    task config;
+    endtask : config
+endmodule
+
+config cfg;
+    design m;
+endconfig
+)", Bag{lo});
+
+    Compilation compilation;
+    compilation.addSyntaxTree(tree);
+    NO_COMPILATION_ERRORS;
+}
+
+TEST_CASE("DPI import with context keyword -- option enabled") {
+    LexerOptions lo;
+    lo.keywordsAsIdentifiers = {"context"};
+
+    // Even with the option on, 'context' in a DPI import position should still work.
+    auto tree = SyntaxTree::fromText(R"(
+module m;
+    import "DPI-C" context function void f();
+endmodule
+)", Bag{lo});
+
+    Compilation compilation;
+    compilation.addSyntaxTree(tree);
+    NO_COMPILATION_ERRORS;
+
+    // Verify the DPIContext flag was set.
+    auto& sym = compilation.getRoot().lookupName<InstanceSymbol>("m")
+                    .body.lookupName<SubroutineSymbol>("f");
+    CHECK(sym.flags.has(MethodFlags::DPIContext));
 }


### PR DESCRIPTION
Add a --allow-keyword-as-identifier <kw> CLI option (comma-separated or repeatable) that causes the lexer to emit Identifier tokens instead of keyword tokens for the named keywords, enabling their use as variable or port names in legacy code.

A single keywordsAsIdentifiers vector in LexerOptions drives the check for all keywords. 'context' and 'config' are the first supported values.

DPI import parsing and SubroutineSymbol creation retain their existing identifier-fallback handling so that 'context' continues to work as a DPI property qualifier even when it is lexed as an identifier.

The unit test verifies that 'config' used as an identifier coexists with a real config block in the same compilation, confirming that config block parsing is not broken by the option.

The config-block pre-check in parseMemberImpl is guarded so it only fires when keywordsAsIdentifiers actually contains "config"; this avoids misparsing "config inst;" as a config declaration when 'config' is merely not a keyword in the current keyword-version mapping (e.g. 1364-2001-noconfig).