### PR TITLE
Stream AST JSON output to file instead of building in memory

### DIFF
--- a/include/slang/text/Json.h
+++ b/include/slang/text/Json.h
@@ -8,6 +8,7 @@
 #pragma once
 
 #include <memory>
+#include <ostream>
 
 #include "slang/util/Util.h"
 
@@ -76,6 +77,12 @@ public:
 
     /// Writes a newline character into the buffer.
     void writeNewLine();
+
+    /// Flushes the accumulated content to the given output stream, retaining
+    /// only the trailing separator state so that subsequent writes continue
+    /// correctly.  Call this after completing each top-level value to bound
+    /// the in-memory buffer size.
+    void flushTo(std::ostream& out);
 
     // Don't let c-strings implicitly convert to bool, we want callers
     // to pass a string_view instead.

--- a/source/text/Json.cpp
+++ b/source/text/Json.cpp
@@ -100,6 +100,20 @@ void JsonWriter::writeNewLine() {
     buffer->append("\n");
 }
 
+void JsonWriter::flushTo(std::ostream& out) {
+    // Write everything up to (but not including) the trailing separator
+    // (trailing comma and any following whitespace/newlines), then discard
+    // that content while keeping the separator in the buffer so the next
+    // write continues with correct punctuation and indentation.
+    size_t contentEnd = findLastComma();
+    out.write(buffer->data(), (std::streamsize)contentEnd);
+
+    // Preserve only the trailing separator.
+    std::string trailing(buffer->data() + contentEnd, buffer->size() - contentEnd);
+    buffer->clear();
+    buffer->append(trailing);
+}
+
 void JsonWriter::writeQuoted(std::string_view str) {
     SmallVector<char> vec(str.size() + 2, UninitializedTag());
     vec.push_back('"');

--- a/tools/driver/slang_main.cpp
+++ b/tools/driver/slang_main.cpp
@@ -28,6 +28,25 @@ using namespace slang::driver;
 void printASTJson(Compilation& compilation, const std::string& fileName,
                   const std::vector<std::string>& scopes, bool includeSourceInfo,
                   bool detailedTypes) {
+    // Stream output directly to the destination.  A single JsonWriter (and
+    // ASTSerializer) is kept alive for the entire run so that shared state
+    // such as the set of already-printed enum types remains consistent across
+    // the design root and all definition serializations.  After each complete
+    // top-level value the buffer is flushed and cleared via flushTo(), keeping
+    // peak memory proportional to the largest single serialized object.
+
+    std::ofstream fileStream;
+    std::ostream* out;
+
+    if (fileName == "-") {
+        out = &std::cout;
+    }
+    else {
+        fileStream.open(fileName);
+        fileStream.exceptions(std::ios::failbit | std::ios::badbit);
+        out = &fileStream;
+    }
+
     JsonWriter writer;
     writer.setPrettyPrint(true);
 
@@ -40,23 +59,30 @@ void printASTJson(Compilation& compilation, const std::string& fileName,
         serializer.startObject();
         serializer.writeProperty("design");
         serializer.serialize(compilation.getRoot());
+        writer.flushTo(*out);
+
         serializer.writeProperty("definitions");
         serializer.startArray();
-        for (auto def : compilation.getDefinitions())
+        for (auto def : compilation.getDefinitions()) {
             serializer.serialize(*def);
+            writer.flushTo(*out);
+        }
         serializer.endArray();
         serializer.endObject();
     }
     else {
         for (auto& scopeName : scopes) {
             auto sym = compilation.getRoot().lookupName(scopeName);
-            if (sym)
+            if (sym) {
                 serializer.serialize(*sym);
+                writer.flushTo(*out);
+            }
         }
     }
 
+    // Write whatever remains in the buffer (closing brackets, final newline).
     writer.writeNewLine();
-    OS::writeFile(fileName, writer.view());
+    writer.flushTo(*out);
 }
 
 void printCSTJson(Driver& driver, const std::string& fileName,


### PR DESCRIPTION
Apply the same streaming approach used for the CST printer to printASTJson.  Add JsonWriter::flushTo(std::ostream&) which writes the accumulated content up to (but not including) the trailing separator to the given stream, then discards that content while retaining the separator in the buffer so subsequent writes remain well-formed.

A single ASTSerializer (and its underlying JsonWriter) is kept alive for the entire output so that shared state -- notably the set of already-printed enum types -- stays consistent across the design root and all definition serializations.  flushTo() is called after serializing the design root and after each individual definition, keeping peak memory proportional to the largest single serialized object rather than the sum of all objects.

The output format is byte-for-byte identical to the previous implementation.