### PR TITLE
Stream CST JSON output to file instead of building in memory

### DIFF
--- a/include/slang/text/Json.h
+++ b/include/slang/text/Json.h
@@ -34,6 +34,11 @@ public:
     /// and indentation are added to make the output more human friendly.
     void setPrettyPrint(bool enabled) { pretty = enabled; }
 
+    /// Sets the initial indentation level (in spaces, not levels).
+    /// Use this when the writer is being used for a sub-tree that will be
+    /// embedded inside an already-indented context.
+    void setInitialIndent(int indent) { currentIndent = indent; }
+
     /// @return a view of the emitted JSON text so far.
     /// @note the returned view is not guaranteed to remain valid once
     /// additional writes are performed.

--- a/tools/driver/slang_main.cpp
+++ b/tools/driver/slang_main.cpp
@@ -61,23 +61,46 @@ void printASTJson(Compilation& compilation, const std::string& fileName,
 
 void printCSTJson(Driver& driver, const std::string& fileName,
                   CSTJsonMode mode = CSTJsonMode::Full) {
-    JsonWriter writer;
-    writer.setPrettyPrint(true);
+    // Stream output directly to the destination instead of accumulating the
+    // entire JSON tree in memory first.  Each syntax tree is serialized into
+    // its own temporary JsonWriter buffer, written out immediately, and then
+    // discarded, keeping memory proportional to the largest single tree.
 
-    CSTSerializer converter(writer, mode);
+    std::ofstream fileStream;
+    std::ostream* out;
 
-    writer.startObject();
-    writer.writeProperty("syntaxTrees");
-    writer.startArray();
+    if (fileName == "-") {
+        out = &std::cout;
+    }
+    else {
+        fileStream.open(fileName);
+        fileStream.exceptions(std::ios::failbit | std::ios::badbit);
+        out = &fileStream;
+    }
 
-    for (auto& tree : driver.syntaxTrees)
+    // Write the outer envelope header.
+    *out << "{\n  \"syntaxTrees\": [";
+
+    // Serialize each tree into a fresh writer and flush it immediately.
+    // setInitialIndent(4) makes each tree object open at the 4-space level
+    // so its contents are indented at 6 spaces, matching the original output.
+    bool first = true;
+    for (auto& tree : driver.syntaxTrees) {
+        JsonWriter treeWriter;
+        treeWriter.setPrettyPrint(true);
+        treeWriter.setInitialIndent(4);
+
+        CSTSerializer converter(treeWriter, mode);
         converter.serialize(*tree);
 
-    writer.endArray();
-    writer.endObject();
+        auto sv = first ? std::string_view("\n    ") : std::string_view(",\n    ");
+        out->write(sv.data(), (std::streamsize)sv.size());
+        first = false;
+        auto view = treeWriter.view();
+        out->write(view.data(), (std::streamsize)view.size());
+    }
 
-    writer.writeNewLine();
-    OS::writeFile(fileName, writer.view());
+    *out << "\n  ]\n}\n";
 }
 
 template<typename TArgs>


### PR DESCRIPTION
Previously printCSTJson accumulated the entire JSON for all syntax trees in a single JsonWriter buffer before calling OS::writeFile, causing peak memory usage proportional to the full output size.

Rework the function to open the output destination once and serialize each syntax tree into a short-lived JsonWriter that is written to the file and destroyed immediately.  Peak memory is now proportional to the largest single tree rather than the sum of all trees.

Add JsonWriter::setInitialIndent so that per-tree writers can be started at the correct nesting depth (4 spaces), keeping the output format byte-for-byte identical to the previous implementation.  The outer envelope ("{\n  \"syntaxTrees\": [" ... "]\n}\n") is written directly
as literal strings, and per-tree separators ("\n    " / ",\n    ") are
written between consecutive tree objects.