### PR TITLE
Allow streaming operators as branches of conditional (ternary) expressions

### DIFF
--- a/include/slang/ast/ASTContext.h
+++ b/include/slang/ast/ASTContext.h
@@ -184,13 +184,8 @@ enum class SLANG_EXPORT ASTFlags : uint64_t {
 
     /// AST binding is for a wildcard port connection.
     WildcardPortConn = 1ull << 42,
-
-    /// AST binding is for the operand of an explicit bitstream cast expression.
-    /// Used to distinguish bitstream cast semantics from assignment semantics when
-    /// binding a streaming concatenation with a known target type.
-    BitstreamCast = 1ull << 43,
 };
-SLANG_BITMASK(ASTFlags, BitstreamCast)
+SLANG_BITMASK(ASTFlags, WildcardPortConn)
 
 /// Various flags that can be applied to a constant expression evaluation.
 enum class SLANG_EXPORT EvalFlags : uint8_t {

--- a/include/slang/ast/ASTContext.h
+++ b/include/slang/ast/ASTContext.h
@@ -184,8 +184,13 @@ enum class SLANG_EXPORT ASTFlags : uint64_t {
 
     /// AST binding is for a wildcard port connection.
     WildcardPortConn = 1ull << 42,
+
+    /// AST binding is for the operand of an explicit bitstream cast expression.
+    /// Used to distinguish bitstream cast semantics from assignment semantics when
+    /// binding a streaming concatenation with a known target type.
+    BitstreamCast = 1ull << 43,
 };
-SLANG_BITMASK(ASTFlags, WildcardPortConn)
+SLANG_BITMASK(ASTFlags, BitstreamCast)
 
 /// Various flags that can be applied to a constant expression evaluation.
 enum class SLANG_EXPORT EvalFlags : uint8_t {

--- a/include/slang/ast/expressions/OperatorExpressions.h
+++ b/include/slang/ast/expressions/OperatorExpressions.h
@@ -363,7 +363,8 @@ public:
 
     static Expression& fromSyntax(Compilation& compilation,
                                   const syntax::StreamingConcatenationExpressionSyntax& syntax,
-                                  const ASTContext& context);
+                                  const ASTContext& context,
+                                  const Type* assignmentTarget = nullptr);
 
     static bool isKind(ExpressionKind kind) { return kind == ExpressionKind::Streaming; }
 

--- a/source/ast/Expression.cpp
+++ b/source/ast/Expression.cpp
@@ -909,7 +909,8 @@ Expression& Expression::create(Compilation& compilation, const ExpressionSyntax&
             break;
         case SyntaxKind::StreamingConcatenationExpression:
             result = &StreamingConcatenationExpression::fromSyntax(
-                compilation, syntax.as<StreamingConcatenationExpressionSyntax>(), context);
+                compilation, syntax.as<StreamingConcatenationExpressionSyntax>(), context,
+                assignmentTarget);
             break;
         case SyntaxKind::ElementSelectExpression:
             result = &bindSelectExpression(compilation, syntax.as<ElementSelectExpressionSyntax>(),

--- a/source/ast/expressions/ConversionExpression.cpp
+++ b/source/ast/expressions/ConversionExpression.cpp
@@ -178,11 +178,11 @@ Expression& Expression::convertAssignment(const ASTContext& context, const Type&
         }
 
         if (expr.kind == ExpressionKind::Streaming) {
+            // This path is reached only when streaming is used in a self-determined context
+            // (AllowSelfDeterminedStreamConcat mode) where no assignmentTarget was available
+            // to pre-convert in fromSyntax. Validate and wrap as a streaming conversion.
             if (Bitstream::canBeSource(type, expr.as<StreamingConcatenationExpression>(),
                                        assignmentRange, context)) {
-                // Add an implicit bit-stream casting otherwise types are not assignment compatible.
-                // The size rule is not identical to explicit bit-stream casting so a different
-                // ConversionKind is used.
                 result = comp.emplace<ConversionExpression>(type, ConversionKind::StreamingConcat,
                                                             *result, result->sourceRange);
                 selfDetermined(context, result);
@@ -296,7 +296,8 @@ Expression& ConversionExpression::fromSyntax(Compilation& comp, const CastExpres
             return badExpr(comp, nullptr);
         }
 
-        operand = &create(comp, *syntax.right, context, ASTFlags::StreamingAllowed, type);
+        operand = &create(comp, *syntax.right, context,
+                          ASTFlags::StreamingAllowed | ASTFlags::BitstreamCast, type);
         if (operand->bad())
             return badExpr(comp, nullptr);
     }

--- a/source/ast/expressions/ConversionExpression.cpp
+++ b/source/ast/expressions/ConversionExpression.cpp
@@ -287,8 +287,8 @@ Expression& ConversionExpression::fromSyntax(Compilation& comp, const CastExpres
         // For other operands (e.g. assignment patterns), assignmentTarget is needed for type
         // deduction. The cast syntax wraps the operand in ParenthesizedExpressionSyntax, so
         // check the inner expression kind.
-        const bool isStreamingOperand =
-            syntax.right->expression->kind == SyntaxKind::StreamingConcatenationExpression;
+        const bool isStreamingOperand = syntax.right->expression->kind ==
+                                        SyntaxKind::StreamingConcatenationExpression;
         operand = &create(comp, *syntax.right, context, ASTFlags::StreamingAllowed,
                           isStreamingOperand ? nullptr : type);
         if (operand->bad())

--- a/source/ast/expressions/ConversionExpression.cpp
+++ b/source/ast/expressions/ConversionExpression.cpp
@@ -177,20 +177,6 @@ Expression& Expression::convertAssignment(const ASTContext& context, const Type&
                                                       *result, nullptr, assignmentRange);
         }
 
-        if (expr.kind == ExpressionKind::Streaming) {
-            // This path is reached only when streaming is used in a self-determined context
-            // (AllowSelfDeterminedStreamConcat mode) where no assignmentTarget was available
-            // to pre-convert in fromSyntax. Validate and wrap as a streaming conversion.
-            if (Bitstream::canBeSource(type, expr.as<StreamingConcatenationExpression>(),
-                                       assignmentRange, context)) {
-                result = comp.emplace<ConversionExpression>(type, ConversionKind::StreamingConcat,
-                                                            *result, result->sourceRange);
-                selfDetermined(context, result);
-                return *result;
-            }
-            return badExpr(comp, &expr);
-        }
-
         if (expr.kind == ExpressionKind::ValueRange) {
             // Convert each side of the range and return that as a new range.
             auto convert = [&](Expression& expr) -> Expression& {
@@ -296,8 +282,15 @@ Expression& ConversionExpression::fromSyntax(Compilation& comp, const CastExpres
             return badExpr(comp, nullptr);
         }
 
-        operand = &create(comp, *syntax.right, context,
-                          ASTFlags::StreamingAllowed | ASTFlags::BitstreamCast, type);
+        // Don't pass type as assignmentTarget for streaming operands: the existing
+        // isBitstreamCast path below handles them with the correct semantics and error codes.
+        // For other operands (e.g. assignment patterns), assignmentTarget is needed for type
+        // deduction. The cast syntax wraps the operand in ParenthesizedExpressionSyntax, so
+        // check the inner expression kind.
+        const bool isStreamingOperand =
+            syntax.right->expression->kind == SyntaxKind::StreamingConcatenationExpression;
+        operand = &create(comp, *syntax.right, context, ASTFlags::StreamingAllowed,
+                          isStreamingOperand ? nullptr : type);
         if (operand->bad())
             return badExpr(comp, nullptr);
     }

--- a/source/ast/expressions/OperatorExpressions.cpp
+++ b/source/ast/expressions/OperatorExpressions.cpp
@@ -1455,7 +1455,7 @@ Expression& ConditionalExpression::fromSyntax(Compilation& comp,
         rightFlags |= ASTFlags::AllowUnboundedLiteral;
     }
 
-    // Pass through the flag allowing streaming operators.
+    // Pass through the flag allowing streaming operators as branches.
     if (context.flags.has(ASTFlags::StreamingAllowed)) {
         leftFlags |= ASTFlags::StreamingAllowed;
         rightFlags |= ASTFlags::StreamingAllowed;
@@ -1471,16 +1471,6 @@ Expression& ConditionalExpression::fromSyntax(Compilation& comp,
         lt = &comp.getIntType();
     if (rt->isUnbounded())
         rt = &comp.getIntType();
-
-    // If a branch is a streaming concatenation (void type), substitute the assignment
-    // target or the other branch's type for the purpose of type unification. The actual
-    // conversion of the streaming branch happens below via convertAssignment.
-    const bool leftIsStreaming = left.kind == ExpressionKind::Streaming && lt->isVoid();
-    const bool rightIsStreaming = right.kind == ExpressionKind::Streaming && rt->isVoid();
-    if (leftIsStreaming)
-        lt = assignmentTarget ? assignmentTarget : rt;
-    if (rightIsStreaming)
-        rt = assignmentTarget ? assignmentTarget : lt;
 
     // Force four-state return type for ambiguous condition case.
     const Type* resultType = OpInfo::binaryType(comp, lt, rt, isFourState);
@@ -1540,24 +1530,9 @@ Expression& ConditionalExpression::fromSyntax(Compilation& comp,
                                                            syntax.sourceRange(), isConst, isTrue));
     }
 
-    // Convert streaming concat branches to the result type before building the node.
-    Expression* leftExpr = &left;
-    Expression* rightExpr = &right;
-    if (!bad) {
-        if (leftIsStreaming) {
-            leftExpr = &convertAssignment(trueContext, *resultType, left, left.sourceRange);
-            bad |= leftExpr->bad();
-        }
-        if (rightIsStreaming) {
-            rightExpr = &convertAssignment(context, *resultType, right, right.sourceRange);
-            bad |= rightExpr->bad();
-        }
-    }
-
     auto result = comp.emplace<ConditionalExpression>(*resultType, conditions.copy(comp),
-                                                      syntax.question.location(), *leftExpr,
-                                                      *rightExpr, syntax.sourceRange(), isConst,
-                                                      isTrue);
+                                                      syntax.question.location(), left, right,
+                                                      syntax.sourceRange(), isConst, isTrue);
     if (bad)
         return badExpr(comp, result);
 
@@ -2299,7 +2274,7 @@ void ReplicationExpression::serializeTo(ASTSerializer& serializer) const {
 
 Expression& StreamingConcatenationExpression::fromSyntax(
     Compilation& comp, const StreamingConcatenationExpressionSyntax& syntax,
-    const ASTContext& context) {
+    const ASTContext& context, const Type* assignmentTarget) {
 
     const bool isDestination = context.flags.has(ASTFlags::LValue);
     const bool isRightToLeft = syntax.operatorToken.kind == TokenKind::LeftShift;
@@ -2434,22 +2409,33 @@ Expression& StreamingConcatenationExpression::fromSyntax(
         buffer.push_back({&arg, withExpr, constantWithWidth});
     }
 
-    // So normally the type of a streaming concatenation is never inspected,
-    // since it can only be used in assignments and there is explicit handling
-    // of these expressions there. We use a void type for the result to represent
-    // this (also because otherwise what type can we use for e.g. non fixed-size
-    // streams). However, in VCS compat mode the error about requiring an assignment
-    // context can be silenced, so we need to come up with a real result type here,
-    // which we do by converting to a packed bit vector of bitstream width.
     auto& result = *comp.emplace<StreamingConcatenationExpression>(
         comp.getVoidType(), sliceSize, bitstreamWidth, buffer.ccopy(comp), syntax.sourceRange());
 
     if (!context.flags.has(ASTFlags::StreamingAllowed)) {
-        // Cap the width so we don't overflow. The conversion will error for us
-        // since the target width will be less than the source width.
+        // VCS compat mode: the error about requiring an assignment context can be silenced,
+        // so produce a real result type by converting to a packed bit vector of bitstream width.
+        // Cap the width so we don't overflow; the conversion will error for width mismatch.
         auto width = std::min(bitstreamWidth, (uint64_t)SVInt::MAX_BITS);
         auto& type = comp.getType(bitwidth_t(width), IntegralFlags::FourState);
         return convertAssignment(context, type, result, result.sourceRange);
+    }
+
+    // When the assignment target type is known (and not void — which happens when LHS is also a
+    // streaming concat), validate widths and wrap in a StreamingConcat conversion so the expression
+    // carries the target type directly, avoiding void-type special casing elsewhere.
+    // In explicit bitstream cast context the outer ConversionExpression::fromSyntax already
+    // handles validation and wrapping via isBitstreamCast, so skip pre-conversion here.
+    if (!isDestination && assignmentTarget && !assignmentTarget->isVoid() &&
+        !assignmentTarget->isError() && !context.flags.has(ASTFlags::BitstreamCast)) {
+        if (!Bitstream::canBeSource(*assignmentTarget, result, result.sourceRange, context)) {
+            return badResult();
+        }
+        Expression* conv = comp.emplace<ConversionExpression>(*assignmentTarget,
+                                                              ConversionKind::StreamingConcat,
+                                                              result, result.sourceRange);
+        selfDetermined(context, conv);
+        return *conv;
     }
 
     return result;

--- a/source/ast/expressions/OperatorExpressions.cpp
+++ b/source/ast/expressions/OperatorExpressions.cpp
@@ -1526,9 +1526,10 @@ Expression& ConditionalExpression::fromSyntax(Compilation& comp,
         diag << *lt << *rt;
         diag << left.sourceRange;
         diag << right.sourceRange;
-        return badExpr(comp, comp.emplace<ConditionalExpression>(
-                                  *resultType, conditions.copy(comp), syntax.question.location(),
-                                  left, right, syntax.sourceRange(), isConst, isTrue));
+        return badExpr(comp,
+                       comp.emplace<ConditionalExpression>(*resultType, conditions.copy(comp),
+                                                           syntax.question.location(), left, right,
+                                                           syntax.sourceRange(), isConst, isTrue));
     }
 
     // Convert streaming concat branches to the result type before building the node.

--- a/source/ast/expressions/OperatorExpressions.cpp
+++ b/source/ast/expressions/OperatorExpressions.cpp
@@ -1485,6 +1485,13 @@ Expression& ConditionalExpression::fromSyntax(Compilation& comp,
     // Force four-state return type for ambiguous condition case.
     const Type* resultType = OpInfo::binaryType(comp, lt, rt, isFourState);
 
+    // If either branch already has an error, skip type unification.
+    if (bad) {
+        return badExpr(comp, comp.emplace<ConditionalExpression>(
+                                  *resultType, conditions.copy(comp), syntax.question.location(),
+                                  left, right, syntax.sourceRange(), isConst, isTrue));
+    }
+
     // If both sides of the expression are numeric, we've already determined the correct
     // result type. Otherwise, follow the rules in [11.14.11].
     bool good = true;

--- a/source/ast/expressions/OperatorExpressions.cpp
+++ b/source/ast/expressions/OperatorExpressions.cpp
@@ -1487,9 +1487,10 @@ Expression& ConditionalExpression::fromSyntax(Compilation& comp,
 
     // If either branch already has an error, skip type unification.
     if (bad) {
-        return badExpr(comp, comp.emplace<ConditionalExpression>(
-                                  *resultType, conditions.copy(comp), syntax.question.location(),
-                                  left, right, syntax.sourceRange(), isConst, isTrue));
+        return badExpr(comp,
+                       comp.emplace<ConditionalExpression>(*resultType, conditions.copy(comp),
+                                                           syntax.question.location(), left, right,
+                                                           syntax.sourceRange(), isConst, isTrue));
     }
 
     // If both sides of the expression are numeric, we've already determined the correct

--- a/source/ast/expressions/OperatorExpressions.cpp
+++ b/source/ast/expressions/OperatorExpressions.cpp
@@ -1474,45 +1474,42 @@ Expression& ConditionalExpression::fromSyntax(Compilation& comp,
 
     // Force four-state return type for ambiguous condition case.
     const Type* resultType = OpInfo::binaryType(comp, lt, rt, isFourState);
-
-    // If either branch already has an error, skip type unification.
-    if (bad) {
-        return badExpr(comp,
-                       comp.emplace<ConditionalExpression>(*resultType, conditions.copy(comp),
-                                                           syntax.question.location(), left, right,
-                                                           syntax.sourceRange(), isConst, isTrue));
-    }
+    auto result = comp.emplace<ConditionalExpression>(*resultType, conditions.copy(comp),
+                                                      syntax.question.location(), left, right,
+                                                      syntax.sourceRange(), isConst, isTrue);
+    if (bad)
+        return badExpr(comp, result);
 
     // If both sides of the expression are numeric, we've already determined the correct
     // result type. Otherwise, follow the rules in [11.14.11].
     bool good = true;
     if (!lt->isNumeric() || !rt->isNumeric()) {
         if (lt->isNull() && rt->isNull()) {
-            resultType = &comp.getNullType();
+            result->type = &comp.getNullType();
         }
         else if (lt->isClass() || rt->isClass() || lt->isCHandle() || rt->isCHandle() ||
                  lt->isEvent() || rt->isEvent() || lt->isVirtualInterface() ||
                  rt->isVirtualInterface() || lt->isCovergroup() || rt->isCovergroup()) {
             if (lt->isNull())
-                resultType = rt;
+                result->type = rt;
             else if (rt->isNull())
-                resultType = lt;
+                result->type = lt;
             else if (rt->isAssignmentCompatible(*lt))
-                resultType = rt;
+                result->type = rt;
             else if (lt->isAssignmentCompatible(*rt))
-                resultType = lt;
+                result->type = lt;
             else if (auto common = Type::getCommonBase(*lt, *rt))
-                resultType = common;
+                result->type = common;
             else if (lt->isEquivalent(*rt))
-                resultType = lt;
+                result->type = lt;
             else
                 good = false;
         }
         else if (lt->isEquivalent(*rt)) {
-            resultType = lt;
+            result->type = lt;
         }
         else if (left.isImplicitString() && right.isImplicitString()) {
-            resultType = &comp.getStringType();
+            result->type = &comp.getStringType();
         }
         else {
             good = false;
@@ -1524,17 +1521,8 @@ Expression& ConditionalExpression::fromSyntax(Compilation& comp,
         diag << *lt << *rt;
         diag << left.sourceRange;
         diag << right.sourceRange;
-        return badExpr(comp,
-                       comp.emplace<ConditionalExpression>(*resultType, conditions.copy(comp),
-                                                           syntax.question.location(), left, right,
-                                                           syntax.sourceRange(), isConst, isTrue));
-    }
-
-    auto result = comp.emplace<ConditionalExpression>(*resultType, conditions.copy(comp),
-                                                      syntax.question.location(), left, right,
-                                                      syntax.sourceRange(), isConst, isTrue);
-    if (bad)
         return badExpr(comp, result);
+    }
 
     // Warn about cases where a conditional expression and a binary operator
     // are mixed in a way that suggests the user mixed up the precedence order.
@@ -2412,26 +2400,24 @@ Expression& StreamingConcatenationExpression::fromSyntax(
     auto& result = *comp.emplace<StreamingConcatenationExpression>(
         comp.getVoidType(), sliceSize, bitstreamWidth, buffer.ccopy(comp), syntax.sourceRange());
 
+    // In VCS compat mode the error about requiring an assignment context can be silenced,
+    // so we need a real target type. Use a packed bit vector of the bitstream width.
+    // Cap the width so we don't overflow; canBeSource below will error if target < source.
+    const Type* effectiveTarget = assignmentTarget;
     if (!context.flags.has(ASTFlags::StreamingAllowed)) {
-        // VCS compat mode: the error about requiring an assignment context can be silenced,
-        // so produce a real result type by converting to a packed bit vector of bitstream width.
-        // Cap the width so we don't overflow; the conversion will error for width mismatch.
         auto width = std::min(bitstreamWidth, (uint64_t)SVInt::MAX_BITS);
-        auto& type = comp.getType(bitwidth_t(width), IntegralFlags::FourState);
-        return convertAssignment(context, type, result, result.sourceRange);
+        effectiveTarget = &comp.getType(bitwidth_t(width), IntegralFlags::FourState);
     }
 
     // When the assignment target type is known (and not void — which happens when LHS is also a
     // streaming concat), validate widths and wrap in a StreamingConcat conversion so the expression
     // carries the target type directly, avoiding void-type special casing elsewhere.
-    // In explicit bitstream cast context the outer ConversionExpression::fromSyntax already
-    // handles validation and wrapping via isBitstreamCast, so skip pre-conversion here.
-    if (!isDestination && assignmentTarget && !assignmentTarget->isVoid() &&
-        !assignmentTarget->isError() && !context.flags.has(ASTFlags::BitstreamCast)) {
-        if (!Bitstream::canBeSource(*assignmentTarget, result, result.sourceRange, context)) {
+    if (!isDestination && effectiveTarget && !effectiveTarget->isVoid() &&
+        !effectiveTarget->isError()) {
+        if (!Bitstream::canBeSource(*effectiveTarget, result, result.sourceRange, context)) {
             return badResult();
         }
-        Expression* conv = comp.emplace<ConversionExpression>(*assignmentTarget,
+        Expression* conv = comp.emplace<ConversionExpression>(*effectiveTarget,
                                                               ConversionKind::StreamingConcat,
                                                               result, result.sourceRange);
         selfDetermined(context, conv);

--- a/source/ast/expressions/OperatorExpressions.cpp
+++ b/source/ast/expressions/OperatorExpressions.cpp
@@ -1455,6 +1455,12 @@ Expression& ConditionalExpression::fromSyntax(Compilation& comp,
         rightFlags |= ASTFlags::AllowUnboundedLiteral;
     }
 
+    // Pass through the flag allowing streaming operators.
+    if (context.flags.has(ASTFlags::StreamingAllowed)) {
+        leftFlags |= ASTFlags::StreamingAllowed;
+        rightFlags |= ASTFlags::StreamingAllowed;
+    }
+
     auto& left = create(comp, *syntax.left, trueContext, leftFlags, assignmentTarget);
     auto& right = create(comp, *syntax.right, context, rightFlags, assignmentTarget);
     bad |= left.bad() || right.bad();
@@ -1466,44 +1472,49 @@ Expression& ConditionalExpression::fromSyntax(Compilation& comp,
     if (rt->isUnbounded())
         rt = &comp.getIntType();
 
+    // If a branch is a streaming concatenation (void type), substitute the assignment
+    // target or the other branch's type for the purpose of type unification. The actual
+    // conversion of the streaming branch happens below via convertAssignment.
+    const bool leftIsStreaming = left.kind == ExpressionKind::Streaming && lt->isVoid();
+    const bool rightIsStreaming = right.kind == ExpressionKind::Streaming && rt->isVoid();
+    if (leftIsStreaming)
+        lt = assignmentTarget ? assignmentTarget : rt;
+    if (rightIsStreaming)
+        rt = assignmentTarget ? assignmentTarget : lt;
+
     // Force four-state return type for ambiguous condition case.
     const Type* resultType = OpInfo::binaryType(comp, lt, rt, isFourState);
-    auto result = comp.emplace<ConditionalExpression>(*resultType, conditions.copy(comp),
-                                                      syntax.question.location(), left, right,
-                                                      syntax.sourceRange(), isConst, isTrue);
-    if (bad)
-        return badExpr(comp, result);
 
     // If both sides of the expression are numeric, we've already determined the correct
     // result type. Otherwise, follow the rules in [11.14.11].
     bool good = true;
     if (!lt->isNumeric() || !rt->isNumeric()) {
         if (lt->isNull() && rt->isNull()) {
-            result->type = &comp.getNullType();
+            resultType = &comp.getNullType();
         }
         else if (lt->isClass() || rt->isClass() || lt->isCHandle() || rt->isCHandle() ||
                  lt->isEvent() || rt->isEvent() || lt->isVirtualInterface() ||
                  rt->isVirtualInterface() || lt->isCovergroup() || rt->isCovergroup()) {
             if (lt->isNull())
-                result->type = rt;
+                resultType = rt;
             else if (rt->isNull())
-                result->type = lt;
+                resultType = lt;
             else if (rt->isAssignmentCompatible(*lt))
-                result->type = rt;
+                resultType = rt;
             else if (lt->isAssignmentCompatible(*rt))
-                result->type = lt;
+                resultType = lt;
             else if (auto common = Type::getCommonBase(*lt, *rt))
-                result->type = common;
+                resultType = common;
             else if (lt->isEquivalent(*rt))
-                result->type = lt;
+                resultType = lt;
             else
                 good = false;
         }
         else if (lt->isEquivalent(*rt)) {
-            result->type = lt;
+            resultType = lt;
         }
         else if (left.isImplicitString() && right.isImplicitString()) {
-            result->type = &comp.getStringType();
+            resultType = &comp.getStringType();
         }
         else {
             good = false;
@@ -1515,8 +1526,31 @@ Expression& ConditionalExpression::fromSyntax(Compilation& comp,
         diag << *lt << *rt;
         diag << left.sourceRange;
         diag << right.sourceRange;
-        return badExpr(comp, result);
+        return badExpr(comp, comp.emplace<ConditionalExpression>(
+                                  *resultType, conditions.copy(comp), syntax.question.location(),
+                                  left, right, syntax.sourceRange(), isConst, isTrue));
     }
+
+    // Convert streaming concat branches to the result type before building the node.
+    Expression* leftExpr = &left;
+    Expression* rightExpr = &right;
+    if (!bad) {
+        if (leftIsStreaming) {
+            leftExpr = &convertAssignment(trueContext, *resultType, left, left.sourceRange);
+            bad |= leftExpr->bad();
+        }
+        if (rightIsStreaming) {
+            rightExpr = &convertAssignment(context, *resultType, right, right.sourceRange);
+            bad |= rightExpr->bad();
+        }
+    }
+
+    auto result = comp.emplace<ConditionalExpression>(*resultType, conditions.copy(comp),
+                                                      syntax.question.location(), *leftExpr,
+                                                      *rightExpr, syntax.sourceRange(), isConst,
+                                                      isTrue);
+    if (bad)
+        return badExpr(comp, result);
 
     // Warn about cases where a conditional expression and a binary operator
     // are mixed in a way that suggests the user mixed up the precedence order.

--- a/tests/unittests/ast/ExpressionTests.cpp
+++ b/tests/unittests/ast/ExpressionTests.cpp
@@ -1580,6 +1580,7 @@ TEST_CASE("Streaming operators") {
         {"int a; int b = {>>{a}} + 2;", diag::BadStreamContext},
         {"shortint a,b; int c = {{>>{a}}, b};", diag::BadStreamContext},
         {"int a,b; always_comb {>>{a}} += b;", diag::BadStreamContext},
+        {"int a,b; int c = a ? {>>{a}} + 2 : b;", diag::BadStreamContext},
         {"int a; int b = {<< string {a}};", diag::BadStreamSlice},
         {"typedef bit t[]; int a; int b = {<<t{a}};", diag::BadStreamSlice},
         {"int a, c; int b = {<< c {a}};", diag::ConstEvalNonConstVariable},
@@ -1676,6 +1677,12 @@ module sub(input byte b);
         "struct{bit a[];int b;}a;struct {byte a[];bit b;}b;assign{<<{a}}={>>{b}};",
         "struct{bit a[];int b;}a;int b;assign {>>{a}} = {<<{b}};",
         "localparam int p = {<<{6}}; enum {a={>>{2}},b={<<{p}}, c} t;",
+
+        // Streaming operator as a branch of a conditional (ternary) expression
+        "wire c; assign c = c ? {<<8{c & c}} : c;",
+        "bit s; int a; byte b[4]; assign b = s ? b : {<<3{a}};",
+        "bit s; int a; byte b[4]; assign b = s ? {<<3{a}} : b;",
+        "bit s; int a; byte b[4]; assign b = s ? {<<2{a}} : {<<3{a}};",
 
         R"(
     bit [0:1] c [2:0];

--- a/tests/unittests/ast/ExpressionTests.cpp
+++ b/tests/unittests/ast/ExpressionTests.cpp
@@ -1668,8 +1668,7 @@ module sub(input byte b);
     }
 
     std::string legal[] = {
-        "int a = 0; byte b[4] = {<<3{a}};",
-        "int a; byte b[4]; assign {<<3{b}} = a;",
+        "int a = 0; byte b[4] = {<<3{a}};", "int a; byte b[4]; assign {<<3{b}} = a;",
         "int a; byte b[4]; assign {<<3{b}} = {<<5{a}};",
         "byte b[4] = '{default:0}; int a = int'({<<3{b}}) + 5;",
         "shortint a = 0; byte b[2] = '{default:0}; int c = {<<3{a, {<<5{b}}}};",


### PR DESCRIPTION
Slang incorrectly rejected streaming operators (`{<<N{...}}, {>>N{...}}`) when used as branches of a conditional expression in an assignment context (commercial tools like VCS accept this case):

```verilog
wire c;
assign c = c ? {<<8{c & c}} : c;  // error: streaming operator can only be used in an assignment or bit-stream cast argument
```

Also, this type of RTL design can be found in open-source projects such as CVA6 (https://github.com/openhwgroup/cva6/blob/8e694e6460d017fb8a175336cd7dcb91d8eff682/vendor/pulp-platform/axi_riscv_atomics/src/axi_riscv_amos.sv#L918).

The LRM permits this - streaming operators are valid wherever a bitstream source expression is allowed, including as branches of a ternary that is itself in an assignment context.

Two issues in `ConditionalExpression::fromSyntax`:

1. Missing flag propagation: `ASTFlags::StreamingAllowed` was not forwarded to the true/false branch contexts, so the streaming concatenation parser rejected the expression before type-checking even began.
2. Void-type unification failure: `StreamingConcatenationExpression` intentionally carries a void type (its real type is only resolved when `convertAssignment` wraps it). The existing type-unification logic had no handling for void branches, causing a "bad conditional expression" error even after the flag was propagated.

Fix in `source/ast/expressions/OperatorExpressions.cpp`:

1. Propagate `ASTFlags::StreamingAllowed` to both branch contexts (mirrors the existing `AllowUnboundedLiteral` pattern).
2. Before type unification, detect streaming branches (void-typed `ExpressionKind::Streaming`) and substitute the assignment target type (or the other branch's type) as a stand-in. This lets the existing numeric/class type-unification logic compute a correct `resultType`.
3. After `resultType` is determined but before constructing `ConditionalExpression`, call `convertAssignment` on any streaming branches to produce the proper `ConversionExpression(StreamingConcat)` wrappers — exactly as a direct assignment would.
