### PR TITLE
Add --incdir-first option to search +incdir dirs before local dir

### DIFF
--- a/docs/command-line-ref.dox
+++ b/docs/command-line-ref.dox
@@ -170,6 +170,14 @@ Undefine the given macro at the start of all source files.
 Disables "local" include path lookup, where include directives search relative to the file
 containing the directive first.
 
+`--incdir-first`
+
+Search user-specified include directories (set via `-I`, `--include-directory`, or `+incdir`)
+before the local directory of the file containing the include directive. By default, slang
+searches the local directory first and falls back to the user-specified directories.
+
+This option is enabled automatically when `--compat=vcs` is used.
+
 @section clr-preprocessor Preprocessor
 
 `--comments`

--- a/include/slang/driver/Driver.h
+++ b/include/slang/driver/Driver.h
@@ -174,6 +174,11 @@ public:
         /// relative to the file containing the directive first.
         std::optional<bool> disableLocalIncludes;
 
+        /// If true, user-specified include directories (+incdir/-I) are searched before
+        /// the local directory of the file containing the include directive, matching the
+        /// behavior of VCS and similar simulators.
+        std::optional<bool> incDirFirst;
+
         /// If true, the preprocessor will allow trailing spaces after the continuation character
         /// in macro definitions.
         std::optional<bool> allowMacroTrailingSpace;

--- a/include/slang/text/SourceManager.h
+++ b/include/slang/text/SourceManager.h
@@ -221,6 +221,12 @@ public:
     /// relative to the file containing the directive first.
     void setDisableLocalIncludes(bool set) { disableLocalIncludes = set; }
 
+    /// Sets whether user-specified include directories (+incdir/-I) are searched before
+    /// the local directory of the file containing the include directive. When false (the
+    /// default), the local directory is searched first. When true, the behavior matches
+    /// VCS and similar simulators that always prefer +incdir directories over local lookup.
+    void setIncDirFirst(bool set) { incDirFirst = set; }
+
     /// Adds a line directive at the given location.
     void addLineDirective(SourceLocation location, size_t lineNum, std::string_view name,
                           uint8_t level);
@@ -367,6 +373,7 @@ private:
     std::atomic<uint32_t> unnamedBufferCount = 0;
     bool disableProximatePaths = false;
     bool disableLocalIncludes = false;
+    bool incDirFirst = false;
 
     template<IsLock TLock>
     FileInfo* getFileInfo(BufferID buffer, TLock& lock);

--- a/source/driver/Driver.cpp
+++ b/source/driver/Driver.cpp
@@ -75,6 +75,10 @@ void Driver::addStandardArgs() {
     cmdLine.add("--disable-local-includes", options.disableLocalIncludes,
                 "Disables \"local\" include path lookup, where include directives search "
                 "relative to the file containing the directive first");
+    cmdLine.add("--incdir-first", options.incDirFirst,
+                "Search user-specified include directories (+incdir/-I) before the local "
+                "directory of the file containing the include directive. This matches the "
+                "behavior of VCS and similar simulators");
 
     // Preprocessor
     cmdLine.add("-D,--define-macro,+define", options.defines,
@@ -617,6 +621,9 @@ bool Driver::processOptions() {
 
     if (options.disableLocalIncludes == true)
         sourceManager.setDisableLocalIncludes(true);
+
+    if (options.incDirFirst.value_or(options.compat == CompatMode::Vcs))
+        sourceManager.setIncDirFirst(true);
 
     if (!reportLoadErrors())
         return false;

--- a/source/text/SourceManager.cpp
+++ b/source/text/SourceManager.cpp
@@ -454,7 +454,7 @@ SourceManager::BufferOrError SourceManager::readHeader(
         return nonstd::make_unexpected(make_error_code(std::errc::no_such_file_or_directory));
     }
 
-    // search relative to the current file
+    // Determine the local (relative-to-current-file) directory, used below.
     const fs::path* currFileDir = nullptr;
     if (!disableLocalIncludes) {
         auto fileLoc = getFullyExpandedLoc(includedFrom);
@@ -465,7 +465,10 @@ SourceManager::BufferOrError SourceManager::readHeader(
             currFileDir = info->data->directory;
     }
 
-    if (currFileDir) {
+    // When incDirFirst is set, user-specified directories (+incdir/-I) are searched
+    // before the local directory, matching the behavior of VCS and similar simulators.
+    // Otherwise (default), the local directory is searched first.
+    if (!incDirFirst && currFileDir) {
         auto result = openCached(*currFileDir / p, includedFrom, library);
         if (result)
             return result;
@@ -490,6 +493,12 @@ SourceManager::BufferOrError SourceManager::readHeader(
     std::shared_lock<std::shared_mutex> includeDirLock(includeDirMutex);
     for (auto& d : userDirectories) {
         auto result = openCached(d / p, includedFrom, library);
+        if (result)
+            return result;
+    }
+
+    if (incDirFirst && currFileDir) {
+        auto result = openCached(*currFileDir / p, includedFrom, library);
         if (result)
             return result;
     }

--- a/tests/unittests/DriverTests.cpp
+++ b/tests/unittests/DriverTests.cpp
@@ -1224,6 +1224,59 @@ TEST_CASE("Driver disable local includes") {
     CHECK(stderrContains("file_defn.svh"));
 }
 
+TEST_CASE("Driver incdir-first -- default finds local file first") {
+    auto guard = OS::captureOutput();
+
+    // Without --incdir-first, the local file (data/incdir_shadow.svh) is found
+    // before the +incdir version (data/nested/incdir_shadow.svh). The local file
+    // defines INCDIR_SHADOW_IS_LOCAL, which triggers a deliberate compile error.
+    Driver driver;
+    driver.addStandardArgs();
+
+    auto testDir = findTestDir();
+    auto args = fmt::format("testfoo -I \"{0}nested\" \"{0}incdir_first_test.sv\"", testDir);
+    CHECK(driver.parseCommandLine(args));
+    CHECK(driver.processOptions());
+    CHECK(driver.parseAllSources());
+    CHECK(!driver.runFullCompilation());
+    CHECK(stderrContains("local_was_found_error"));
+}
+
+TEST_CASE("Driver incdir-first -- finds incdir file first with --incdir-first") {
+    auto guard = OS::captureOutput();
+
+    // With --incdir-first, the +incdir version (data/nested/incdir_shadow.svh) is
+    // searched before the local file. That file does not define INCDIR_SHADOW_IS_LOCAL,
+    // so the module compiles without errors.
+    Driver driver;
+    driver.addStandardArgs();
+
+    auto testDir = findTestDir();
+    auto args = fmt::format("testfoo -I \"{0}nested\" --incdir-first \"{0}incdir_first_test.sv\"",
+                            testDir);
+    CHECK(driver.parseCommandLine(args));
+    CHECK(driver.processOptions());
+    CHECK(driver.parseAllSources());
+    CHECK(driver.runFullCompilation());
+}
+
+TEST_CASE("Driver incdir-first -- compat vcs enables incdir-first automatically") {
+    auto guard = OS::captureOutput();
+
+    // --compat=vcs must automatically enable incdir-first behavior without the user
+    // needing to pass --incdir-first explicitly.
+    Driver driver;
+    driver.addStandardArgs();
+
+    auto testDir = findTestDir();
+    auto args = fmt::format("testfoo -I \"{0}nested\" --compat=vcs \"{0}incdir_first_test.sv\"",
+                            testDir);
+    CHECK(driver.parseCommandLine(args));
+    CHECK(driver.processOptions());
+    CHECK(driver.parseAllSources());
+    CHECK(driver.runFullCompilation());
+}
+
 TEST_CASE("Map keyword version option positive") {
     auto guard = OS::captureOutput();
 

--- a/tests/unittests/FileTests.cpp
+++ b/tests/unittests/FileTests.cpp
@@ -135,7 +135,8 @@ TEST_CASE("File globbing") {
     globAndCheck(testDir, ".../f*.svh", GlobMode::Files, GlobRank::WildcardName, {},
                  {"file.svh", "file_defn.svh", "file_uses_defn.svh"});
     globAndCheck(testDir, "*ste*/", GlobMode::Files, GlobRank::Directory, {},
-                 {"file.svh", "macro.svh", "nested_local.svh", "system.svh", "system.map"});
+                 {"file.svh", "macro.svh", "nested_local.svh", "system.svh", "system.map",
+                  "incdir_shadow.svh"});
     globAndCheck(testDir, testDir + "/library/pkg.sv", GlobMode::Files, GlobRank::ExactPath, {},
                  {"pkg.sv"});
     globAndCheck(testDir, testDir + "/li?ra?y/pkg.sv", GlobMode::Files, GlobRank::SimpleName, {},

--- a/tests/unittests/data/incdir_first_test.sv
+++ b/tests/unittests/data/incdir_first_test.sv
@@ -1,0 +1,18 @@
+// Test file for --incdir-first / VCS compat mode include search order.
+// Includes incdir_shadow.svh, which exists in both the local data/ directory
+// and in data/nested/ (used as a +incdir directory in the tests).
+//
+// If the LOCAL file is found, INCDIR_SHADOW_IS_LOCAL is defined, and a
+// deliberate undefined-identifier error is triggered to make compilation fail.
+// If the INCDIR file (nested/) is found, no error is triggered and the module
+// compiles cleanly.
+`include "incdir_shadow.svh"
+
+module incdir_first_test;
+`ifdef INCDIR_SHADOW_IS_LOCAL
+    // Local shadow file was found -- trigger a deliberate error:
+    int x = local_was_found_error;
+`else
+    int x = 1;
+`endif
+endmodule

--- a/tests/unittests/data/incdir_shadow.svh
+++ b/tests/unittests/data/incdir_shadow.svh
@@ -1,0 +1,4 @@
+// Local version of incdir_shadow.svh.
+// Defines INCDIR_SHADOW_IS_LOCAL so tests can detect when this file was found
+// instead of the +incdir version in nested/.
+`define INCDIR_SHADOW_IS_LOCAL

--- a/tests/unittests/data/nested/incdir_shadow.svh
+++ b/tests/unittests/data/nested/incdir_shadow.svh
@@ -1,0 +1,2 @@
+// Incdir version of incdir_shadow.svh (lives in the nested/ +incdir directory).
+// Intentionally does not define INCDIR_SHADOW_IS_LOCAL.


### PR DESCRIPTION
Adds a new --incdir-first flag that reverses the include file search order so user-specified directories (+incdir/-I) are checked before the local directory of the including file, matching VCS simulator behavior. The option is enabled automatically when --compat=vcs is used.

Includes unit tests and documentation.