### PR TITLE
Fix /* in libmap file paths being treated as block comments

### DIFF
--- a/include/slang/parsing/Lexer.h
+++ b/include/slang/parsing/Lexer.h
@@ -121,6 +121,10 @@ public:
     /// Returns the BufferID of the source buffer being lexed.
     BufferID getBufferId() const { return bufferId; }
 
+    /// When set to true, '/' is not treated as the start of a comment during trivia
+    /// scanning. Used when parsing library map file paths that may contain /* glob patterns.
+    void setFilePathMode(bool enable) { filePathMode = enable; }
+
     /// Concatenates two tokens together. This may result in more than one output token
     /// if the right hand token being concatenated ends up splitting and being re-lexed.
     /// Returns true if the concatenation succeeded and false otherwise.
@@ -226,6 +230,10 @@ private:
 
     // the number of errors that have occurred while lexing the current buffer
     uint32_t errorCount = 0;
+
+    // When true, '/' is not treated as the start of a comment in trivia scanning.
+    // Used when parsing library map file paths that may contain /* glob patterns.
+    bool filePathMode = false;
 
     // temporary storage for building arrays of trivia
     SmallVector<Trivia, 32> triviaBuffer;

--- a/include/slang/parsing/Preprocessor.h
+++ b/include/slang/parsing/Preprocessor.h
@@ -166,6 +166,11 @@ public:
     /// Gets the allocator used by the preprocessor.
     BumpAllocator& getAllocator() const { return alloc; }
 
+    /// Enables or disables file path mode on the current lexer. When enabled,
+    /// '/' is not treated as a comment start, allowing file paths with glob
+    /// wildcards like $ROOT/*/subdir/*.v to be parsed correctly.
+    void setFilePathMode(bool enable);
+
     /// Gets the diagnostic bag passed to the Preprocessor's constructor.
     Diagnostics& getDiagnostics() const { return diagnostics; }
 

--- a/source/parsing/Lexer.cpp
+++ b/source/parsing/Lexer.cpp
@@ -1242,6 +1242,11 @@ void Lexer::lexTrivia() {
                 scanWhitespace();
                 break;
             case '/':
+                // In file path mode, don't treat / as a comment start. File paths
+                // can contain wildcard sequences like /* that would otherwise be
+                // misidentified as a block comment (e.g. $ROOT/*/subdir/*.v).
+                if (filePathMode)
+                    return;
                 switch (peek(1)) {
                     case '/':
                         advance(2);

--- a/source/parsing/Parser_members.cpp
+++ b/source/parsing/Parser_members.cpp
@@ -3929,7 +3929,9 @@ MemberSyntax* Parser::parseLibraryMember() {
             return &factory.emptyMember(nullptr, nullptr, consume());
         case TokenKind::IncludeKeyword: {
             auto keyword = consume();
+            getPP().setFilePathMode(true);
             auto& path = parseFilePathSpec();
+            getPP().setFilePathMode(false);
             auto semi = expect(TokenKind::Semicolon);
             return &factory.libraryIncludeStatement(nullptr, keyword, path, semi);
         }
@@ -3958,6 +3960,7 @@ LibraryDeclarationSyntax& Parser::parseLibraryDecl() {
         return buffer.copy(alloc);
     };
 
+    getPP().setFilePathMode(true);
     auto filePaths = parseFilePathList();
 
     LibraryIncDirClauseSyntax* incDir = nullptr;
@@ -3967,6 +3970,7 @@ LibraryDeclarationSyntax& Parser::parseLibraryDecl() {
         auto incPaths = parseFilePathList();
         incDir = &factory.libraryIncDirClause(minus, incDirKeyword, incPaths);
     }
+    getPP().setFilePathMode(false);
 
     return factory.libraryDeclaration(nullptr, keyword, name, filePaths, incDir,
                                       expect(TokenKind::Semicolon));

--- a/source/parsing/Preprocessor.cpp
+++ b/source/parsing/Preprocessor.cpp
@@ -88,6 +88,11 @@ Preprocessor::Preprocessor(const Preprocessor& other) :
     keywordVersionStack.push_back(LF::getDefaultKeywordVersion(options.languageVersion));
 }
 
+void Preprocessor::setFilePathMode(bool enable) {
+    if (!lexerStack.empty())
+        lexerStack.back()->setFilePathMode(enable);
+}
+
 void Preprocessor::pushSource(std::string_view source, std::string_view name) {
     auto buffer = sourceManager.assignText(source);
     pushSource(buffer);

--- a/tests/unittests/parsing/MemberParsingTests.cpp
+++ b/tests/unittests/parsing/MemberParsingTests.cpp
@@ -1225,6 +1225,28 @@ library rtlLib /a/b/c, f/...*?/asdf*.v,
     CHECK_DIAGNOSTICS_EMPTY;
 }
 
+TEST_CASE("Library map path with glob wildcard containing /*") {
+    // Paths like $ROOT/*/subdir/*.v contain /* which must not be treated as
+    // a block comment start by the lexer.
+    auto tree = SyntaxTree::fromLibraryMapText(
+        R"(library STUB $IP_ROOT/*/stub/*.v, $PRJ/top/stubs/*.v;)", getSourceManager());
+
+    REQUIRE(tree);
+
+    diagnostics = tree->diagnostics();
+    CHECK_DIAGNOSTICS_EMPTY;
+
+    auto& libMap = tree->root().as<LibraryMapSyntax>();
+    REQUIRE(libMap.members.size() == 1);
+    auto& libDecl = libMap.members[0]->as<LibraryDeclarationSyntax>();
+    CHECK(libDecl.name.valueText() == "STUB");
+    REQUIRE(libDecl.filePaths.size() == 2);
+    CHECK(libDecl.filePaths[0]->path.valueText().find("$IP_ROOT/*/stub/*.v") !=
+          std::string_view::npos);
+    CHECK(libDecl.filePaths[1]->path.valueText().find("$PRJ/top/stubs/*.v") !=
+          std::string_view::npos);
+}
+
 TEST_CASE("Genblock parsing regress") {
     auto& text = R"(
 module m;


### PR DESCRIPTION
Paths in library map declarations can contain glob wildcards that produce /* sequences (e.g. $IP_ROOT/*/stub/*.v). The SV lexer was consuming /* as a block comment start, swallowing the rest of the path and producing an 'is a directory' error when only the env var prefix survived parsing.

Add a filePathMode flag to the Lexer that prevents '/' from being processed as a comment start in trivia scanning. The Parser enables this mode around file path list parsing in library declarations and include statements.