### PR TITLE
Add --allow-lib-module-redef option for VCS-compatible module redefin…

### DIFF
--- a/docs/command-line-ref.dox
+++ b/docs/command-line-ref.dox
@@ -635,6 +635,21 @@ for compatibility purposes.
 Allow assignment pattern expressions to be used in unpacked array concatenations.
 The LRM states that these are not assignment-like contexts but some tools allow it anyway.
 
+`--allow-lib-module-redef`
+
+Allow multiple definitions of the same module, interface, program, or primitive at the root
+scope within the same library, provided the conflicting definition comes from a library file
+specified with `-v` / `--libfile`. The first definition encountered is kept and all subsequent
+redefinitions from library files are silently discarded, regardless of whether the kind
+(module vs primitive etc.) matches. This matches the behavior of VCS and similar simulators,
+which resolve such conflicts by picking the first definition found in compilation order.
+
+Without this option (or when the conflicting definition is not a library file), a same-kind
+redefinition produces a `duplicate-definition` warning and a different-kind redefinition
+(e.g. a `module` and a `primitive` sharing the same name) is a hard error.
+
+This option is enabled automatically when `--compat=vcs` or `--compat=all` is used.
+
 `--cmd-ignore <vendor_cmd>,<N>`
 
 Define rule to ignore vendor command &lt;vendor_cmd> with its following &lt;N> parameters.

--- a/include/slang/ast/Compilation.h
+++ b/include/slang/ast/Compilation.h
@@ -122,9 +122,15 @@ enum class SLANG_EXPORT CompilationFlags {
 
     /// Allow assignment pattern expressions to be used in unpacked array concatenations.
     /// Normally these are not assignment-like contexts but some tools allow it anyway.
-    AllowArrayConcatAssignPattern = 1 << 15
+    AllowArrayConcatAssignPattern = 1 << 15,
+
+    /// Allow multiple definitions of the same module, interface, program, or primitive at
+    /// the root scope within the same library, keeping the first and silently discarding
+    /// subsequent ones, but only when the conflicting definition comes from a library file
+    /// (specified with -v / --libfile). This matches the behavior of VCS and similar simulators.
+    AllowLibModuleRedefinition = 1 << 16
 };
-SLANG_BITMASK(CompilationFlags, AllowArrayConcatAssignPattern)
+SLANG_BITMASK(CompilationFlags, AllowLibModuleRedefinition)
 
 /// Contains various options that can control compilation behavior.
 struct SLANG_EXPORT CompilationOptions {

--- a/source/ast/Compilation.cpp
+++ b/source/ast/Compilation.cpp
@@ -22,6 +22,7 @@
 #include "slang/syntax/AllSyntax.h"
 #include "slang/syntax/SyntaxTree.h"
 #include "slang/text/CharInfo.h"
+#include "slang/text/SourceManager.h"
 #include "slang/util/TimeTrace.h"
 
 using namespace slang::parsing;
@@ -865,9 +866,27 @@ void Compilation::insertDefinition(Symbol& symbol, const Scope& scope) {
                 auto vSym = *v;
                 auto vLib = vSym->getSourceLibrary();
                 if (vLib == symLib) {
-                    // Duplicate in the same library. If they are both the same kind
-                    // then we report a warning and take the first one, otherwise
-                    // we give a hard error.
+                    // Duplicate in the same library.
+                    if (hasFlag(CompilationFlags::AllowLibModuleRedefinition)) {
+                        // VCS-like behavior: silently keep the first definition and
+                        // discard all subsequent ones, but only when the incoming
+                        // duplicate comes from a library file (-v / --libfile).
+                        bool isLibrary = false;
+                        if (symbol.kind == SymbolKind::Definition) {
+                            auto st = symbol.as<DefinitionSymbol>().syntaxTree;
+                            isLibrary = st && st->isLibraryUnit;
+                        }
+                        else if (sourceManager) {
+                            auto loc = symbol.location;
+                            isLibrary = loc.valid() && sourceManager->getBufferKind(loc.buffer()) ==
+                                                           SourceManager::BufferKind::LibraryFile;
+                        }
+                        if (isLibrary)
+                            return;
+                    }
+
+                    // If they are both the same kind then we report a warning and
+                    // take the first one, otherwise we give a hard error.
                     if (vSym->kind == symbol.kind) {
                         if (!warned) {
                             // We keep going after this because there might also

--- a/source/driver/CompatSettings.cpp
+++ b/source/driver/CompatSettings.cpp
@@ -34,7 +34,8 @@ using namespace analysis;
     CompilationFlags::AllowBareValParamAssignment, \
     CompilationFlags::AllowSelfDeterminedStreamConcat, \
     CompilationFlags::AllowMergingAnsiPorts, \
-    CompilationFlags::AllowArrayConcatAssignPattern
+    CompilationFlags::AllowArrayConcatAssignPattern, \
+    CompilationFlags::AllowLibModuleRedefinition
 
 static constexpr CompilationFlags vcsCompFlags[] = {VCS_COMP_FLAGS};
 static constexpr CompilationFlags allCompFlags[] = {

--- a/source/driver/Driver.cpp
+++ b/source/driver/Driver.cpp
@@ -239,6 +239,11 @@ void Driver::addStandardArgs() {
                 "Allow assignment pattern expressions to be used in unpacked array "
                 "concatenations. The LRM states that these are not assignment-like "
                 "contexts but some tools allow it anyway.");
+    addCompFlag(CompilationFlags::AllowLibModuleRedefinition, "--allow-lib-module-redef",
+                "Allow multiple definitions of the same module, interface, program, or "
+                "primitive at the root scope within the same library when the conflicting "
+                "definition comes from a library file (-v / --libfile); the first definition "
+                "is kept and subsequent library-file redefinitions are silently discarded");
 
     cmdLine.add("--top", options.topModules,
                 "One or more top-level modules to instantiate "

--- a/tests/unittests/DriverTests.cpp
+++ b/tests/unittests/DriverTests.cpp
@@ -1277,6 +1277,82 @@ TEST_CASE("Driver incdir-first -- compat vcs enables incdir-first automatically"
     CHECK(driver.runFullCompilation());
 }
 
+TEST_CASE("Driver module redef -- default errors on different-kind redefinition") {
+    auto guard = OS::captureOutput();
+
+    // Without --allow-lib-module-redef, a module and a primitive sharing the same
+    // name in the same library produce a hard Redefinition error.
+    Driver driver;
+    driver.addStandardArgs();
+
+    auto testDir = findTestDir();
+    auto args = fmt::format("testfoo --single-unit \"{0}redef_module.sv\" "
+                            "\"{0}redef_primitive.sv\" \"{0}redef_top.sv\"",
+                            testDir);
+    CHECK(driver.parseCommandLine(args));
+    CHECK(driver.processOptions());
+    CHECK(driver.parseAllSources());
+    CHECK(!driver.runFullCompilation());
+    CHECK(stderrContains("redefinition of 'mux_primitive'"));
+}
+
+TEST_CASE("Driver module redef -- allow-lib-module-redef keeps first definition for lib files") {
+    auto guard = OS::captureOutput();
+
+    // With --allow-lib-module-redef and both conflicting files as library files (-v),
+    // the first definition (module) wins and the conflicting primitive is silently discarded.
+    Driver driver;
+    driver.addStandardArgs();
+
+    auto testDir = findTestDir();
+    auto args = fmt::format("testfoo --single-unit --allow-lib-module-redef "
+                            "-v \"{0}redef_module.sv\" -v \"{0}redef_primitive.sv\" "
+                            "\"{0}redef_top.sv\"",
+                            testDir);
+    CHECK(driver.parseCommandLine(args));
+    CHECK(driver.processOptions());
+    CHECK(driver.parseAllSources());
+    CHECK(driver.runFullCompilation());
+}
+
+TEST_CASE("Driver module redef -- allow-lib-module-redef errors on non-library redef") {
+    auto guard = OS::captureOutput();
+
+    // With --allow-lib-module-redef but files NOT specified as libraries (no -v),
+    // redefinition is still an error.
+    Driver driver;
+    driver.addStandardArgs();
+
+    auto testDir = findTestDir();
+    auto args = fmt::format("testfoo --single-unit --allow-lib-module-redef "
+                            "\"{0}redef_module.sv\" \"{0}redef_primitive.sv\" "
+                            "\"{0}redef_top.sv\"",
+                            testDir);
+    CHECK(driver.parseCommandLine(args));
+    CHECK(driver.processOptions());
+    CHECK(driver.parseAllSources());
+    CHECK(!driver.runFullCompilation());
+    CHECK(stderrContains("redefinition of 'mux_primitive'"));
+}
+
+TEST_CASE("Driver module redef -- compat vcs enables allow-lib-module-redef automatically") {
+    auto guard = OS::captureOutput();
+
+    // --compat=vcs must automatically enable --allow-lib-module-redef behavior.
+    Driver driver;
+    driver.addStandardArgs();
+
+    auto testDir = findTestDir();
+    auto args = fmt::format("testfoo --single-unit --compat=vcs "
+                            "-v \"{0}redef_module.sv\" -v \"{0}redef_primitive.sv\" "
+                            "\"{0}redef_top.sv\"",
+                            testDir);
+    CHECK(driver.parseCommandLine(args));
+    CHECK(driver.processOptions());
+    CHECK(driver.parseAllSources());
+    CHECK(driver.runFullCompilation());
+}
+
 TEST_CASE("Map keyword version option positive") {
     auto guard = OS::captureOutput();
 

--- a/tests/unittests/data/redef_module.sv
+++ b/tests/unittests/data/redef_module.sv
@@ -1,0 +1,7 @@
+// First definition: module named mux_primitive.
+// With --allow-module-redef this definition wins over any later redefinitions.
+module mux_primitive(Y, S, A, B);
+  output Y;
+  input S, A, B;
+  assign Y = S ? B : A;
+endmodule

--- a/tests/unittests/data/redef_primitive.sv
+++ b/tests/unittests/data/redef_primitive.sv
@@ -1,0 +1,13 @@
+// Second definition of the same name as a primitive.
+// Without --allow-module-redef this triggers a hard Redefinition error
+// because the kind (primitive) differs from the first definition (module).
+primitive mux_primitive(Y, S, A, B);
+  output Y;
+  input S, A, B;
+  table
+    0 0 ? : 0 ;
+    0 1 ? : 1 ;
+    1 ? 0 : 0 ;
+    1 ? 1 : 1 ;
+  endtable
+endprimitive

--- a/tests/unittests/data/redef_top.sv
+++ b/tests/unittests/data/redef_top.sv
@@ -1,0 +1,6 @@
+// Instantiates mux_primitive. When --allow-module-redef is used the module
+// version (from redef_module.sv) is kept and this compiles cleanly.
+module redef_top;
+  logic S, A, B, Y;
+  mux_primitive prim(Y, S, A, B);
+endmodule


### PR DESCRIPTION
…ition

When multiple library files (-v / --libfile) define a module, interface, program, or primitive with the same name in the same library, slang normally errors. VCS resolves such conflicts silently by keeping the first definition.

Add CompilationFlags::AllowLibModuleRedefinition and the --allow-lib-module-redef CLI option to match this behavior: when the conflicting definition comes from a library file, the first definition wins and the duplicate is silently discarded, regardless of whether the kinds match (e.g. module vs primitive). Non-library (regular source) redefinitions are still rejected as errors even when the flag is set.

The option is automatically enabled when --compat=vcs is used. Four unit tests and documentation are included.