### PR TITLE
Add CST memory usage statistics (--cst-memory-stats)

### DIFF
--- a/docs/command-line-ref.dox
+++ b/docs/command-line-ref.dox
@@ -340,6 +340,22 @@ Controls the level of detail included in the CST JSON output. The available mode
 
 The default mode is `full` if this option is not specified.
 
+`--cst-memory-stats <file>`
+
+Dump memory usage statistics for the concrete syntax tree to the specified file, or '-' for
+stdout. May be invoked as soon as parsing is complete, even when elaboration is skipped.
+
+The report is organized into three sections:
+
+- **Driver Components** — bytes consumed by the source manager (raw file content and cached
+  line-offset tables) and by the bump allocators backing each parsed syntax tree and library
+  map tree.
+- **Syntax Node Data** — total bytes attributed to syntax nodes, with a per-kind breakdown
+  sorted by memory consumption (count, total bytes, and average bytes per node), followed by
+  token and trivia heap totals.
+- **Module/Package/Scope breakdown** — node memory grouped by the enclosing
+  module/interface/program/package scope, sorted by memory consumption.
+
 @section depfiles Dependency Files
 
 These options output various dependency files as filelists in addition to other actions.

--- a/include/slang/parsing/Token.h
+++ b/include/slang/parsing/Token.h
@@ -185,6 +185,14 @@ public:
     bool valid() const { return info != nullptr; }
     explicit operator bool() const { return valid(); }
 
+    /// Returns the size in bytes of all heap-allocated data referenced by this token beyond
+    /// sizeof(Token): the Info block (including any extra type-specific data) plus the trivia
+    /// array.
+    size_t getReferencedSize() const;
+
+    /// Returns the size in bytes of the trivia array separately allocated for this token.
+    size_t getTriviaArraySize() const;
+
     bool operator==(const Token& other) const { return kind == other.kind && info == other.info; }
 
     /// Modification methods to make it easier to deal with immutable tokens.

--- a/include/slang/syntax/CSTMemoryStats.h
+++ b/include/slang/syntax/CSTMemoryStats.h
@@ -1,0 +1,21 @@
+//------------------------------------------------------------------------------
+// CSTMemoryStats.h
+// Memory usage statistics for the CST (Concrete Syntax Tree).
+//
+// SPDX-FileCopyrightText: Michael Popoloski
+// SPDX-License-Identifier: MIT
+//------------------------------------------------------------------------------
+#pragma once
+
+#include <string>
+
+#include "slang/util/Util.h"
+
+namespace slang::driver {
+class Driver;
+}
+
+/// Prints memory usage statistics for all parsed CST syntax trees held by @a driver.
+/// May be called as soon as parsing is complete, even when elaboration is skipped.
+/// Output is written to @a fileName; use "-" for stdout.
+SLANG_EXPORT void printCSTMemoryStats(slang::driver::Driver& driver, const std::string& fileName);

--- a/include/slang/syntax/SyntaxNode.h
+++ b/include/slang/syntax/SyntaxNode.h
@@ -146,6 +146,9 @@ public:
     /// Gets the number of (direct) children underneath this node in the tree.
     size_t getChildCount() const; // Note: implemented in AllSyntax.cpp
 
+    /// Gets the memory allocated for this node.
+    size_t getSize() const { return sizeof(*this); }
+
     /// An iterator that walks through all tokens in a syntax node in order.
     class SLANG_EXPORT token_iterator : public iterator_facade<token_iterator> {
     public:

--- a/include/slang/text/SourceManager.h
+++ b/include/slang/text/SourceManager.h
@@ -172,6 +172,10 @@ public:
     /// Gets the actual source text for a given file buffer.
     std::string_view getSourceText(BufferID buffer) const;
 
+    /// Returns the total bytes consumed by all loaded source files:
+    /// raw file content plus any cached line-offset tables.
+    size_t getMemoryUsage() const;
+
     /// Gets a value that can be used to sort a given buffer when comparing
     /// to other buffers.
     uint64_t getSortKey(BufferID buffer) const;

--- a/include/slang/util/BumpAllocator.h
+++ b/include/slang/util/BumpAllocator.h
@@ -95,11 +95,16 @@ public:
 #endif
     }
 
+    /// Returns the total number of bytes reserved from the OS by this allocator
+    /// (sum of all segment allocation sizes, excluding segment headers).
+    size_t getTotalAllocatedBytes() const;
+
 protected:
     // Allocations are tracked as a linked list of segments.
     struct Segment {
         Segment* prev;
         byte* current;
+        size_t allocatedSize; // total bytes requested from OS for this segment
     };
 
     Segment* head;

--- a/include/slang/util/MemStatsUtil.h
+++ b/include/slang/util/MemStatsUtil.h
@@ -1,0 +1,47 @@
+//------------------------------------------------------------------------------
+// MemStatsUtil.h
+// Shared utilities for CST and AST memory statistics.
+//
+// SPDX-FileCopyrightText: Michael Popoloski
+// SPDX-License-Identifier: MIT
+//------------------------------------------------------------------------------
+#pragma once
+
+#include <cstddef>
+#include <cstdio>
+#include <fmt/format.h>
+#include <fstream>
+#include <string>
+
+namespace slang {
+
+static inline std::string memStatsFmtBytes(size_t bytes) {
+    auto d = static_cast<double>(bytes);
+    if (bytes < 1024)
+        return fmt::format("{} B", bytes);
+    else if (bytes < 1024 * 1024)
+        return fmt::format("{:.2f} KB", d / 1024.0);
+    else if (bytes < 1024 * 1024 * 1024)
+        return fmt::format("{:.2f} MB", d / (1024.0 * 1024.0));
+    else
+        return fmt::format("{:.2f} GB", d / (1024.0 * 1024.0 * 1024.0));
+}
+
+// Returns the current RSS (resident set size) of the process in bytes.
+// Reads /proc/self/status on Linux; returns 0 on unsupported platforms.
+static inline size_t memStatsGetProcessRSS() {
+#if defined(__linux__)
+    std::ifstream status("/proc/self/status");
+    std::string line;
+    while (std::getline(status, line)) {
+        if (line.rfind("VmRSS:", 0) == 0) {
+            size_t kib = 0;
+            if (std::sscanf(line.c_str() + 6, "%zu", &kib) == 1)
+                return kib * 1024;
+        }
+    }
+#endif
+    return 0;
+}
+
+} // namespace slang

--- a/scripts/syntax_gen.py
+++ b/scripts/syntax_gen.py
@@ -382,6 +382,58 @@ namespace slang::syntax {
             outf.write("    PtrTokenOrSyntax getChildPtr(size_t index);\n")
             outf.write("    void setChild(size_t index, TokenOrSyntax child);\n\n")
 
+            # Generate getSize(): total memory for this node and all non-SyntaxNode
+            # members it owns (directly or via contained lists/tokens).
+            #
+            # Rules per member type:
+            #   Token          - sizeof in sizeof(*this); add getReferencedSize()
+            #                    for the Info block + trivia heap.
+            #   TokenList      - sizeof(TokenList) in sizeof(*this); add the span
+            #                    array (size*sizeof(Token)) and getReferencedSize()
+            #                    for every Token value in the span.
+            #   SyntaxList<U>  - sizeof in sizeof(*this); add the pointer span array
+            #                    (size*sizeof(U*)); do NOT recurse into U nodes —
+            #                    the visitor counts those separately.
+            #   SepSyntaxList  - sizeof in sizeof(*this); add the TokenOrSyntax span
+            #                    array and getReferencedSize() for separator Tokens;
+            #                    do NOT recurse into U nodes.
+            #   U* / not_null  - pointer already in sizeof(*this); nothing extra.
+            outf.write("    size_t getSize() const {\n")
+            outf.write("        size_t total = sizeof(*this);\n")
+            for m in currtype.combinedMembers:
+                mtype, mname = m[0], m[1]
+                if mtype == "Token":
+                    outf.write(
+                        "        total += {}.getReferencedSize();\n".format(mname)
+                    )
+                elif mtype == "TokenList":
+                    outf.write(
+                        "        total += {0}.size() * sizeof(Token);\n".format(mname)
+                    )
+                    outf.write(
+                        "        for (const auto& t : {0}) total += t.getReferencedSize();\n".format(
+                            mname
+                        )
+                    )
+                elif mtype.startswith("SyntaxList<"):
+                    outf.write(
+                        "        total += {0}.size() * sizeof(void*);\n".format(mname)
+                    )
+                elif mtype.startswith("SeparatedSyntaxList<"):
+                    outf.write(
+                        "        total += {0}.getChildCount() * sizeof(TokenOrSyntax);\n".format(
+                            mname
+                        )
+                    )
+                    outf.write(
+                        "        for (const auto& ts : {0}.elems())\n".format(mname)
+                    )
+                    outf.write(
+                        "            if (ts.isToken()) total += ts.token().getReferencedSize();\n"
+                    )
+            outf.write("        return total;\n")
+            outf.write("    }\n\n")
+
             docf.write(
                 "    @fn static bool slang::syntax::{}::isChildOptional(size_t index);\n".format(
                     name

--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -98,6 +98,7 @@ add_library(
   parsing/Preprocessor_macros.cpp
   parsing/Preprocessor_pragmas.cpp
   parsing/Token.cpp
+  syntax/CSTMemoryStats.cpp
   syntax/CSTSerializer.cpp
   syntax/SyntaxFacts.cpp
   syntax/SyntaxNode.cpp

--- a/source/parsing/Token.cpp
+++ b/source/parsing/Token.cpp
@@ -452,6 +452,23 @@ Token Token::deepClone(BumpAllocator& alloc) const {
     return clone(alloc, triviaBuffer.copy(alloc), rawText(), location());
 }
 
+size_t Token::getReferencedSize() const {
+    if (!info)
+        return 0;
+    size_t size = sizeof(Info) + getExtraSize(kind);
+    if (triviaCountSmall > 0) {
+        size += sizeof(const Trivia*);
+        if (triviaCountSmall > MaxTriviaSmallCount)
+            size += sizeof(size_t);
+    }
+    size += trivia().size() * sizeof(Trivia);
+    return size;
+}
+
+size_t Token::getTriviaArraySize() const {
+    return trivia().size() * sizeof(Trivia);
+}
+
 void Token::init(BumpAllocator& alloc, TokenKind kind_, std::span<Trivia const> trivia,
                  std::string_view rawText, SourceLocation location) {
     kind = kind_;

--- a/source/syntax/CSTMemoryStats.cpp
+++ b/source/syntax/CSTMemoryStats.cpp
@@ -1,0 +1,185 @@
+//------------------------------------------------------------------------------
+// CSTMemoryStats.cpp
+// Memory usage statistics for the CST (Concrete Syntax Tree).
+//
+// SPDX-FileCopyrightText: Michael Popoloski
+// SPDX-License-Identifier: MIT
+//------------------------------------------------------------------------------
+#include "slang/syntax/CSTMemoryStats.h"
+
+#include <algorithm>
+#include <fstream>
+#include <iostream>
+#include <map>
+#include <ostream>
+#include <string>
+#include <vector>
+
+#include "slang/driver/Driver.h"
+#include "slang/syntax/AllSyntax.h"
+#include "slang/syntax/SyntaxTree.h"
+#include "slang/syntax/SyntaxVisitor.h"
+#include "slang/util/MemStatsUtil.h"
+
+using namespace slang;
+using namespace slang::syntax;
+using namespace slang::parsing;
+using namespace slang::driver;
+
+// Walks every syntax node and accumulates memory per SyntaxKind and per
+// enclosing module/package/interface/program scope.
+//
+// Accounting rules:
+//   - Concrete non-list nodes: node.getSize() = sizeof(T)
+//                              + getReferencedSize() for each direct Token member
+//     Embedded list structs (SyntaxList, SeparatedSyntaxList, TokenList) are part
+//     of sizeof(T); their span arrays and element contents are not included here.
+//   - Child SyntaxNode pointer members: visited and counted separately by the visitor.
+//   - List nodes (SyntaxList / SeparatedSyntaxList / TokenList): NOT tracked as
+//     separate nodes; sizeof is already part of the parent.  The visitor still
+//     walks into them so tokens are picked up by visitToken().
+//   - Token Info blocks and trivia arrays: tracked separately via visitToken().
+struct CSTMemVisitor : public SyntaxVisitor<CSTMemVisitor> {
+    struct KindStats {
+        size_t count = 0;
+        size_t bytes = 0;
+    };
+    std::map<SyntaxKind, KindStats> kindStats;
+    std::map<std::string, size_t> scopeBytes;
+    std::vector<std::string> scopeStack;
+
+    size_t totalTokenBytes = 0;  // sizeof(Token) + Info block + trivia array per token
+    size_t totalTriviaBytes = 0; // trivia array bytes (subset of totalTokenBytes)
+
+    std::string currentScope() const {
+        return scopeStack.empty() ? "<toplevel>" : scopeStack.back();
+    }
+
+#ifdef _MSC_VER
+#    pragma warning(push)
+#    pragma warning(disable : 4702) // unreachable code
+#endif
+    // Catch-all for all concrete syntax node types and list nodes.
+    template<typename T>
+    void handle(const T& node) {
+        if constexpr (std::is_base_of_v<SyntaxListBase, T>) {
+            // List sizes are included in the parent node's getSize().
+            // Still walk children so tokens are tracked via visitToken().
+            visitDefault(node);
+            return;
+        }
+        size_t sz = node.getSize();
+        kindStats[node.kind].count++;
+        kindStats[node.kind].bytes += sz;
+        scopeBytes[currentScope()] += sz;
+        visitDefault(node);
+    }
+#ifdef _MSC_VER
+#    pragma warning(pop)
+#endif
+
+    // Specific handler for module/interface/program/package declarations:
+    // push a new scope name before recursing into children.
+    void handle(const ModuleDeclarationSyntax& node) {
+        std::string name = std::string(node.header->name.valueText());
+        if (!scopeStack.empty())
+            name = scopeStack.back() + "." + name;
+
+        size_t sz = node.getSize();
+        kindStats[node.kind].count++;
+        kindStats[node.kind].bytes += sz;
+        scopeBytes[name] += sz;
+
+        scopeStack.push_back(name);
+        visitDefault(node);
+        scopeStack.pop_back();
+    }
+
+    // Track token Info blocks and trivia arrays separately.
+    void visitToken(Token token) {
+        if (!token.valid())
+            return;
+        totalTokenBytes += sizeof(Token) + token.getReferencedSize();
+        totalTriviaBytes += token.getTriviaArraySize();
+    }
+};
+
+void printCSTMemoryStats(Driver& driver, const std::string& fileName) {
+    std::ofstream fileStream;
+    std::ostream* outPtr;
+    if (fileName == "-") {
+        outPtr = &std::cout;
+    }
+    else {
+        fileStream.open(fileName);
+        fileStream.exceptions(std::ios::failbit | std::ios::badbit);
+        outPtr = &fileStream;
+    }
+    std::ostream& out = *outPtr;
+    size_t processRSS = memStatsGetProcessRSS();
+    size_t syntaxTreeAllocBytes = 0;
+    size_t libraryMapAllocBytes = 0;
+    size_t totalNodeBytes = 0;
+
+    CSTMemVisitor vis;
+
+    auto accumTrees = [&](const auto& trees, size_t& allocBytes) {
+        for (auto& tree : trees) {
+            allocBytes += tree->allocator().getTotalAllocatedBytes();
+            tree->root().visit(vis);
+        }
+    };
+
+    accumTrees(driver.syntaxTrees, syntaxTreeAllocBytes);
+    accumTrees(driver.sourceLoader.getLibraryMaps(), libraryMapAllocBytes);
+    for (auto& [kind, ks] : vis.kindStats)
+        totalNodeBytes += ks.bytes;
+
+    size_t sourceManagerBytes = driver.sourceManager.getMemoryUsage();
+
+    out << "\n--- CST (Concrete Syntax Tree) ---\n";
+    if (processRSS > 0)
+        out << fmt::format("{:>4}{:<28}: {}\n", "", "Process RSS", memStatsFmtBytes(processRSS));
+    out << "\n  Driver Components:\n";
+    out << fmt::format("{:>4}{:<28}: {}\n", "", "Source Manager",
+                       memStatsFmtBytes(sourceManagerBytes));
+    out << fmt::format("{:>4}{:<28}: {}\n", "", "Syntax Tree Allocators",
+                       memStatsFmtBytes(syntaxTreeAllocBytes));
+    out << fmt::format("{:>4}{:<28}: {}\n", "", "Library Map Allocators",
+                       memStatsFmtBytes(libraryMapAllocBytes));
+    out << "\n  Syntax Node Data:\n";
+    out << fmt::format("{:>4}{:<28}: {}\n", "", "Total node memory",
+                       memStatsFmtBytes(totalNodeBytes));
+    out << fmt::format("{:>8}{:<28}: {}\n", "", "Total token memory",
+                       memStatsFmtBytes(vis.totalTokenBytes));
+    out << fmt::format("{:>12}{:<28}: {}\n", "", "Total trivia memory",
+                       memStatsFmtBytes(vis.totalTriviaBytes));
+
+    // Per-kind breakdown, sorted by bytes descending.
+    out << "\n  Node type breakdown (sorted by memory):\n";
+    std::vector<std::pair<SyntaxKind, CSTMemVisitor::KindStats>> kindVec(vis.kindStats.begin(),
+                                                                         vis.kindStats.end());
+    std::sort(kindVec.begin(), kindVec.end(),
+              [](const auto& a, const auto& b) { return a.second.bytes > b.second.bytes; });
+    out << fmt::format("    {:<45} {:>10}  {:>10}  {:>12}\n", "Node Kind", "Count", "Total",
+                       "Per Node");
+    out << fmt::format("    {}\n", std::string(80, '-'));
+    for (auto& [kind, ks] : kindVec) {
+        size_t perNode = ks.count > 0 ? ks.bytes / ks.count : 0;
+        out << fmt::format("    {:<45} {:>10}  {:>10}  {:>12}\n", toString(kind), ks.count,
+                           memStatsFmtBytes(ks.bytes), memStatsFmtBytes(perNode));
+    }
+
+    // Per-module/package/scope breakdown, sorted by bytes descending.
+    out << "\n  Module/Package/Scope breakdown (sorted by memory):\n";
+    std::vector<std::pair<std::string, size_t>> scopeVec(vis.scopeBytes.begin(),
+                                                         vis.scopeBytes.end());
+    std::sort(scopeVec.begin(), scopeVec.end(),
+              [](const auto& a, const auto& b) { return a.second > b.second; });
+    out << fmt::format("    {:<50} {:>15}\n", "Scope", "Node Memory");
+    out << fmt::format("    {}\n", std::string(70, '-'));
+    for (auto& [scope, bytes] : scopeVec)
+        out << fmt::format("    {:<50} {:>15}\n", scope, memStatsFmtBytes(bytes));
+
+    out << "\n";
+}

--- a/source/text/SourceManager.cpp
+++ b/source/text/SourceManager.cpp
@@ -824,4 +824,16 @@ const SourceManager::LineDirectiveInfo* SourceManager::FileInfo::getPreviousLine
     }
 }
 
+size_t SourceManager::getMemoryUsage() const {
+    std::shared_lock<std::shared_mutex> lock(mutex);
+    size_t total = 0;
+    for (auto& [path, entry] : lookupCache) {
+        if (entry.first) {
+            total += entry.first->mem.size();
+            total += entry.first->lineOffsets.size() * sizeof(size_t);
+        }
+    }
+    return total;
+}
+
 } // namespace slang

--- a/source/util/BumpAllocator.cpp
+++ b/source/util/BumpAllocator.cpp
@@ -68,7 +68,15 @@ BumpAllocator::Segment* BumpAllocator::allocSegment(Segment* prev, size_t size) 
     auto seg = (Segment*)::operator new(size);
     seg->prev = prev;
     seg->current = (byte*)seg + sizeof(Segment);
+    seg->allocatedSize = size;
     return seg;
+}
+
+size_t BumpAllocator::getTotalAllocatedBytes() const {
+    size_t total = 0;
+    for (Segment* seg = head; seg; seg = seg->prev)
+        total += seg->allocatedSize;
+    return total;
 }
 
 } // namespace slang

--- a/tests/unittests/DriverTests.cpp
+++ b/tests/unittests/DriverTests.cpp
@@ -9,6 +9,7 @@
 #include "slang/ast/symbols/CompilationUnitSymbols.h"
 #include "slang/ast/symbols/InstanceSymbols.h"
 #include "slang/driver/Driver.h"
+#include "slang/syntax/CSTMemoryStats.h"
 #include "slang/text/SourceManager.h"
 
 using namespace slang::driver;
@@ -1339,4 +1340,38 @@ TEST_CASE("Driver file preprocess with source info") {
     CHECK(contains(output, "test.sv:4\nmodule m;"));
     CHECK(contains(output, "mod1.sv:1\nmodule mod1"));
     CHECK(contains(output, "test.sv:15\n"));
+}
+
+TEST_CASE("Driver CST memory stats -- output contains expected sections") {
+    auto guard = OS::captureOutput();
+
+    Driver driver;
+    driver.addStandardArgs();
+
+    auto testDir = findTestDir();
+    auto args = fmt::format(
+        "testfoo \"{0}test4.sv\" --top=frob --allow-use-before-declare -DFOOBAR -Gbar=1",
+        findTestDir());
+    CHECK(driver.parseCommandLine(args));
+    CHECK(driver.processOptions());
+    CHECK(driver.parseAllSources());
+
+    // Write CST stats to a temp file and verify the major section headers are present.
+    std::string tmpPath = "/tmp/slang_cst_stats_test.txt";
+    printCSTMemoryStats(driver, tmpPath);
+
+    std::ifstream f(tmpPath);
+    REQUIRE(f.is_open());
+    std::string content((std::istreambuf_iterator<char>(f)), std::istreambuf_iterator<char>());
+    std::remove(tmpPath.c_str());
+
+    CHECK(content.find("--- CST (Concrete Syntax Tree) ---") != std::string::npos);
+    CHECK(content.find("Driver Components:") != std::string::npos);
+    CHECK(content.find("Source Manager") != std::string::npos);
+    CHECK(content.find("Syntax Tree Allocators") != std::string::npos);
+    CHECK(content.find("Syntax Node Data:") != std::string::npos);
+    CHECK(content.find("Node type breakdown") != std::string::npos);
+    CHECK(content.find("Module/Package/Scope breakdown") != std::string::npos);
+    // The parsed module should appear as a named scope.
+    CHECK(content.find("baz") != std::string::npos);
 }

--- a/tests/unittests/parsing/VisitorTests.cpp
+++ b/tests/unittests/parsing/VisitorTests.cpp
@@ -9,6 +9,7 @@
 #include "slang/analysis/AnalysisManager.h"
 #include "slang/ast/ASTVisitor.h"
 #include "slang/parsing/ParserMetadata.h"
+#include "slang/parsing/Token.h"
 #include "slang/syntax/AllSyntax.h"
 #include "slang/syntax/SyntaxNode.h"
 #include "slang/syntax/SyntaxPrinter.h"
@@ -184,6 +185,39 @@ public:
         insertAtBack(portList->ports, makeArg("argZ"), makeComma());
     }
 };
+
+TEST_CASE("Token getReferencedSize and SyntaxNode getSize") {
+    using namespace slang::parsing;
+    using namespace slang::syntax;
+
+    auto tree = SyntaxTree::fromText("module m; endmodule");
+
+    // Collect all tokens and find the ModuleDeclarationSyntax via the visitor.
+    struct Collector : public SyntaxVisitor<Collector> {
+        void visitToken(Token tok) {
+            if (tok.valid())
+                tokens.push_back(tok);
+        }
+        void handle(const ModuleDeclarationSyntax& node) {
+            modDecl = &node;
+            visitDefault(node);
+        }
+        std::vector<Token> tokens;
+        const ModuleDeclarationSyntax* modDecl = nullptr;
+    } collector;
+    tree->root().visit(collector);
+
+    // Every valid token must have a positive referenced size (Info block).
+    REQUIRE(!collector.tokens.empty());
+    for (auto& tok : collector.tokens) {
+        CHECK(tok.getReferencedSize() > 0);
+        CHECK(tok.getTriviaArraySize() <= tok.getReferencedSize());
+    }
+
+    // getSize() on the module declaration must be >= the struct's sizeof.
+    REQUIRE(collector.modDecl != nullptr);
+    CHECK(collector.modDecl->getSize() >= sizeof(*collector.modDecl));
+}
 
 TEST_CASE("Basic rewriting") {
     auto tree = SyntaxTree::fromText(R"(

--- a/tests/unittests/util/UtilTests.cpp
+++ b/tests/unittests/util/UtilTests.cpp
@@ -7,6 +7,7 @@
 #include <sstream>
 
 #include "slang/util/Bag.h"
+#include "slang/util/BumpAllocator.h"
 #include "slang/util/Random.h"
 #include "slang/util/TimeTrace.h"
 
@@ -22,6 +23,21 @@ TEST_CASE("Assertions") {
     CHECK_THROWS_AS([&] { SLANG_UNREACHABLE; }(), std::logic_error);
 }
 #endif
+
+TEST_CASE("BumpAllocator getTotalAllocatedBytes") {
+    using namespace slang;
+
+    // BumpAllocator pre-allocates an initial segment, so total is non-zero from the start.
+    BumpAllocator ba;
+    size_t initial = ba.getTotalAllocatedBytes();
+    CHECK(initial > 0);
+
+    // After allocating more than a segment can hold, a new segment is added.
+    // Force overflow by allocating more than SEGMENT_SIZE at once.
+    constexpr size_t big = 1024 * 1024; // 1 MB, larger than the default segment
+    ba.allocate(big, 1);
+    CHECK(ba.getTotalAllocatedBytes() >= initial + big);
+}
 
 TEST_CASE("TypeName test") {
     CHECK(typeName<void>() == "void");

--- a/tools/driver/slang_main.cpp
+++ b/tools/driver/slang_main.cpp
@@ -14,6 +14,7 @@
 #include "slang/ast/symbols/CompilationUnitSymbols.h"
 #include "slang/diagnostics/TextDiagnosticClient.h"
 #include "slang/driver/Driver.h"
+#include "slang/syntax/CSTMemoryStats.h"
 #include "slang/syntax/CSTSerializer.h"
 #include "slang/syntax/SyntaxTree.h"
 #include "slang/text/Json.h"
@@ -212,6 +213,12 @@ int driverMain(int argc, TArgs argv) {
                            "the results to the given file in Chrome Event Tracing JSON format",
                            "<path>");
 
+        std::optional<std::string> cstMemoryStatsFile;
+        driver.cmdLine.add(
+            "--cst-memory-stats", cstMemoryStatsFile,
+            "Dump CST memory usage statistics to the specified file, or '-' for stdout", "<file>",
+            CommandLineFlags::FilePath);
+
         if (!driver.parseCommandLine(argc, argv))
             return 1;
 
@@ -283,6 +290,9 @@ int driverMain(int argc, TArgs argv) {
                 printCSTJson(driver, *cstJsonFile, cstJsonMode.value_or(CSTJsonMode::Full));
             }
 
+            if (cstMemoryStatsFile)
+                printCSTMemoryStats(driver, *cstMemoryStatsFile);
+
             if (onlyParse == true)
                 return ok && driver.reportParseDiags();
 
@@ -305,6 +315,7 @@ int driverMain(int argc, TArgs argv) {
                 printASTJson(*compilation, *astJsonFile, astJsonScopes, includeSourceInfo == true,
                              serializeDetailedTypes == true);
             }
+
             return ok;
         };
 


### PR DESCRIPTION
Introduces a new --cst-memory-stats option that reports detailed memory usage for the concrete syntax tree: driver components (source manager, syntax tree allocators), and a syntax node data breakdown by kind, token, trivia, and scope.

Supporting infrastructure added:
- BumpAllocator::getTotalAllocatedBytes() via a per-segment allocatedSize field
- Token::getReferencedSize() / getTriviaArraySize() for heap beyond sizeof(Token)
- SourceManager::getMemoryUsage() for raw source text + line-offset cache bytes
- syntax_gen.py: generate getSize() on each SyntaxNode covering all non-child members (token info blocks, list span arrays, separator tokens)
- MemStatsUtil: shared helpers for RSS query and human-readable byte formatting