### PR TITLE
python: expose ValueDriver source and flags enums

### DIFF
--- a/bindings/python/AnalysisBindings.cpp
+++ b/bindings/python/AnalysisBindings.cpp
@@ -167,6 +167,28 @@ void registerAnalysis(py::module_& m, py::module_& ast) {
         .value("Continuous", DriverKind::Continuous)
         .finalize();
 
+    py::native_enum<DriverSource>(m, "DriverSource", "enum.Enum")
+        .value("Initial", DriverSource::Initial)
+        .value("Final", DriverSource::Final)
+        .value("Always", DriverSource::Always)
+        .value("AlwaysComb", DriverSource::AlwaysComb)
+        .value("AlwaysLatch", DriverSource::AlwaysLatch)
+        .value("AlwaysFF", DriverSource::AlwaysFF)
+        .value("Subroutine", DriverSource::Subroutine)
+        .value("Other", DriverSource::Other)
+        .finalize();
+
+    py::native_enum<DriverFlags>(m, "DriverFlags", "enum.Flag")
+        .value("None", DriverFlags::None)
+        .value("InputPort", DriverFlags::InputPort)
+        .value("OutputPort", DriverFlags::OutputPort)
+        .value("ClockVar", DriverFlags::ClockVar)
+        .value("Initializer", DriverFlags::Initializer)
+        .value("FromSideEffect", DriverFlags::FromSideEffect)
+        .value("HasOverrideRange", DriverFlags::HasOverrideRange)
+        .value("ViaIndirectPort", DriverFlags::ViaIndirectPort)
+        .finalize();
+
     py::native_enum<AnalysisFlags>(m, "AnalysisFlags", "enum.Flag")
         .value("None", AnalysisFlags::None)
         .value("CheckUnused", AnalysisFlags::CheckUnused)

--- a/pyslang/tests/test_analysis.py
+++ b/pyslang/tests/test_analysis.py
@@ -3,7 +3,9 @@
 
 from pyslang.analysis import (
     AnalysisManager,
+    DriverFlags,
     DriverKind,
+    DriverSource,
     FlowAnalysis,
     ReadRange,
     SensitivityList,
@@ -248,6 +250,31 @@ endmodule
 def test_driver_kind_enum():
     assert hasattr(DriverKind, "Procedural")
     assert hasattr(DriverKind, "Continuous")
+
+
+def test_value_driver_metadata_enums():
+    tree = SyntaxTree.fromText("""
+module m(input logic a, b, output logic c);
+    assign c = a & b;
+endmodule
+""")
+    compilation = Compilation()
+    compilation.addSyntaxTree(tree)
+    compilation.getAllDiagnostics()
+
+    root = compilation.getRoot()
+    c = root.lookupName("m.c")
+
+    am = AnalysisManager()
+    am.analyze(compilation)
+
+    drivers = am.getDrivers(c)
+    assert len(drivers) == 1
+
+    driver = drivers[0][0]
+    assert driver.kind == DriverKind.Continuous
+    assert driver.source == DriverSource.Other
+    assert driver.flags == DriverFlags["None"]
 
 
 def test_lsp_utilities_get_bounds():


### PR DESCRIPTION
Fix for Python enum bindings for pyslang.analysis.ValueDriver.source and ValueDriver.flags. 

Faced an issue where ValueDriver exposed these fields, but reading them from Python would error because DriverSource and DriverFlags were never registered in the binding layer. I registered them and a small regression test as written in the contribution doc. 

Testing:
  - python -m pytest pyslang/tests/test_analysis.py