### PR TITLE
Add BS_thread_pool.hpp to install targets

### DIFF
--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -269,4 +269,11 @@ if(SLANG_INCLUDE_INSTALL)
       EXPORT slangTargets
       COMPONENT slang_Development)
   endif()
+
+  if(SLANG_USE_THREADS)
+    install(
+      FILES ${PROJECT_SOURCE_DIR}/external/BS_thread_pool.hpp
+      DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+      COMPONENT slang_Development)
+  endif()
 endif()


### PR DESCRIPTION
This commit fixes the compilation of packages relying on this package as a library.
I ran into this when trying to build llvm/circt for nixpkgs.
I am new to the codebase, so let me know if changes are needed.