### PR TITLE
Fix exponential JSON output growth with --ast-json-detailed-types

### DIFF
--- a/include/slang/ast/types/TypePrinter.h
+++ b/include/slang/ast/types/TypePrinter.h
@@ -45,6 +45,9 @@ struct SLANG_EXPORT TypePrintingOptions {
     /// Print enums as links instead of their expanded type details.
     bool enumsAsLinks = false;
 
+    /// Print classes and covergroups as links instead of their expanded type details.
+    bool classesAsLinks = false;
+
     /// Selects a style for anonymous types, either the system ID name
     /// or a more human-friendly name.
     enum AnonymousTypeStyle { SystemName, FriendlyName } anonymousTypeStyle = SystemName;

--- a/source/ast/ASTSerializer.cpp
+++ b/source/ast/ASTSerializer.cpp
@@ -267,6 +267,7 @@ void ASTSerializer::visit(const T& elem, bool inMembersArray) {
                 if (includeAddrs) {
                     printer.options.typedefsAsLinks = true;
                     printer.options.enumsAsLinks = true;
+                    printer.options.classesAsLinks = true;
                 }
 
                 printer.append(elem);
@@ -285,9 +286,11 @@ void ASTSerializer::visit(const T& elem, bool inMembersArray) {
             }
 
             // Even when printing detailed type info, if we're not in a members array prefer
-            // to print links to typedefs and enums to reduce verbosity of output.
+            // to print links to typedefs, enums, classes, and covergroups to avoid
+            // re-serializing the same type many times over.
             if (!inMembersArray && includeAddrs &&
-                (std::is_same_v<TypeAliasType, T> || std::is_same_v<EnumType, T>)) {
+                (std::is_same_v<TypeAliasType, T> || std::is_same_v<EnumType, T> ||
+                 std::is_same_v<ClassType, T> || std::is_same_v<CovergroupType, T>)) {
                 writer.writeValue(printType());
                 return;
             }

--- a/source/ast/types/TypePrinter.cpp
+++ b/source/ast/types/TypePrinter.cpp
@@ -364,12 +364,16 @@ void TypePrinter::visit(const PropertyType& type, std::string_view) {
 }
 
 void TypePrinter::visit(const ClassType& type, std::string_view) {
+    if (options.classesAsLinks)
+        buffer->format("{} ", uintptr_t(&type));
     buffer->append(type.name);
     if (type.genericClass)
         appendParameters(type.genericParameters, false);
 }
 
 void TypePrinter::visit(const CovergroupType& type, std::string_view) {
+    if (options.classesAsLinks)
+        buffer->format("{} ", uintptr_t(&type));
     if (type.name.empty())
         buffer->append("<unnamed covergroup>");
     else


### PR DESCRIPTION
When serializing large codebases (e.g. UVM) with --ast-json-detailed-types, the same class type could be fully serialized inline every time it appeared as a variable's type, causing exponential output growth and OOM crashes.

Enums and typedefs already had a 'links' mechanism in TypePrinter to emit an address-prefixed name instead of re-serializing the full type. Extend this pattern to ClassType and CovergroupType:

- Add classesAsLinks option to TypePrintingOptions
- Emit "<addr> name" links in TypePrinter for ClassType/CovergroupType
- In ASTSerializer, treat ClassType/CovergroupType like enums/typedefs when appearing as type references (not in members arrays): emit a link instead of full inline serialization

UVM 2020.3.1 with --ast-json-detailed-types now produces 129MB of JSON instead of exhausting all available memory.

Fixes MikePopoloski/slang#1781