### PR TITLE
pyslang: expose 'thisVar' property in SubroutineSymbol and ClassType bindings

### DIFF
--- a/bindings/python/SymbolBindings.cpp
+++ b/bindings/python/SymbolBindings.cpp
@@ -325,6 +325,8 @@ void registerSymbols(py::module_& m) {
         .def_readonly("subroutineKind", &SubroutineSymbol::subroutineKind)
         .def_readonly("visibility", &SubroutineSymbol::visibility)
         .def_readonly("flags", &SubroutineSymbol::flags)
+        .def_readonly("thisVar", &SubroutineSymbol::thisVar)
+        .def_readonly("returnValVar", &SubroutineSymbol::returnValVar)
         .def_property_readonly("arguments", &SubroutineSymbol::getArguments)
         .def_property_readonly("body", &SubroutineSymbol::getBody)
         .def_property_readonly("returnType", &SubroutineSymbol::getReturnType)

--- a/bindings/python/TypeBindings.cpp
+++ b/bindings/python/TypeBindings.cpp
@@ -280,11 +280,19 @@ void registerTypes(py::module_& m) {
         .def_readonly("isAbstract", &ClassType::isAbstract)
         .def_readonly("isInterface", &ClassType::isInterface)
         .def_readonly("isFinal", &ClassType::isFinal)
+        .def_readonly("thisVar", &ClassType::thisVar)
         .def_property_readonly("baseClass", &ClassType::getBaseClass)
         .def_property_readonly("implementedInterfaces", &ClassType::getImplementedInterfaces)
         .def_property_readonly("baseConstructorCall", &ClassType::getBaseConstructorCall)
         .def_property_readonly("constructor", &ClassType::getConstructor)
-        .def_property_readonly("firstForwardDecl", &ClassType::getFirstForwardDecl);
+        .def_property_readonly("firstForwardDecl", &ClassType::getFirstForwardDecl)
+        .def_property_readonly("properties",
+             [](const ClassType& self) {
+                 py::list result;
+                 for (auto& prop : self.properties())
+                     result.append(py::cast(&prop));
+                 return result;
+             });
 
     py::classh<GenericClassDefSymbol, Symbol>(m, "GenericClassDefSymbol")
         .def_readonly("isInterface", &GenericClassDefSymbol::isInterface)

--- a/bindings/python/TypeBindings.cpp
+++ b/bindings/python/TypeBindings.cpp
@@ -286,13 +286,12 @@ void registerTypes(py::module_& m) {
         .def_property_readonly("baseConstructorCall", &ClassType::getBaseConstructorCall)
         .def_property_readonly("constructor", &ClassType::getConstructor)
         .def_property_readonly("firstForwardDecl", &ClassType::getFirstForwardDecl)
-        .def_property_readonly("properties",
-             [](const ClassType& self) {
-                 py::list result;
-                 for (auto& prop : self.properties())
-                     result.append(py::cast(&prop));
-                 return result;
-             });
+        .def_property_readonly("properties", [](const ClassType& self) {
+            py::list result;
+            for (auto& prop : self.properties())
+                result.append(py::cast(&prop));
+            return result;
+        });
 
     py::classh<GenericClassDefSymbol, Symbol>(m, "GenericClassDefSymbol")
         .def_readonly("isInterface", &GenericClassDefSymbol::isInterface)

--- a/pyslang/tests/test_class_bindings.py
+++ b/pyslang/tests/test_class_bindings.py
@@ -17,12 +17,21 @@ def _compile(code):
 
 
 def _find_class(comp, name="Foo"):
-    return next((m for cu in comp.getRoot().compilationUnits for m in cu 
-                 if m.kind == SymbolKind.ClassType and m.name == name), None)
+    return next(
+        (
+            m
+            for cu in comp.getRoot().compilationUnits
+            for m in cu
+            if m.kind == SymbolKind.ClassType and m.name == name
+        ),
+        None,
+    )
 
 
 def _find_method(cls, name):
-    return next((m for m in cls if m.kind == SymbolKind.Subroutine and m.name == name), None)
+    return next(
+        (m for m in cls if m.kind == SymbolKind.Subroutine and m.name == name), None
+    )
 
 
 def test_subroutine_thisvar_class_methods():
@@ -79,9 +88,11 @@ def test_subroutine_thisvar_free_function():
         initial $display("%0d", add(1, 2));
     endmodule
     """)
-    found = any(m.kind == SymbolKind.Subroutine and m.name == "add" and m.thisVar is None
-                for inst in comp.getRoot().topInstances
-                for m in inst.body)
+    found = any(
+        m.kind == SymbolKind.Subroutine and m.name == "add" and m.thisVar is None
+        for inst in comp.getRoot().topInstances
+        for m in inst.body
+    )
     assert found, "free function 'add' not found"
 
 
@@ -130,7 +141,11 @@ def test_subroutine_return_val_var():
             elif m.name == "also_nothing":
                 assert m.returnValVar is None
                 checked.add("also_nothing")
-    assert checked == {"add", "do_nothing", "also_nothing"}, f"not all subroutines found, got: {checked}"
+    assert checked == {
+        "add",
+        "do_nothing",
+        "also_nothing",
+    }, f"not all subroutines found, got: {checked}"
 
 
 def test_classtype_properties():

--- a/pyslang/tests/test_class_bindings.py
+++ b/pyslang/tests/test_class_bindings.py
@@ -1,0 +1,209 @@
+# SPDX-FileCopyrightText: Chaitanya Sharma
+# SPDX-License-Identifier: MIT
+
+from pyslang.ast import (
+    Compilation,
+    MethodFlags,
+    SymbolKind,
+)
+from pyslang.syntax import SyntaxTree
+
+
+def _compile(code):
+    tree, comp = SyntaxTree.fromText(code), Compilation()
+    comp.addSyntaxTree(tree)
+    comp.getAllDiagnostics()
+    return comp
+
+
+def _find_class(comp, name="Foo"):
+    return next((m for cu in comp.getRoot().compilationUnits for m in cu 
+                 if m.kind == SymbolKind.ClassType and m.name == name), None)
+
+
+def _find_method(cls, name):
+    return next((m for m in cls if m.kind == SymbolKind.Subroutine and m.name == name), None)
+
+
+def test_subroutine_thisvar_class_methods():
+    """Non-static class methods have thisVar pointing to the implicit `this`"""
+    comp = _compile("""
+    class Foo;
+        int x;
+        function new(int v);
+            x = v;
+        endfunction
+        function int get_x();
+            return x;
+        endfunction
+        task show();
+            $display("%0d", x);
+        endtask
+    endclass
+    module top; endmodule
+    """)
+
+    cls = _find_class(comp)
+    assert cls is not None
+
+    for method_name in ("new", "get_x", "show"):
+        method = _find_method(cls, method_name)
+        assert method is not None, f"method {method_name} not found"
+        assert method.thisVar is not None, f"{method_name}.thisVar should not be None"
+        assert method.thisVar.name == "this"
+        assert method.thisVar.type.isClass
+
+
+def test_subroutine_thisvar_static_method():
+    """Static class methods have thisVar == None"""
+    comp = _compile("""
+    class Foo;
+        static function void bar();
+        endfunction
+    endclass
+    module top; endmodule
+    """)
+
+    method = _find_method(_find_class(comp), "bar")
+    assert method is not None
+    assert method.thisVar is None
+
+
+def test_subroutine_thisvar_free_function():
+    """Free functions have thisVar == None"""
+    comp = _compile("""
+    module top;
+        function int add(int a, int b);
+            return a + b;
+        endfunction
+        initial $display("%0d", add(1, 2));
+    endmodule
+    """)
+    found = any(m.kind == SymbolKind.Subroutine and m.name == "add" and m.thisVar is None
+                for inst in comp.getRoot().topInstances
+                for m in inst.body)
+    assert found, "free function 'add' not found"
+
+
+def test_classtype_thisvar():
+    comp = _compile("""
+    class Foo;
+        int x;
+    endclass
+    module top; endmodule
+    """)
+
+    cls = _find_class(comp)
+    assert cls is not None
+    assert cls.thisVar is not None
+    assert cls.thisVar.name == "this"
+    assert cls.thisVar.type.isClass
+
+
+def test_subroutine_return_val_var():
+    """Functions have returnValVar; tasks and void functions do not."""
+    comp = _compile("""
+    module top;
+        function int add(int a, int b);
+            return a + b;
+        endfunction
+        task do_nothing();
+        endtask
+        function void also_nothing();
+        endfunction
+    endmodule
+    """)
+
+    checked = set()
+    for inst in comp.getRoot().topInstances:
+        for m in inst.body:
+            if m.kind != SymbolKind.Subroutine:
+                continue
+            if m.name == "add":
+                assert m.returnValVar is not None
+                assert m.returnValVar.name == "add"
+                assert m.returnValVar.type.bitWidth == 32
+                checked.add("add")
+            elif m.name == "do_nothing":
+                assert m.returnValVar is None
+                checked.add("do_nothing")
+            elif m.name == "also_nothing":
+                assert m.returnValVar is None
+                checked.add("also_nothing")
+    assert checked == {"add", "do_nothing", "also_nothing"}, f"not all subroutines found, got: {checked}"
+
+
+def test_classtype_properties():
+    """ClassType.properties returns only ClassPropertySymbol members."""
+    comp = _compile("""
+    class Foo;
+        int x;
+        string s;
+        real r;
+        function new(); endfunction
+        function int get_x(); return x; endfunction
+    endclass
+    module top; endmodule
+    """)
+
+    cls = _find_class(comp)
+    assert cls is not None
+
+    props = cls.properties
+    assert len(props) == 3
+
+    assert props[0].name == "x"
+    assert props[0].kind == SymbolKind.ClassProperty
+    assert props[0].type.isIntegral
+
+    assert props[1].name == "s"
+    assert props[1].type.isString
+
+    assert props[2].name == "r"
+    assert props[2].type.isFloating
+
+
+def test_classtype_properties_with_inheritance():
+    comp = _compile("""
+    class Base;
+        int a;
+    endclass
+    class Child extends Base;
+        int b;
+    endclass
+    module top; endmodule
+    """)
+
+    cls = _find_class(comp, "Child")
+    assert cls is not None
+
+    props = cls.properties
+    assert len(props) == 2
+    assert props[0].name == "a", "inherited property should come first"
+    assert props[1].name == "b"
+
+
+def test_classtype_properties_empty():
+    comp = _compile("""
+    class Foo;
+        function void noop(); endfunction
+    endclass
+    module top; endmodule
+    """)
+
+    cls = _find_class(comp)
+    assert cls is not None
+    assert len(cls.properties) == 0
+
+
+def test_constructor_flags():
+    comp = _compile("""
+    class Foo;
+        function new(); endfunction
+    endclass
+    module top; endmodule
+    """)
+
+    ctor = _find_method(_find_class(comp), "new")
+    assert ctor is not None
+    assert ctor.flags & MethodFlags.Constructor


### PR DESCRIPTION
saw [ConstraintBlockSymbol.thisVar](https://github.com/MikePopoloski/slang/blob/042fd16d144aefd10919e1a6de4d5d127c666f9e/bindings/python/TypeBindings.cpp#L311) was already bound, so this just follows that
essentially
- `SubroutineSymbol.thisVar`, the implicit `this` handle for non-static class methods (`None` for free functions and static methods)
- `SubroutineSymbol.returnValVar`, the return value variable for functions (`None` for tasks and void functions)
- `ClassType.thisVar`, the class-level implicit `this` variable
- `ClassType.properties`, list of `ClassPropertySymbol` members, including inherited ones
