### PR TITLE
Add bits-of-integer-constant lint

### DIFF
--- a/scripts/diagnostics.txt
+++ b/scripts/diagnostics.txt
@@ -1076,6 +1076,7 @@ warning format-multibit-strength FormatMultibitStrength "formatting strength val
 warning nonstandard-sys-func NonstandardSysFunc "system function '{}' is non-standard"
 warning isunbounded-param-arg IsUnboundedParamArg "argument to $isunbounded must be the name of a parameter"
 warning dynamic-cast-const DynamicCastConst "$cast from {} to {} will always {}"
+warning bits-of-integer-constant BitsOfIntegerConstant "$bits of expression with type {} always returns '{}'; did you mean to use the constant value directly, or use $clog2?"
 
 subsystem ConstEval
 note NoteInCallTo "in call to '{}'"
@@ -1300,7 +1301,7 @@ group default = { real-underflow real-overflow vector-overflow int-overflow unco
                   multiple-cont-assigns multiple-always-assigns misplaced-trailing-separator
                   qualifiers-on-out-of-block member-impl-not-found shift-count-overflow shift-count-negative
                   initializer-required package-import-in-class foreach-call-expr nonstandard-hierarchical-cross
-                  nonstandard-inside nonstandard-bare-assoc-pattern }
+                  nonstandard-inside nonstandard-bare-assoc-pattern bits-of-integer-constant }
 
 group extra = { empty-member empty-stmt dup-import pointless-void-cast case-gen-none case-gen-dup
                 unused-result format-real ignored-slice task-ignored width-trunc dup-attr event-const

--- a/scripts/warning_docs.txt
+++ b/scripts/warning_docs.txt
@@ -1460,6 +1460,20 @@ class C;
 endclass
 ```
 
+-Wbits-of-integer-constant
+$bits applied to a parameter with a simple integer or scalar type always returns
+the fixed width of that type, not a value derived from the parameter itself.
+For example, `$bits(P)` where P is `parameter int` always returns 32.
+The intention here is often to instead use the parameter directly, or use $clog2().
+```
+module m;
+    parameter int max_value = 10;
+    logic[$bits(max_value+1)-1:0] value;
+
+    logic[$clog2(max_value+1)-1:0] value;
+endmodule
+```
+
 @category Compatibility
 
 -Wdpi-spec

--- a/source/ast/builtins/QueryFuncs.cpp
+++ b/source/ast/builtins/QueryFuncs.cpp
@@ -47,6 +47,12 @@ public:
                 diag.addNote(diag::NoteDeclarationHere, type.location);
             return comp.getErrorType();
         }
+
+        // const evalable integer
+        if (type.isPredefinedInteger() && context.tryEval(*args[0])) {
+            context.addDiag(diag::BitsOfIntegerConstant, range) << type << type.getBitWidth();
+        }
+
         return comp.getIntegerType();
     }
 

--- a/tests/unittests/ast/SystemFuncTests.cpp
+++ b/tests/unittests/ast/SystemFuncTests.cpp
@@ -1680,6 +1680,57 @@ localparam p = $bits(a);
     CHECK(p.getValue().integer() == -8);
 }
 
+TEST_CASE("$bits on simple integer parameter") {
+    auto tree = SyntaxTree::fromText(R"(
+module m;
+    typedef int my_int_t;
+    parameter int P = 5;
+    localparam int LP = 10;
+    parameter my_int_t R = 42;
+    localparam a = $bits(P);
+    localparam b = $bits(P+1);
+    localparam c = $bits(LP);
+    localparam d = $bits(R);
+endmodule
+)");
+
+    Compilation compilation;
+    compilation.addSyntaxTree(tree);
+
+    auto& diags = compilation.getAllDiagnostics();
+    CHECK(diags.size() == 4);
+    for (auto& d : diags)
+        CHECK(d.code == diag::BitsOfIntegerConstant);
+}
+
+TEST_CASE("$bits on simple integer parameter: no warn cases") {
+    auto tree = SyntaxTree::fromText(R"(
+module m #(parameter type T = int, parameter T TP = 5);
+    typedef struct packed { logic [7:0] a; logic [7:0] b; } my_t;
+    parameter my_t S = '{default: 0};
+
+    // Allow type parameters that happen to be ints
+    localparam a = $bits(T);
+    localparam b = $bits(S);
+    // It will warn in this case, but $bits(T) can be used instead.
+    // localparam c = $bits(TP);
+    localparam d = $bits(int);
+
+    // Allow signals that are ints
+    int x;
+    logic [31:0] y;
+    byte z;
+    localparam e = $bits(x);
+    localparam f = $bits(y);
+    localparam g = $bits(z);
+endmodule
+)");
+
+    Compilation compilation;
+    compilation.addSyntaxTree(tree);
+    NO_COMPILATION_ERRORS;
+}
+
 TEST_CASE("Restriction on automatic variables in $past") {
     auto tree = SyntaxTree::fromText(R"(
 module m;


### PR DESCRIPTION
$bits() on an integer parameter are almost always a mistake.