### PR TITLE
Preserve bound control expressions and branch kind on generate symbols

### DIFF
--- a/bindings/python/SymbolBindings.cpp
+++ b/bindings/python/SymbolBindings.cpp
@@ -475,7 +475,7 @@ void registerSymbols(py::module_& m) {
         .def_readonly("initialExpression", &GenerateBlockArraySymbol::initialExpression)
         .def_readonly("stopExpression", &GenerateBlockArraySymbol::stopExpression)
         .def_readonly("iterExpression", &GenerateBlockArraySymbol::iterExpression)
-        .def_readonly("genvar", &GenerateBlockArraySymbol::genvar)
+        .def_readonly("loopVariable", &GenerateBlockArraySymbol::loopVariable)
         .def_property_readonly("externalName", &GenerateBlockArraySymbol::getExternalName);
 
     py::classh<EmptyMemberSymbol, Symbol>(m, "EmptyMemberSymbol");

--- a/bindings/python/SymbolBindings.cpp
+++ b/bindings/python/SymbolBindings.cpp
@@ -465,8 +465,7 @@ void registerSymbols(py::module_& m) {
         .def_readonly("branchKind", &GenerateBlockSymbol::branchKind)
         .def_readonly("caseItemExpressions", &GenerateBlockSymbol::caseItemExpressions)
         .def_property_readonly("arrayIndex", &GenerateBlockSymbol::getArrayIndex)
-        .def_property_readonly("conditionExpression",
-                               &GenerateBlockSymbol::getConditionExpression)
+        .def_property_readonly("conditionExpression", &GenerateBlockSymbol::getConditionExpression)
         .def_property_readonly("externalName", &GenerateBlockSymbol::getExternalName);
 
     py::classh<GenerateBlockArraySymbol, Symbol, Scope>(m, "GenerateBlockArraySymbol")

--- a/bindings/python/SymbolBindings.cpp
+++ b/bindings/python/SymbolBindings.cpp
@@ -457,16 +457,26 @@ void registerSymbols(py::module_& m) {
         .def_property_readonly("body", &ProceduralBlockSymbol::getBody)
         .def_property_readonly("blocks", &ProceduralBlockSymbol::getBlocks);
 
+    EXPOSE_ENUM(m, GenerateBranchKind);
+
     py::classh<GenerateBlockSymbol, Symbol, Scope>(m, "GenerateBlockSymbol")
         .def_readonly("constructIndex", &GenerateBlockSymbol::constructIndex)
         .def_readonly("isUninstantiated", &GenerateBlockSymbol::isUninstantiated)
         .def_readonly("arrayIndex", &GenerateBlockSymbol::arrayIndex)
+        .def_readonly("branchKind", &GenerateBlockSymbol::branchKind)
+        .def_readonly("generateConstructSyntax", &GenerateBlockSymbol::generateConstructSyntax)
+        .def_readonly("conditionExpression", &GenerateBlockSymbol::conditionExpression)
+        .def_readonly("caseItemExpressions", &GenerateBlockSymbol::caseItemExpressions)
         .def_property_readonly("externalName", &GenerateBlockSymbol::getExternalName);
 
     py::classh<GenerateBlockArraySymbol, Symbol, Scope>(m, "GenerateBlockArraySymbol")
         .def_readonly("constructIndex", &GenerateBlockArraySymbol::constructIndex)
         .def_readonly("entries", &GenerateBlockArraySymbol::entries)
         .def_readonly("valid", &GenerateBlockArraySymbol::valid)
+        .def_readonly("initialExpression", &GenerateBlockArraySymbol::initialExpression)
+        .def_readonly("stopExpression", &GenerateBlockArraySymbol::stopExpression)
+        .def_readonly("iterExpression", &GenerateBlockArraySymbol::iterExpression)
+        .def_readonly("genvar", &GenerateBlockArraySymbol::genvar)
         .def_property_readonly("externalName", &GenerateBlockArraySymbol::getExternalName);
 
     py::classh<EmptyMemberSymbol, Symbol>(m, "EmptyMemberSymbol");

--- a/bindings/python/SymbolBindings.cpp
+++ b/bindings/python/SymbolBindings.cpp
@@ -462,11 +462,11 @@ void registerSymbols(py::module_& m) {
     py::classh<GenerateBlockSymbol, Symbol, Scope>(m, "GenerateBlockSymbol")
         .def_readonly("constructIndex", &GenerateBlockSymbol::constructIndex)
         .def_readonly("isUninstantiated", &GenerateBlockSymbol::isUninstantiated)
-        .def_readonly("arrayIndex", &GenerateBlockSymbol::arrayIndex)
         .def_readonly("branchKind", &GenerateBlockSymbol::branchKind)
-        .def_readonly("generateConstructSyntax", &GenerateBlockSymbol::generateConstructSyntax)
-        .def_readonly("conditionExpression", &GenerateBlockSymbol::conditionExpression)
         .def_readonly("caseItemExpressions", &GenerateBlockSymbol::caseItemExpressions)
+        .def_property_readonly("arrayIndex", &GenerateBlockSymbol::getArrayIndex)
+        .def_property_readonly("conditionExpression",
+                               &GenerateBlockSymbol::getConditionExpression)
         .def_property_readonly("externalName", &GenerateBlockSymbol::getExternalName);
 
     py::classh<GenerateBlockArraySymbol, Symbol, Scope>(m, "GenerateBlockArraySymbol")

--- a/bindings/python/SyntaxBindings.cpp
+++ b/bindings/python/SyntaxBindings.cpp
@@ -355,7 +355,8 @@ void registerSyntax(py::module_& syntax, py::module_& parsing) {
     };
 
     py::classh<SyntaxNode>(m, "SyntaxNode")
-        .def_readonly("parent", &SyntaxNode::parent)
+        .def_property_readonly("parent",
+                               [](const SyntaxNode& n) -> const SyntaxNode* { return n.parent; })
         .def_readonly("kind", &SyntaxNode::kind)
         .def("getFirstToken", &SyntaxNode::getFirstToken)
         .def("getLastToken", &SyntaxNode::getLastToken)

--- a/include/slang/ast/symbols/BlockSymbols.h
+++ b/include/slang/ast/symbols/BlockSymbols.h
@@ -16,6 +16,7 @@
 namespace slang::ast {
 
 class Expression;
+class VariableSymbol;
 
 /// Indicates which branch of a conditional or loop generate construct
 /// produced a given GenerateBlockSymbol.
@@ -195,19 +196,17 @@ public:
     bool valid = false;
     bool isUnnamed = false;
 
-    /// Bound initializer expression of the enclosing loop-generate.
+    /// Initial value assigned to loopVariable.
     const Expression* initialExpression = nullptr;
 
-    /// Bound stop expression of the enclosing loop-generate.
+    /// Bound stop expression of the loop-generate.
     const Expression* stopExpression = nullptr;
 
-    /// Bound iteration expression of the enclosing loop-generate.
+    /// Bound iteration expression of the loop-generate.
     const Expression* iterExpression = nullptr;
 
-    /// Canonical genvar symbol for this loop. For an inline genvar this is a
-    /// fabricated symbol held as a member of this array; for an external
-    /// genvar it resolves to the declaration in an enclosing scope.
-    const Symbol* genvar = nullptr;
+    /// Loop variable used by the bound stop and iteration expressions.
+    const VariableSymbol* loopVariable = nullptr;
 
     GenerateBlockArraySymbol(Compilation& compilation, std::string_view name, SourceLocation loc,
                              uint32_t constructIndex) :

--- a/include/slang/ast/symbols/BlockSymbols.h
+++ b/include/slang/ast/symbols/BlockSymbols.h
@@ -15,6 +15,15 @@
 
 namespace slang::ast {
 
+class Expression;
+
+/// Indicates which branch of a conditional or loop generate construct
+/// produced a given GenerateBlockSymbol.
+#define GENERATE_BRANCH_KIND(x) \
+    x(IfTrue) x(IfFalse) x(CaseItem) x(CaseDefault) x(LoopIteration) x(IllegalUnconditional)
+SLANG_ENUM(GenerateBranchKind, GENERATE_BRANCH_KIND)
+#undef GENERATE_BRANCH_KIND
+
 /// Represents a statement block, either sequential or parallel.
 class SLANG_EXPORT StatementBlockSymbol final : public Symbol, public Scope {
 public:
@@ -122,6 +131,20 @@ public:
     bool isUnnamed = false;
     const SVInt* arrayIndex = nullptr;
 
+    /// Indicates which branch of the originating generate construct produced
+    /// this block.
+    GenerateBranchKind branchKind = GenerateBranchKind::IllegalUnconditional;
+
+    /// Originating generate construct; always an IfGenerateSyntax,
+    /// CaseGenerateSyntax, or LoopGenerateSyntax when non-null.
+    const syntax::SyntaxNode* generateConstructSyntax = nullptr;
+
+    /// Bound condition of the enclosing if- or case-generate, if any.
+    const Expression* conditionExpression = nullptr;
+
+    /// Bound case-item label expressions for case-generate blocks.
+    std::span<const Expression* const> caseItemExpressions;
+
     GenerateBlockSymbol(Compilation& compilation, std::string_view name, SourceLocation loc,
                         uint32_t constructIndex, bool isUninstantiated) :
         Symbol(SymbolKind::GenerateBlock, name, loc), Scope(compilation, this),
@@ -154,6 +177,20 @@ public:
     uint32_t constructIndex;
     bool valid = false;
     bool isUnnamed = false;
+
+    /// Bound initializer expression of the enclosing loop-generate.
+    const Expression* initialExpression = nullptr;
+
+    /// Bound stop expression of the enclosing loop-generate.
+    const Expression* stopExpression = nullptr;
+
+    /// Bound iteration expression of the enclosing loop-generate.
+    const Expression* iterExpression = nullptr;
+
+    /// Canonical genvar symbol for this loop. For an inline genvar this is a
+    /// fabricated symbol held as a member of this array; for an external
+    /// genvar it resolves to the declaration in an enclosing scope.
+    const Symbol* genvar = nullptr;
 
     GenerateBlockArraySymbol(Compilation& compilation, std::string_view name, SourceLocation loc,
                              uint32_t constructIndex) :

--- a/include/slang/ast/symbols/BlockSymbols.h
+++ b/include/slang/ast/symbols/BlockSymbols.h
@@ -21,7 +21,7 @@ class Expression;
 /// produced a given GenerateBlockSymbol.
 #define GENERATE_BRANCH_KIND(x) \
     x(IfTrue) x(IfFalse) x(CaseItem) x(CaseDefault) x(LoopIteration) x(IllegalUnconditional)
-SLANG_ENUM(GenerateBranchKind, GENERATE_BRANCH_KIND)
+SLANG_ENUM_SIZED(GenerateBranchKind, uint8_t, GENERATE_BRANCH_KIND)
 #undef GENERATE_BRANCH_KIND
 
 /// Represents a statement block, either sequential or parallel.
@@ -127,29 +127,46 @@ private:
 class SLANG_EXPORT GenerateBlockSymbol final : public Symbol, public Scope {
 public:
     uint32_t constructIndex = 0;
-    bool isUninstantiated = false;
-    bool isUnnamed = false;
-    const SVInt* arrayIndex = nullptr;
 
-    /// Indicates which branch of the originating generate construct produced
-    /// this block.
+    /// Indicates which branch of the originating generate construct produced this block.
     GenerateBranchKind branchKind = GenerateBranchKind::IllegalUnconditional;
 
-    /// Originating generate construct; always an IfGenerateSyntax,
-    /// CaseGenerateSyntax, or LoopGenerateSyntax when non-null.
-    const syntax::SyntaxNode* generateConstructSyntax = nullptr;
+    bool isUninstantiated = false;
+    bool isUnnamed = false;
 
-    /// Bound condition of the enclosing if- or case-generate, if any.
-    const Expression* conditionExpression = nullptr;
+    /// Storage for either the loop iteration index or the bound if/case condition.
+    /// The active member is selected by branchKind.
+    union {
+        const SVInt* arrayIndex = nullptr;
+        const Expression* conditionExpression;
+    };
 
     /// Bound case-item label expressions for case-generate blocks.
-    std::span<const Expression* const> caseItemExpressions;
+    std::span<const Expression* const> caseItemExpressions = {};
 
     GenerateBlockSymbol(Compilation& compilation, std::string_view name, SourceLocation loc,
                         uint32_t constructIndex, bool isUninstantiated) :
         Symbol(SymbolKind::GenerateBlock, name, loc), Scope(compilation, this),
         constructIndex(constructIndex), isUninstantiated(isUninstantiated),
         isUnnamed(name.empty()) {}
+
+    /// Returns the loop-iteration index, or nullptr if this block is not a loop iteration.
+    const SVInt* getArrayIndex() const {
+        return branchKind == GenerateBranchKind::LoopIteration ? arrayIndex : nullptr;
+    }
+
+    /// Returns the bound if/case condition, or nullptr if this block is not a conditional branch.
+    const Expression* getConditionExpression() const {
+        switch (branchKind) {
+            case GenerateBranchKind::IfTrue:
+            case GenerateBranchKind::IfFalse:
+            case GenerateBranchKind::CaseItem:
+            case GenerateBranchKind::CaseDefault:
+                return conditionExpression;
+            default:
+                return nullptr;
+        }
+    }
 
     std::string getExternalName() const;
 

--- a/pyslang/tests/test_generate_provenance.py
+++ b/pyslang/tests/test_generate_provenance.py
@@ -153,9 +153,13 @@ endmodule
     assert arr.initialExpression is not None
     assert arr.stopExpression is not None
     assert arr.iterExpression is not None
-    assert arr.genvar is not None
-    assert arr.genvar.kind == SymbolKind.Genvar
-    assert arr.genvar.name == "g"
+    assert arr.loopVariable is not None
+    assert arr.loopVariable.kind == SymbolKind.Variable
+    assert arr.loopVariable.name == "g"
+    assert arr.loopVariable.syntax is not None
+    assert arr.loopVariable.syntax.kind == SyntaxKind.IdentifierName
+    assert arr.loopVariable.syntax.parent is not None
+    assert arr.loopVariable.syntax.parent.kind == SyntaxKind.GenvarDeclaration
 
     # The loop array's own syntax is the LoopGenerateSyntax directly.
     assert arr.syntax is not None
@@ -180,7 +184,11 @@ endmodule
 """)
 
     arr = comp.getRoot().lookupName("Top.arr")
-    assert arr.genvar is not None
-    assert arr.genvar.kind == SymbolKind.Genvar
-    assert arr.genvar.name == "i"
+    assert arr.loopVariable is not None
+    assert arr.loopVariable.kind == SymbolKind.Variable
+    assert arr.loopVariable.name == "i"
+    assert arr.loopVariable.syntax is not None
+    assert arr.loopVariable.syntax.kind == SyntaxKind.IdentifierName
+    # Fabricated node has no parent linkage in inline form.
+    assert arr.loopVariable.syntax.parent is None
     assert len(arr.entries) == 2

--- a/pyslang/tests/test_generate_provenance.py
+++ b/pyslang/tests/test_generate_provenance.py
@@ -19,6 +19,19 @@ def _compile(code):
     return comp
 
 
+_CONSTRUCT_KINDS = {SyntaxKind.IfGenerate, SyntaxKind.CaseGenerate, SyntaxKind.LoopGenerate}
+
+
+def _construct_of(block):
+    # Walks up through any ElseClause / StandardCaseItem / DefaultCaseItem
+    # wrapper to the enclosing if/case/loop-generate node.
+    syntax = block.syntax
+    node = syntax.parent if syntax is not None else None
+    while node is not None and node.kind not in _CONSTRUCT_KINDS:
+        node = node.parent
+    return node
+
+
 def test_if_generate_provenance():
     comp = _compile("""
 module Top #(parameter int MODE = 1)();
@@ -47,10 +60,15 @@ endmodule
     # Both arms share the same bound condition object.
     assert if_true.conditionExpression is if_false.conditionExpression
     assert len(if_true.caseItemExpressions) == 0
+    # Conditional branches never expose a loop index.
+    assert if_true.arrayIndex is None
+    assert if_false.arrayIndex is None
 
-    assert if_true.generateConstructSyntax is not None
-    assert if_true.generateConstructSyntax.kind == SyntaxKind.IfGenerate
-    assert if_true.generateConstructSyntax is if_false.generateConstructSyntax
+    true_construct = _construct_of(if_true)
+    false_construct = _construct_of(if_false)
+    assert true_construct is not None
+    assert true_construct.kind == SyntaxKind.IfGenerate
+    assert true_construct is false_construct
 
 
 def test_directly_nested_if_generate_preserves_structure():
@@ -71,15 +89,17 @@ endmodule
     t = root.lookupName("Top.t")
     f = root.lookupName("Top.f")
 
-    assert t.generateConstructSyntax is not None
-    assert t.generateConstructSyntax.kind == SyntaxKind.IfGenerate
-    assert t.generateConstructSyntax is f.generateConstructSyntax
+    inner_if = _construct_of(t)
+    assert inner_if is not None
+    assert inner_if.kind == SyntaxKind.IfGenerate
+    assert inner_if is _construct_of(f)
 
-    # Outer construct reachable via syntax-parent walk.
-    outer = t.generateConstructSyntax.parent
+    # The directly-nested outer construct is reachable by continuing the walk.
+    outer = inner_if.parent
+    while outer is not None and outer.kind != SyntaxKind.IfGenerate:
+        outer = outer.parent
     assert outer is not None
-    assert outer.kind == SyntaxKind.IfGenerate
-    assert outer is not t.generateConstructSyntax
+    assert outer is not inner_if
 
 
 def test_case_generate_provenance():
@@ -106,6 +126,12 @@ endmodule
     assert case_item.conditionExpression is case_default.conditionExpression
     assert len(case_item.caseItemExpressions) == 2
     assert len(case_default.caseItemExpressions) == 0
+    assert case_item.arrayIndex is None
+
+    case_construct = _construct_of(case_item)
+    assert case_construct is not None
+    assert case_construct.kind == SyntaxKind.CaseGenerate
+    assert case_construct is _construct_of(case_default)
 
 
 def test_loop_generate_provenance():
@@ -127,9 +153,17 @@ endmodule
     assert arr.genvar.kind == SymbolKind.Genvar
     assert arr.genvar.name == "g"
 
+    # The loop array's own syntax is the LoopGenerateSyntax directly.
+    assert arr.syntax is not None
+    assert arr.syntax.kind == SyntaxKind.LoopGenerate
+
     assert len(arr.entries) == 3
     for entry in arr.entries:
         assert entry.branchKind == GenerateBranchKind.LoopIteration
+        assert entry.arrayIndex is not None
+        assert entry.conditionExpression is None
+        # Each entry's syntax parent walks back to the LoopGenerateSyntax.
+        assert _construct_of(entry) is arr.syntax
 
 
 def test_loop_generate_inline_genvar():

--- a/pyslang/tests/test_generate_provenance.py
+++ b/pyslang/tests/test_generate_provenance.py
@@ -19,7 +19,11 @@ def _compile(code):
     return comp
 
 
-_CONSTRUCT_KINDS = {SyntaxKind.IfGenerate, SyntaxKind.CaseGenerate, SyntaxKind.LoopGenerate}
+_CONSTRUCT_KINDS = {
+    SyntaxKind.IfGenerate,
+    SyntaxKind.CaseGenerate,
+    SyntaxKind.LoopGenerate,
+}
 
 
 def _construct_of(block):

--- a/pyslang/tests/test_generate_provenance.py
+++ b/pyslang/tests/test_generate_provenance.py
@@ -1,0 +1,158 @@
+# SPDX-FileCopyrightText: Michael Popoloski
+# SPDX-License-Identifier: MIT
+
+from pyslang.ast import (
+    Compilation,
+    GenerateBlockArraySymbol,
+    GenerateBlockSymbol,
+    GenerateBranchKind,
+    SymbolKind,
+)
+from pyslang.syntax import SyntaxKind, SyntaxTree
+
+
+def _compile(code):
+    tree, comp = SyntaxTree.fromText(code), Compilation()
+    comp.addSyntaxTree(tree)
+    # Force elaboration diagnostics so all provenance is populated.
+    comp.getAllDiagnostics()
+    return comp
+
+
+def test_if_generate_provenance():
+    comp = _compile(
+        """
+module Top #(parameter int MODE = 1)();
+    if (MODE == 1) begin : if_true
+        int a;
+    end
+    else begin : if_false
+        int b;
+    end
+endmodule
+"""
+    )
+
+    root = comp.getRoot()
+    if_true = root.lookupName("Top.if_true")
+    if_false = root.lookupName("Top.if_false")
+
+    assert isinstance(if_true, GenerateBlockSymbol)
+    assert isinstance(if_false, GenerateBlockSymbol)
+
+    assert if_true.branchKind == GenerateBranchKind.IfTrue
+    assert if_false.branchKind == GenerateBranchKind.IfFalse
+    assert not if_true.isUninstantiated
+    assert if_false.isUninstantiated
+
+    assert if_true.conditionExpression is not None
+    # Both arms share the same bound condition object.
+    assert if_true.conditionExpression is if_false.conditionExpression
+    assert len(if_true.caseItemExpressions) == 0
+
+    assert if_true.generateConstructSyntax is not None
+    assert if_true.generateConstructSyntax.kind == SyntaxKind.IfGenerate
+    assert if_true.generateConstructSyntax is if_false.generateConstructSyntax
+
+
+def test_directly_nested_if_generate_preserves_structure():
+    # Inner if is unbracketed; LRM flattens it into the outer scope.
+    comp = _compile(
+        """
+module Top #(parameter int A = 1, parameter int B = 1)();
+    if (A == 1)
+        if (B == 1) begin : t
+            int x;
+        end
+        else begin : f
+            int y;
+        end
+endmodule
+"""
+    )
+
+    root = comp.getRoot()
+    t = root.lookupName("Top.t")
+    f = root.lookupName("Top.f")
+
+    assert t.generateConstructSyntax is not None
+    assert t.generateConstructSyntax.kind == SyntaxKind.IfGenerate
+    assert t.generateConstructSyntax is f.generateConstructSyntax
+
+    # Outer construct reachable via syntax-parent walk.
+    outer = t.generateConstructSyntax.parent
+    assert outer is not None
+    assert outer.kind == SyntaxKind.IfGenerate
+    assert outer is not t.generateConstructSyntax
+
+
+def test_case_generate_provenance():
+    comp = _compile(
+        """
+module Top #(parameter int MODE = 1)();
+    case (MODE)
+        1, 2: begin : case_item_lo
+            int c;
+        end
+        default: begin : case_default
+            int d;
+        end
+    endcase
+endmodule
+"""
+    )
+
+    root = comp.getRoot()
+    case_item = root.lookupName("Top.case_item_lo")
+    case_default = root.lookupName("Top.case_default")
+
+    assert case_item.branchKind == GenerateBranchKind.CaseItem
+    assert case_default.branchKind == GenerateBranchKind.CaseDefault
+    assert case_item.conditionExpression is not None
+    assert case_item.conditionExpression is case_default.conditionExpression
+    assert len(case_item.caseItemExpressions) == 2
+    assert len(case_default.caseItemExpressions) == 0
+
+
+def test_loop_generate_provenance():
+    comp = _compile(
+        """
+module Top;
+    genvar g;
+    for (g = 0; g < 3; g = g + 1) begin : arr
+        int e;
+    end
+endmodule
+"""
+    )
+
+    arr = comp.getRoot().lookupName("Top.arr")
+    assert isinstance(arr, GenerateBlockArraySymbol)
+    assert arr.initialExpression is not None
+    assert arr.stopExpression is not None
+    assert arr.iterExpression is not None
+    assert arr.genvar is not None
+    assert arr.genvar.kind == SymbolKind.Genvar
+    assert arr.genvar.name == "g"
+
+    assert len(arr.entries) == 3
+    for entry in arr.entries:
+        assert entry.branchKind == GenerateBranchKind.LoopIteration
+
+
+def test_loop_generate_inline_genvar():
+    comp = _compile(
+        """
+module Top;
+    for (genvar i = 0; i < 2; i = i + 1) begin : arr
+        int x;
+    end
+endmodule
+"""
+    )
+
+    arr = comp.getRoot().lookupName("Top.arr")
+    assert arr.genvar is not None
+    assert arr.genvar.kind == SymbolKind.Genvar
+    assert arr.genvar.name == "i"
+    assert len(arr.entries) == 2

--- a/pyslang/tests/test_generate_provenance.py
+++ b/pyslang/tests/test_generate_provenance.py
@@ -20,8 +20,7 @@ def _compile(code):
 
 
 def test_if_generate_provenance():
-    comp = _compile(
-        """
+    comp = _compile("""
 module Top #(parameter int MODE = 1)();
     if (MODE == 1) begin : if_true
         int a;
@@ -30,8 +29,7 @@ module Top #(parameter int MODE = 1)();
         int b;
     end
 endmodule
-"""
-    )
+""")
 
     root = comp.getRoot()
     if_true = root.lookupName("Top.if_true")
@@ -57,8 +55,7 @@ endmodule
 
 def test_directly_nested_if_generate_preserves_structure():
     # Inner if is unbracketed; LRM flattens it into the outer scope.
-    comp = _compile(
-        """
+    comp = _compile("""
 module Top #(parameter int A = 1, parameter int B = 1)();
     if (A == 1)
         if (B == 1) begin : t
@@ -68,8 +65,7 @@ module Top #(parameter int A = 1, parameter int B = 1)();
             int y;
         end
 endmodule
-"""
-    )
+""")
 
     root = comp.getRoot()
     t = root.lookupName("Top.t")
@@ -87,8 +83,7 @@ endmodule
 
 
 def test_case_generate_provenance():
-    comp = _compile(
-        """
+    comp = _compile("""
 module Top #(parameter int MODE = 1)();
     case (MODE)
         1, 2: begin : case_item_lo
@@ -99,8 +94,7 @@ module Top #(parameter int MODE = 1)();
         end
     endcase
 endmodule
-"""
-    )
+""")
 
     root = comp.getRoot()
     case_item = root.lookupName("Top.case_item_lo")
@@ -115,16 +109,14 @@ endmodule
 
 
 def test_loop_generate_provenance():
-    comp = _compile(
-        """
+    comp = _compile("""
 module Top;
     genvar g;
     for (g = 0; g < 3; g = g + 1) begin : arr
         int e;
     end
 endmodule
-"""
-    )
+""")
 
     arr = comp.getRoot().lookupName("Top.arr")
     assert isinstance(arr, GenerateBlockArraySymbol)
@@ -141,15 +133,13 @@ endmodule
 
 
 def test_loop_generate_inline_genvar():
-    comp = _compile(
-        """
+    comp = _compile("""
 module Top;
     for (genvar i = 0; i < 2; i = i + 1) begin : arr
         int x;
     end
 endmodule
-"""
-    )
+""")
 
     arr = comp.getRoot().lookupName("Top.arr")
     assert arr.genvar is not None

--- a/source/ast/Lookup.cpp
+++ b/source/ast/Lookup.cpp
@@ -1288,7 +1288,7 @@ static const Symbol* selectSingleChild(const Symbol& symbol, const BitSelectSynt
 
         int32_t idx = 0;
         for (auto entry : array.entries) {
-            if (entry->arrayIndex && *entry->arrayIndex == *index) {
+            if (auto entryIdx = entry->getArrayIndex(); entryIdx && *entryIdx == *index) {
                 result.path.emplace_back(*entry, idx);
                 return entry;
             }

--- a/source/ast/Symbol.cpp
+++ b/source/ast/Symbol.cpp
@@ -160,7 +160,7 @@ static void getHierarchicalPathImpl(const Symbol& symbol, FormatBuffer& buffer,
     }
     else if (current->kind == SymbolKind::GenerateBlock) {
         auto& block = current->as<GenerateBlockSymbol>();
-        if (auto index = block.arrayIndex) {
+        if (auto index = block.getArrayIndex()) {
             buffer.append("[");
             buffer.append(index->toString(LiteralBase::Decimal, false));
             buffer.append("]");

--- a/source/ast/expressions/MiscExpressions.cpp
+++ b/source/ast/expressions/MiscExpressions.cpp
@@ -37,7 +37,7 @@ static std::string_view getNonValueName(const Symbol& symbol) {
         auto sym = &symbol;
         while (sym->kind == SymbolKind::GenerateBlock) {
             auto& block = sym->as<GenerateBlockSymbol>();
-            if (!block.arrayIndex)
+            if (!block.getArrayIndex())
                 return sym->name;
 
             auto scope = block.getParentScope();

--- a/source/ast/symbols/BlockSymbols.cpp
+++ b/source/ast/symbols/BlockSymbols.cpp
@@ -475,12 +475,17 @@ static void createCondGenBlock(Compilation& compilation, const SyntaxNode& synta
                                const ASTContext& context, uint32_t constructIndex,
                                bool isUninstantiated,
                                const SyntaxList<AttributeInstanceSyntax>& attributes,
-                               SmallVectorBase<GenerateBlockSymbol*>& results) {
+                               SmallVectorBase<GenerateBlockSymbol*>& results,
+                               GenerateBranchKind branchKind,
+                               const SyntaxNode* generateConstructSyntax,
+                               const Expression* conditionExpr,
+                               std::span<const Expression* const> caseItemExprs) {
     // [27.5] If a generate block in a conditional generate construct consists of only one item
     // that is itself a conditional generate construct and if that item is not surrounded by
     // begin-end keywords, then this generate block is not treated as a separate scope. The
     // generate construct within this block is said to be directly nested. The generate blocks
     // of the directly nested construct are treated as if they belong to the outer construct.
+    // Each flattened block still carries its own immediate construct pointer.
     switch (syntax.kind) {
         case SyntaxKind::IfGenerate:
             GenerateBlockSymbol::fromSyntax(compilation, syntax.as<IfGenerateSyntax>(), context,
@@ -494,6 +499,11 @@ static void createCondGenBlock(Compilation& compilation, const SyntaxNode& synta
             break;
     }
 
+    SLANG_ASSERT(generateConstructSyntax == nullptr ||
+                 generateConstructSyntax->kind == SyntaxKind::IfGenerate ||
+                 generateConstructSyntax->kind == SyntaxKind::CaseGenerate ||
+                 generateConstructSyntax->kind == SyntaxKind::LoopGenerate);
+
     auto [name, loc] = getGenerateBlockName(syntax);
     if (name.empty()) {
         auto range = syntax.kind == SyntaxKind::GenerateBlock
@@ -506,6 +516,10 @@ static void createCondGenBlock(Compilation& compilation, const SyntaxNode& synta
                                                           isUninstantiated);
     block->setSyntax(syntax);
     block->setAttributes(*context.scope, attributes);
+    block->branchKind = branchKind;
+    block->generateConstructSyntax = generateConstructSyntax;
+    block->conditionExpression = conditionExpr;
+    block->caseItemExpressions = caseItemExprs;
     results.push_back(block);
 
     addBlockMembers(*block, syntax);
@@ -522,10 +536,12 @@ void GenerateBlockSymbol::fromSyntax(Compilation& compilation, const IfGenerateS
         selector = cv.isTrue();
 
     createCondGenBlock(compilation, *syntax.block, context, constructIndex,
-                       !selector.has_value() || !selector.value(), syntax.attributes, results);
+                       !selector.has_value() || !selector.value(), syntax.attributes, results,
+                       GenerateBranchKind::IfTrue, &syntax, &cond, {});
     if (syntax.elseClause) {
         createCondGenBlock(compilation, *syntax.elseClause->clause, context, constructIndex,
-                           !selector.has_value() || selector.value(), syntax.attributes, results);
+                           !selector.has_value() || selector.value(), syntax.attributes, results,
+                           GenerateBranchKind::IfFalse, &syntax, &cond, {});
     }
 }
 
@@ -582,13 +598,19 @@ void GenerateBlockSymbol::fromSyntax(Compilation& compilation, const CaseGenerat
         if (item->kind != SyntaxKind::StandardCaseItem)
             continue;
 
-        // Check each case expression to see if it matches the condition value.
+        // Check each case expression to see if it matches the condition value,
+        // and collect the bound item expressions so they can be preserved on
+        // the resulting block.
         bool currentFound = false;
         SourceRange currentMatchRange;
         auto& sci = item->as<StandardCaseItemSyntax>();
+
+        SmallVector<const Expression*> itemExprs;
+        itemExprs.reserve(sci.expressions.size());
         for (size_t i = 0; i < sci.expressions.size(); i++) {
             // Have to keep incrementing the iterator here so that we stay in sync.
             auto expr = *boundIt++;
+            itemExprs.push_back(expr);
             ConstantValue val = context.eval(*expr);
 
             bool match = val && val == condVal;
@@ -601,12 +623,15 @@ void GenerateBlockSymbol::fromSyntax(Compilation& compilation, const CaseGenerat
             }
         }
 
+        auto itemExprSpan = itemExprs.copy(compilation);
+
         if (currentFound && !found) {
             // This is the first match for this entire case generate.
             found = true;
             matchRange = currentMatchRange;
             createCondGenBlock(compilation, *sci.clause, context, constructIndex, isUninstantiated,
-                               syntax.attributes, results);
+                               syntax.attributes, results, GenerateBranchKind::CaseItem, &syntax,
+                               condExpr, itemExprSpan);
         }
         else {
             // If we previously found a block, this block also matched, which we should warn about.
@@ -619,14 +644,16 @@ void GenerateBlockSymbol::fromSyntax(Compilation& compilation, const CaseGenerat
 
             // This block is not taken, so create it as uninstantiated.
             createCondGenBlock(compilation, *sci.clause, context, constructIndex, true,
-                               syntax.attributes, results);
+                               syntax.attributes, results, GenerateBranchKind::CaseItem, &syntax,
+                               condExpr, itemExprSpan);
         }
     }
 
     if (defBlock) {
         // Only instantiated if no other blocks were instantiated.
         createCondGenBlock(compilation, *defBlock, context, constructIndex,
-                           isUninstantiated || found, syntax.attributes, results);
+                           isUninstantiated || found, syntax.attributes, results,
+                           GenerateBranchKind::CaseDefault, &syntax, condExpr, {});
     }
     else if (!found) {
         auto& diag = context.addDiag(diag::CaseGenerateNoBlock, condExpr->sourceRange);
@@ -645,6 +672,10 @@ GenerateBlockSymbol& GenerateBlockSymbol::fromSyntax(const Scope& scope,
                                                    scope.isUninstantiated());
     block->setSyntax(syntax);
     block->setAttributes(scope, syntax.attributes);
+    block->branchKind = GenerateBranchKind::IllegalUnconditional;
+    block->generateConstructSyntax = nullptr;
+    block->conditionExpression = nullptr;
+    block->caseItemExpressions = {};
 
     for (auto member : syntax.members)
         block->addMembers(*member);
@@ -683,6 +714,18 @@ std::string GenerateBlockSymbol::getExternalName() const {
 void GenerateBlockSymbol::serializeTo(ASTSerializer& serializer) const {
     serializer.write("constructIndex", constructIndex);
     serializer.write("isUninstantiated", isUninstantiated);
+    serializer.write("branchKind", toString(branchKind));
+    // Emitted as a syntax-kind label only; not a serializable identity reference.
+    if (generateConstructSyntax)
+        serializer.write("generateConstructSyntax", toString(generateConstructSyntax->kind));
+    if (conditionExpression)
+        serializer.write("conditionExpression", *conditionExpression);
+    if (!caseItemExpressions.empty()) {
+        serializer.startArray("caseItemExpressions");
+        for (auto expr : caseItemExpressions)
+            serializer.serialize(*expr);
+        serializer.endArray();
+    }
 }
 
 static uint64_t getGenerateLoopCount(const Scope& parent) {
@@ -752,12 +795,14 @@ GenerateBlockArraySymbol& GenerateBlockArraySymbol::fromSyntax(Compilation& comp
         }
 
         comp.noteReference(*symbol);
+        result->genvar = symbol;
     }
     else {
         // Fabricate a genvar symbol to live in this array since it was declared inline.
         auto genvarSymbol = comp.emplace<GenvarSymbol>(genvar.valueText(), genvar.location());
         genvarSymbol->setSyntax(*genvarSyntax);
         result->addMember(*genvarSymbol);
+        result->genvar = genvarSymbol;
     }
 
     SmallVector<const GenerateBlockSymbol*> entries;
@@ -773,6 +818,8 @@ GenerateBlockArraySymbol& GenerateBlockArraySymbol::fromSyntax(Compilation& comp
 
         block->addMember(*implicitParam);
         block->setSyntax(*syntax.block);
+        block->branchKind = GenerateBranchKind::LoopIteration;
+        block->generateConstructSyntax = &syntax;
 
         addBlockMembers(*block, *syntax.block);
 
@@ -787,6 +834,7 @@ GenerateBlockArraySymbol& GenerateBlockArraySymbol::fromSyntax(Compilation& comp
     // Bind the initialization expression.
     auto& initial = Expression::bindRValue(comp.getIntegerType(), *syntax.initialExpr,
                                            syntax.equals.range(), context);
+    result->initialExpression = &initial;
     ConstantValue initialVal = context.eval(initial);
     if (!initialVal)
         return *result;
@@ -808,6 +856,8 @@ GenerateBlockArraySymbol& GenerateBlockArraySymbol::fromSyntax(Compilation& comp
     auto& stopExpr = Expression::bind(*syntax.stopExpr, iterContext);
     auto& iterExpr = Expression::bind(*syntax.iterationExpr, iterContext,
                                       ASTFlags::AssignmentAllowed);
+    result->stopExpression = &stopExpr;
+    result->iterExpression = &iterExpr;
     if (stopExpr.bad() || iterExpr.bad())
         return *result;
 
@@ -895,6 +945,14 @@ std::string GenerateBlockArraySymbol::getExternalName() const {
 
 void GenerateBlockArraySymbol::serializeTo(ASTSerializer& serializer) const {
     serializer.write("constructIndex", constructIndex);
+    if (initialExpression)
+        serializer.write("initialExpression", *initialExpression);
+    if (stopExpression)
+        serializer.write("stopExpression", *stopExpression);
+    if (iterExpression)
+        serializer.write("iterExpression", *iterExpression);
+    if (genvar)
+        serializer.writeLink("genvar", *genvar);
 }
 
 } // namespace slang::ast

--- a/source/ast/symbols/BlockSymbols.cpp
+++ b/source/ast/symbols/BlockSymbols.cpp
@@ -765,6 +765,7 @@ GenerateBlockArraySymbol& GenerateBlockArraySymbol::fromSyntax(Compilation& comp
 
     // If the loop initializer has a `genvar` keyword, we can use the name directly
     // Otherwise we need to do a lookup to make sure we have the actual genvar somewhere.
+    const Symbol* genvarSym = nullptr;
     if (!syntax.genvar) {
         auto symbol = Lookup::unqualifiedAt(*context.scope, genvar.valueText(),
                                             context.getLocation(), genvar.range());
@@ -779,14 +780,14 @@ GenerateBlockArraySymbol& GenerateBlockArraySymbol::fromSyntax(Compilation& comp
         }
 
         comp.noteReference(*symbol);
-        result->genvar = symbol;
+        genvarSym = symbol;
     }
     else {
         // Fabricate a genvar symbol to live in this array since it was declared inline.
         auto genvarSymbol = comp.emplace<GenvarSymbol>(genvar.valueText(), genvar.location());
         genvarSymbol->setSyntax(*genvarSyntax);
         result->addMember(*genvarSymbol);
-        result->genvar = genvarSymbol;
+        genvarSym = genvarSymbol;
     }
 
     SmallVector<const GenerateBlockSymbol*> entries;
@@ -833,6 +834,12 @@ GenerateBlockArraySymbol& GenerateBlockArraySymbol::fromSyntax(Compilation& comp
 
     iterScope.setTemporaryParent(*context.scope, scopeIndex);
     iterScope.addMember(local);
+
+    if (genvarSym) {
+        if (auto sx = genvarSym->getSyntax())
+            local.setSyntax(*sx);
+    }
+    result->loopVariable = &local;
 
     // Bind the stop and iteration expressions so we can reuse them on each iteration.
     ASTContext iterContext(iterScope, LookupLocation::max);
@@ -934,8 +941,8 @@ void GenerateBlockArraySymbol::serializeTo(ASTSerializer& serializer) const {
         serializer.write("stopExpression", *stopExpression);
     if (iterExpression)
         serializer.write("iterExpression", *iterExpression);
-    if (genvar)
-        serializer.writeLink("genvar", *genvar);
+    if (loopVariable)
+        serializer.writeLink("loopVariable", *loopVariable);
 }
 
 } // namespace slang::ast

--- a/source/ast/symbols/BlockSymbols.cpp
+++ b/source/ast/symbols/BlockSymbols.cpp
@@ -476,16 +476,13 @@ static void createCondGenBlock(Compilation& compilation, const SyntaxNode& synta
                                bool isUninstantiated,
                                const SyntaxList<AttributeInstanceSyntax>& attributes,
                                SmallVectorBase<GenerateBlockSymbol*>& results,
-                               GenerateBranchKind branchKind,
-                               const SyntaxNode* generateConstructSyntax,
-                               const Expression* conditionExpr,
+                               GenerateBranchKind branchKind, const Expression* conditionExpr,
                                std::span<const Expression* const> caseItemExprs) {
     // [27.5] If a generate block in a conditional generate construct consists of only one item
     // that is itself a conditional generate construct and if that item is not surrounded by
     // begin-end keywords, then this generate block is not treated as a separate scope. The
     // generate construct within this block is said to be directly nested. The generate blocks
     // of the directly nested construct are treated as if they belong to the outer construct.
-    // Each flattened block still carries its own immediate construct pointer.
     switch (syntax.kind) {
         case SyntaxKind::IfGenerate:
             GenerateBlockSymbol::fromSyntax(compilation, syntax.as<IfGenerateSyntax>(), context,
@@ -498,11 +495,6 @@ static void createCondGenBlock(Compilation& compilation, const SyntaxNode& synta
         default:
             break;
     }
-
-    SLANG_ASSERT(generateConstructSyntax == nullptr ||
-                 generateConstructSyntax->kind == SyntaxKind::IfGenerate ||
-                 generateConstructSyntax->kind == SyntaxKind::CaseGenerate ||
-                 generateConstructSyntax->kind == SyntaxKind::LoopGenerate);
 
     auto [name, loc] = getGenerateBlockName(syntax);
     if (name.empty()) {
@@ -517,7 +509,6 @@ static void createCondGenBlock(Compilation& compilation, const SyntaxNode& synta
     block->setSyntax(syntax);
     block->setAttributes(*context.scope, attributes);
     block->branchKind = branchKind;
-    block->generateConstructSyntax = generateConstructSyntax;
     block->conditionExpression = conditionExpr;
     block->caseItemExpressions = caseItemExprs;
     results.push_back(block);
@@ -537,11 +528,11 @@ void GenerateBlockSymbol::fromSyntax(Compilation& compilation, const IfGenerateS
 
     createCondGenBlock(compilation, *syntax.block, context, constructIndex,
                        !selector.has_value() || !selector.value(), syntax.attributes, results,
-                       GenerateBranchKind::IfTrue, &syntax, &cond, {});
+                       GenerateBranchKind::IfTrue, &cond, {});
     if (syntax.elseClause) {
         createCondGenBlock(compilation, *syntax.elseClause->clause, context, constructIndex,
                            !selector.has_value() || selector.value(), syntax.attributes, results,
-                           GenerateBranchKind::IfFalse, &syntax, &cond, {});
+                           GenerateBranchKind::IfFalse, &cond, {});
     }
 }
 
@@ -630,8 +621,8 @@ void GenerateBlockSymbol::fromSyntax(Compilation& compilation, const CaseGenerat
             found = true;
             matchRange = currentMatchRange;
             createCondGenBlock(compilation, *sci.clause, context, constructIndex, isUninstantiated,
-                               syntax.attributes, results, GenerateBranchKind::CaseItem, &syntax,
-                               condExpr, itemExprSpan);
+                               syntax.attributes, results, GenerateBranchKind::CaseItem, condExpr,
+                               itemExprSpan);
         }
         else {
             // If we previously found a block, this block also matched, which we should warn about.
@@ -644,8 +635,8 @@ void GenerateBlockSymbol::fromSyntax(Compilation& compilation, const CaseGenerat
 
             // This block is not taken, so create it as uninstantiated.
             createCondGenBlock(compilation, *sci.clause, context, constructIndex, true,
-                               syntax.attributes, results, GenerateBranchKind::CaseItem, &syntax,
-                               condExpr, itemExprSpan);
+                               syntax.attributes, results, GenerateBranchKind::CaseItem, condExpr,
+                               itemExprSpan);
         }
     }
 
@@ -653,7 +644,7 @@ void GenerateBlockSymbol::fromSyntax(Compilation& compilation, const CaseGenerat
         // Only instantiated if no other blocks were instantiated.
         createCondGenBlock(compilation, *defBlock, context, constructIndex,
                            isUninstantiated || found, syntax.attributes, results,
-                           GenerateBranchKind::CaseDefault, &syntax, condExpr, {});
+                           GenerateBranchKind::CaseDefault, condExpr, {});
     }
     else if (!found) {
         auto& diag = context.addDiag(diag::CaseGenerateNoBlock, condExpr->sourceRange);
@@ -672,10 +663,6 @@ GenerateBlockSymbol& GenerateBlockSymbol::fromSyntax(const Scope& scope,
                                                    scope.isUninstantiated());
     block->setSyntax(syntax);
     block->setAttributes(scope, syntax.attributes);
-    block->branchKind = GenerateBranchKind::IllegalUnconditional;
-    block->generateConstructSyntax = nullptr;
-    block->conditionExpression = nullptr;
-    block->caseItemExpressions = {};
 
     for (auto member : syntax.members)
         block->addMembers(*member);
@@ -715,11 +702,8 @@ void GenerateBlockSymbol::serializeTo(ASTSerializer& serializer) const {
     serializer.write("constructIndex", constructIndex);
     serializer.write("isUninstantiated", isUninstantiated);
     serializer.write("branchKind", toString(branchKind));
-    // Emitted as a syntax-kind label only; not a serializable identity reference.
-    if (generateConstructSyntax)
-        serializer.write("generateConstructSyntax", toString(generateConstructSyntax->kind));
-    if (conditionExpression)
-        serializer.write("conditionExpression", *conditionExpression);
+    if (auto cond = getConditionExpression())
+        serializer.write("conditionExpression", *cond);
     if (!caseItemExpressions.empty()) {
         serializer.startArray("caseItemExpressions");
         for (auto expr : caseItemExpressions)
@@ -819,7 +803,6 @@ GenerateBlockArraySymbol& GenerateBlockArraySymbol::fromSyntax(Compilation& comp
         block->addMember(*implicitParam);
         block->setSyntax(*syntax.block);
         block->branchKind = GenerateBranchKind::LoopIteration;
-        block->generateConstructSyntax = &syntax;
 
         addBlockMembers(*block, *syntax.block);
 

--- a/tests/unittests/ast/HierarchyTests.cpp
+++ b/tests/unittests/ast/HierarchyTests.cpp
@@ -17,7 +17,7 @@
 // ElseClause / StandardCaseItem / DefaultCaseItem syntax node.
 static const SyntaxNode* constructOf(const GenerateBlockSymbol& block) {
     auto s = block.getSyntax();
-    auto p = s ? s->parent : nullptr;
+    const SyntaxNode* p = s ? s->parent : nullptr;
     while (p && p->kind != SyntaxKind::IfGenerate && p->kind != SyntaxKind::CaseGenerate &&
            p->kind != SyntaxKind::LoopGenerate) {
         p = p->parent;
@@ -401,7 +401,7 @@ endmodule
     CHECK(t.getConditionExpression() == f.getConditionExpression());
 
     // The directly-nested outer construct is reachable by continuing the walk.
-    auto* outerIf = innerIf->parent;
+    const SyntaxNode* outerIf = innerIf->parent;
     while (outerIf && outerIf->kind != SyntaxKind::IfGenerate)
         outerIf = outerIf->parent;
     REQUIRE(outerIf != nullptr);
@@ -442,7 +442,7 @@ endmodule
     CHECK(m1Construct == constructOf(md));
 
     // Walk up from the inner case-generate to the enclosing if-generate.
-    auto* cur = m1Construct->parent;
+    const SyntaxNode* cur = m1Construct->parent;
     while (cur && cur->kind != SyntaxKind::IfGenerate)
         cur = cur->parent;
     REQUIRE(cur != nullptr);

--- a/tests/unittests/ast/HierarchyTests.cpp
+++ b/tests/unittests/ast/HierarchyTests.cpp
@@ -9,6 +9,7 @@
 #include "slang/ast/symbols/InstanceSymbols.h"
 #include "slang/ast/symbols/MemberSymbols.h"
 #include "slang/ast/symbols/ParameterSymbols.h"
+#include "slang/syntax/AllSyntax.h"
 #include "slang/text/SourceManager.h"
 
 // Walks up from a generate block to the enclosing if/case/loop-generate node.
@@ -316,9 +317,13 @@ endmodule
     CHECK(loopArr.initialExpression != nullptr);
     CHECK(loopArr.stopExpression != nullptr);
     CHECK(loopArr.iterExpression != nullptr);
-    REQUIRE(loopArr.genvar != nullptr);
-    CHECK(loopArr.genvar->kind == SymbolKind::Genvar);
-    CHECK(loopArr.genvar->name == "g");
+    REQUIRE(loopArr.loopVariable != nullptr);
+    CHECK(loopArr.loopVariable->kind == SymbolKind::Variable);
+    CHECK(loopArr.loopVariable->name == "g");
+    REQUIRE(loopArr.loopVariable->getSyntax() != nullptr);
+    CHECK(loopArr.loopVariable->getSyntax()->kind == SyntaxKind::IdentifierName);
+    REQUIRE(loopArr.loopVariable->getSyntax()->parent != nullptr);
+    CHECK(loopArr.loopVariable->getSyntax()->parent->kind == SyntaxKind::GenvarDeclaration);
     REQUIRE(loopArr.getSyntax() != nullptr);
     CHECK(loopArr.getSyntax()->kind == SyntaxKind::LoopGenerate);
     CHECK(loopArr.entries.size() == 3);
@@ -458,10 +463,47 @@ endmodule
     NO_COMPILATION_ERRORS;
 
     auto& arr = compilation.getRoot().lookupName<GenerateBlockArraySymbol>("Top.arr");
-    REQUIRE(arr.genvar != nullptr);
-    CHECK(arr.genvar->kind == SymbolKind::Genvar);
-    CHECK(arr.genvar->name == "i");
+    REQUIRE(arr.loopVariable != nullptr);
+    CHECK(arr.loopVariable->kind == SymbolKind::Variable);
+    CHECK(arr.loopVariable->name == "i");
+    REQUIRE(arr.loopVariable->getSyntax() != nullptr);
+    CHECK(arr.loopVariable->getSyntax()->kind == SyntaxKind::IdentifierName);
+    // Inline form: fabricated IdentifierNameSyntax has no parent linkage.
+    CHECK(arr.loopVariable->getSyntax()->parent == nullptr);
+    // Source location matches the LoopGenerate identifier token.
+    REQUIRE(arr.getSyntax() != nullptr);
+    auto& loop = arr.getSyntax()->as<LoopGenerateSyntax>();
+    auto& idSyntax = arr.loopVariable->getSyntax()->as<IdentifierNameSyntax>();
+    CHECK(idSyntax.identifier.location() == loop.identifier.location());
     CHECK(arr.entries.size() == 2);
+}
+
+TEST_CASE("Loop-generate stop/iter expressions reference loopVariable") {
+    auto tree = SyntaxTree::fromText(R"(
+module Top;
+    genvar g;
+    for (g = 0; g < 3; g = g + 1) begin : arr
+        int e;
+    end
+endmodule
+)");
+
+    Compilation compilation;
+    compilation.addSyntaxTree(tree);
+    NO_COMPILATION_ERRORS;
+
+    auto& arr = compilation.getRoot().lookupName<GenerateBlockArraySymbol>("Top.arr");
+    REQUIRE(arr.loopVariable != nullptr);
+    REQUIRE(arr.stopExpression != nullptr);
+    REQUIRE(arr.iterExpression != nullptr);
+
+    auto& stopSym =
+        arr.stopExpression->as<BinaryExpression>().left().as<NamedValueExpression>().symbol;
+    CHECK(&stopSym == arr.loopVariable);
+
+    auto& iterSym =
+        arr.iterExpression->as<AssignmentExpression>().left().as<NamedValueExpression>().symbol;
+    CHECK(&iterSym == arr.loopVariable);
 }
 
 TEST_CASE("Program instantiation") {

--- a/tests/unittests/ast/HierarchyTests.cpp
+++ b/tests/unittests/ast/HierarchyTests.cpp
@@ -232,6 +232,216 @@ endmodule
     compilation.getRoot().lookupName<GenerateBlockSymbol>("Top.u2");
 }
 
+TEST_CASE("Generate construct provenance is preserved") {
+    auto tree = SyntaxTree::fromText(R"(
+module Top #(parameter int MODE = 1, parameter int N = 3)();
+    // if-generate
+    if (MODE == 1) begin : if_true
+        int a;
+    end
+    else begin : if_false
+        int b;
+    end
+
+    // case-generate
+    case (MODE)
+        1, 2: begin : case_item_lo
+            int c;
+        end
+        default: begin : case_default
+            int d;
+        end
+    endcase
+
+    // loop-generate with external genvar
+    genvar g;
+    for (g = 0; g < N; g = g + 1) begin : loop_arr
+        int e;
+    end
+endmodule
+)");
+
+    Compilation compilation;
+    compilation.addSyntaxTree(tree);
+    NO_COMPILATION_ERRORS;
+
+    auto& root = compilation.getRoot();
+
+    // if-generate
+    auto& ifTrue = root.lookupName<GenerateBlockSymbol>("Top.if_true");
+    auto& ifFalse = root.lookupName<GenerateBlockSymbol>("Top.if_false");
+    CHECK(ifTrue.branchKind == GenerateBranchKind::IfTrue);
+    CHECK(ifFalse.branchKind == GenerateBranchKind::IfFalse);
+    CHECK(!ifTrue.isUninstantiated);
+    CHECK(ifFalse.isUninstantiated);
+    REQUIRE(ifTrue.conditionExpression != nullptr);
+    CHECK(ifTrue.conditionExpression == ifFalse.conditionExpression);
+    CHECK(ifTrue.caseItemExpressions.empty());
+    REQUIRE(ifTrue.generateConstructSyntax != nullptr);
+    CHECK(ifTrue.generateConstructSyntax->kind == SyntaxKind::IfGenerate);
+    CHECK(ifTrue.generateConstructSyntax == ifFalse.generateConstructSyntax);
+
+    // case-generate
+    auto& caseItem = root.lookupName<GenerateBlockSymbol>("Top.case_item_lo");
+    auto& caseDefault = root.lookupName<GenerateBlockSymbol>("Top.case_default");
+    CHECK(caseItem.branchKind == GenerateBranchKind::CaseItem);
+    CHECK(caseDefault.branchKind == GenerateBranchKind::CaseDefault);
+    REQUIRE(caseItem.conditionExpression != nullptr);
+    CHECK(caseItem.conditionExpression == caseDefault.conditionExpression);
+    CHECK(caseItem.caseItemExpressions.size() == 2);
+    CHECK(caseDefault.caseItemExpressions.empty());
+    REQUIRE(caseItem.generateConstructSyntax != nullptr);
+    CHECK(caseItem.generateConstructSyntax->kind == SyntaxKind::CaseGenerate);
+    CHECK(caseItem.generateConstructSyntax == caseDefault.generateConstructSyntax);
+
+    // loop-generate: the array's getSyntax() returns the LoopGenerateSyntax
+    // directly; each entry block points back to that same construct.
+    auto& loopArr = root.lookupName<GenerateBlockArraySymbol>("Top.loop_arr");
+    CHECK(loopArr.initialExpression != nullptr);
+    CHECK(loopArr.stopExpression != nullptr);
+    CHECK(loopArr.iterExpression != nullptr);
+    REQUIRE(loopArr.genvar != nullptr);
+    CHECK(loopArr.genvar->kind == SymbolKind::Genvar);
+    CHECK(loopArr.genvar->name == "g");
+    REQUIRE(loopArr.getSyntax() != nullptr);
+    CHECK(loopArr.getSyntax()->kind == SyntaxKind::LoopGenerate);
+    CHECK(loopArr.entries.size() == 3);
+    for (auto entry : loopArr.entries) {
+        CHECK(entry->branchKind == GenerateBranchKind::LoopIteration);
+        CHECK(entry->generateConstructSyntax == loopArr.getSyntax());
+    }
+}
+
+TEST_CASE("Generate provenance for nested if-in-if with begin/end") {
+    auto tree = SyntaxTree::fromText(R"(
+module Top #(parameter int A = 1, parameter int B = 1)();
+    if (A == 1) begin : outer
+        if (B == 1) begin : inner
+            int x;
+        end
+    end
+endmodule
+)");
+
+    Compilation compilation;
+    compilation.addSyntaxTree(tree);
+    NO_COMPILATION_ERRORS;
+
+    auto& root = compilation.getRoot();
+    auto& outer = root.lookupName<GenerateBlockSymbol>("Top.outer");
+    auto& inner = root.lookupName<GenerateBlockSymbol>("Top.outer.inner");
+
+    REQUIRE(outer.generateConstructSyntax != nullptr);
+    REQUIRE(inner.generateConstructSyntax != nullptr);
+    CHECK(outer.generateConstructSyntax->kind == SyntaxKind::IfGenerate);
+    CHECK(inner.generateConstructSyntax->kind == SyntaxKind::IfGenerate);
+    CHECK(outer.generateConstructSyntax != inner.generateConstructSyntax);
+
+    CHECK(outer.branchKind == GenerateBranchKind::IfTrue);
+    CHECK(inner.branchKind == GenerateBranchKind::IfTrue);
+    REQUIRE(outer.conditionExpression != nullptr);
+    REQUIRE(inner.conditionExpression != nullptr);
+    CHECK(outer.conditionExpression != inner.conditionExpression);
+}
+
+TEST_CASE("Generate provenance for directly-nested if-in-if") {
+    auto tree = SyntaxTree::fromText(R"(
+module Top #(parameter int A = 1, parameter int B = 1)();
+    if (A == 1)
+        if (B == 1) begin : t
+            int x;
+        end
+        else begin : f
+            int y;
+        end
+endmodule
+)");
+
+    Compilation compilation;
+    compilation.addSyntaxTree(tree);
+    NO_COMPILATION_ERRORS;
+
+    auto& root = compilation.getRoot();
+    auto& t = root.lookupName<GenerateBlockSymbol>("Top.t");
+    auto& f = root.lookupName<GenerateBlockSymbol>("Top.f");
+
+    REQUIRE(t.generateConstructSyntax != nullptr);
+    REQUIRE(f.generateConstructSyntax != nullptr);
+    CHECK(t.generateConstructSyntax->kind == SyntaxKind::IfGenerate);
+    CHECK(t.generateConstructSyntax == f.generateConstructSyntax);
+
+    CHECK(t.branchKind == GenerateBranchKind::IfTrue);
+    CHECK(f.branchKind == GenerateBranchKind::IfFalse);
+    REQUIRE(t.conditionExpression != nullptr);
+    CHECK(t.conditionExpression == f.conditionExpression);
+
+    // Outer construct reachable via syntax-parent walk.
+    auto* innerIf = t.generateConstructSyntax;
+    auto* outerIf = innerIf->parent;
+    REQUIRE(outerIf != nullptr);
+    CHECK(outerIf->kind == SyntaxKind::IfGenerate);
+    CHECK(outerIf != innerIf);
+}
+
+TEST_CASE("Generate provenance for case inside if") {
+    auto tree = SyntaxTree::fromText(R"(
+module Top #(parameter int A = 1, parameter int MODE = 1)();
+    if (A == 1) begin : wrapper
+        case (MODE)
+            1, 2: begin : m1 end
+            default: begin : md end
+        endcase
+    end
+endmodule
+)");
+
+    Compilation compilation;
+    compilation.addSyntaxTree(tree);
+    NO_COMPILATION_ERRORS;
+
+    auto& root = compilation.getRoot();
+    auto& wrapper = root.lookupName<GenerateBlockSymbol>("Top.wrapper");
+    auto& m1 = root.lookupName<GenerateBlockSymbol>("Top.wrapper.m1");
+    auto& md = root.lookupName<GenerateBlockSymbol>("Top.wrapper.md");
+
+    CHECK(wrapper.branchKind == GenerateBranchKind::IfTrue);
+    REQUIRE(wrapper.generateConstructSyntax != nullptr);
+    CHECK(wrapper.generateConstructSyntax->kind == SyntaxKind::IfGenerate);
+
+    CHECK(m1.branchKind == GenerateBranchKind::CaseItem);
+    CHECK(md.branchKind == GenerateBranchKind::CaseDefault);
+    REQUIRE(m1.generateConstructSyntax != nullptr);
+    CHECK(m1.generateConstructSyntax->kind == SyntaxKind::CaseGenerate);
+    CHECK(m1.generateConstructSyntax == md.generateConstructSyntax);
+
+    // Walk up to the enclosing if-generate.
+    auto* cur = m1.generateConstructSyntax->parent;
+    while (cur && cur->kind != SyntaxKind::IfGenerate)
+        cur = cur->parent;
+    REQUIRE(cur != nullptr);
+    CHECK(cur == wrapper.generateConstructSyntax);
+}
+
+TEST_CASE("Generate provenance with inline genvar") {
+    auto tree = SyntaxTree::fromText(R"(
+module Top;
+    for (genvar i = 0; i < 2; i = i + 1) begin : arr
+        int x;
+    end
+endmodule
+)");
+
+    Compilation compilation;
+    compilation.addSyntaxTree(tree);
+    NO_COMPILATION_ERRORS;
+
+    auto& arr = compilation.getRoot().lookupName<GenerateBlockArraySymbol>("Top.arr");
+    REQUIRE(arr.genvar != nullptr);
+    CHECK(arr.genvar->kind == SymbolKind::Genvar);
+    CHECK(arr.genvar->name == "i");
+    CHECK(arr.entries.size() == 2);
+}
+
 TEST_CASE("Program instantiation") {
     auto tree = SyntaxTree::fromText(R"(
 program p1 #(parameter int foo)

--- a/tests/unittests/ast/HierarchyTests.cpp
+++ b/tests/unittests/ast/HierarchyTests.cpp
@@ -11,6 +11,19 @@
 #include "slang/ast/symbols/ParameterSymbols.h"
 #include "slang/text/SourceManager.h"
 
+// Walks up from a generate block to the enclosing if/case/loop-generate node.
+// Needed because if-else and case arms sit under an intermediate
+// ElseClause / StandardCaseItem / DefaultCaseItem syntax node.
+static const SyntaxNode* constructOf(const GenerateBlockSymbol& block) {
+    auto s = block.getSyntax();
+    auto p = s ? s->parent : nullptr;
+    while (p && p->kind != SyntaxKind::IfGenerate && p->kind != SyntaxKind::CaseGenerate &&
+           p->kind != SyntaxKind::LoopGenerate) {
+        p = p->parent;
+    }
+    return p;
+}
+
 TEST_CASE("Finding top level") {
     auto file1 = SyntaxTree::fromText(
         "module A; endmodule\nmodule B; A a(); endmodule\nmodule C; endmodule");
@@ -274,28 +287,31 @@ endmodule
     CHECK(ifFalse.branchKind == GenerateBranchKind::IfFalse);
     CHECK(!ifTrue.isUninstantiated);
     CHECK(ifFalse.isUninstantiated);
-    REQUIRE(ifTrue.conditionExpression != nullptr);
-    CHECK(ifTrue.conditionExpression == ifFalse.conditionExpression);
+    REQUIRE(ifTrue.getConditionExpression() != nullptr);
+    CHECK(ifTrue.getConditionExpression() == ifFalse.getConditionExpression());
     CHECK(ifTrue.caseItemExpressions.empty());
-    REQUIRE(ifTrue.generateConstructSyntax != nullptr);
-    CHECK(ifTrue.generateConstructSyntax->kind == SyntaxKind::IfGenerate);
-    CHECK(ifTrue.generateConstructSyntax == ifFalse.generateConstructSyntax);
+    CHECK(ifTrue.getArrayIndex() == nullptr);
+    REQUIRE(constructOf(ifTrue) != nullptr);
+    CHECK(constructOf(ifTrue)->kind == SyntaxKind::IfGenerate);
+    CHECK(constructOf(ifTrue) == constructOf(ifFalse));
 
     // case-generate
     auto& caseItem = root.lookupName<GenerateBlockSymbol>("Top.case_item_lo");
     auto& caseDefault = root.lookupName<GenerateBlockSymbol>("Top.case_default");
     CHECK(caseItem.branchKind == GenerateBranchKind::CaseItem);
     CHECK(caseDefault.branchKind == GenerateBranchKind::CaseDefault);
-    REQUIRE(caseItem.conditionExpression != nullptr);
-    CHECK(caseItem.conditionExpression == caseDefault.conditionExpression);
+    REQUIRE(caseItem.getConditionExpression() != nullptr);
+    CHECK(caseItem.getConditionExpression() == caseDefault.getConditionExpression());
     CHECK(caseItem.caseItemExpressions.size() == 2);
     CHECK(caseDefault.caseItemExpressions.empty());
-    REQUIRE(caseItem.generateConstructSyntax != nullptr);
-    CHECK(caseItem.generateConstructSyntax->kind == SyntaxKind::CaseGenerate);
-    CHECK(caseItem.generateConstructSyntax == caseDefault.generateConstructSyntax);
+    CHECK(caseItem.getArrayIndex() == nullptr);
+    REQUIRE(constructOf(caseItem) != nullptr);
+    CHECK(constructOf(caseItem)->kind == SyntaxKind::CaseGenerate);
+    CHECK(constructOf(caseItem) == constructOf(caseDefault));
 
     // loop-generate: the array's getSyntax() returns the LoopGenerateSyntax
-    // directly; each entry block points back to that same construct.
+    // directly; each entry block's getSyntax()->parent walks up to that same
+    // construct.
     auto& loopArr = root.lookupName<GenerateBlockArraySymbol>("Top.loop_arr");
     CHECK(loopArr.initialExpression != nullptr);
     CHECK(loopArr.stopExpression != nullptr);
@@ -308,7 +324,9 @@ endmodule
     CHECK(loopArr.entries.size() == 3);
     for (auto entry : loopArr.entries) {
         CHECK(entry->branchKind == GenerateBranchKind::LoopIteration);
-        CHECK(entry->generateConstructSyntax == loopArr.getSyntax());
+        CHECK(constructOf(*entry) == loopArr.getSyntax());
+        CHECK(entry->getArrayIndex() != nullptr);
+        CHECK(entry->getConditionExpression() == nullptr);
     }
 }
 
@@ -331,17 +349,19 @@ endmodule
     auto& outer = root.lookupName<GenerateBlockSymbol>("Top.outer");
     auto& inner = root.lookupName<GenerateBlockSymbol>("Top.outer.inner");
 
-    REQUIRE(outer.generateConstructSyntax != nullptr);
-    REQUIRE(inner.generateConstructSyntax != nullptr);
-    CHECK(outer.generateConstructSyntax->kind == SyntaxKind::IfGenerate);
-    CHECK(inner.generateConstructSyntax->kind == SyntaxKind::IfGenerate);
-    CHECK(outer.generateConstructSyntax != inner.generateConstructSyntax);
+    auto* outerConstruct = constructOf(outer);
+    auto* innerConstruct = constructOf(inner);
+    REQUIRE(outerConstruct != nullptr);
+    REQUIRE(innerConstruct != nullptr);
+    CHECK(outerConstruct->kind == SyntaxKind::IfGenerate);
+    CHECK(innerConstruct->kind == SyntaxKind::IfGenerate);
+    CHECK(outerConstruct != innerConstruct);
 
     CHECK(outer.branchKind == GenerateBranchKind::IfTrue);
     CHECK(inner.branchKind == GenerateBranchKind::IfTrue);
-    REQUIRE(outer.conditionExpression != nullptr);
-    REQUIRE(inner.conditionExpression != nullptr);
-    CHECK(outer.conditionExpression != inner.conditionExpression);
+    REQUIRE(outer.getConditionExpression() != nullptr);
+    REQUIRE(inner.getConditionExpression() != nullptr);
+    CHECK(outer.getConditionExpression() != inner.getConditionExpression());
 }
 
 TEST_CASE("Generate provenance for directly-nested if-in-if") {
@@ -365,21 +385,21 @@ endmodule
     auto& t = root.lookupName<GenerateBlockSymbol>("Top.t");
     auto& f = root.lookupName<GenerateBlockSymbol>("Top.f");
 
-    REQUIRE(t.generateConstructSyntax != nullptr);
-    REQUIRE(f.generateConstructSyntax != nullptr);
-    CHECK(t.generateConstructSyntax->kind == SyntaxKind::IfGenerate);
-    CHECK(t.generateConstructSyntax == f.generateConstructSyntax);
+    auto* innerIf = constructOf(t);
+    REQUIRE(innerIf != nullptr);
+    CHECK(innerIf->kind == SyntaxKind::IfGenerate);
+    CHECK(innerIf == constructOf(f));
 
     CHECK(t.branchKind == GenerateBranchKind::IfTrue);
     CHECK(f.branchKind == GenerateBranchKind::IfFalse);
-    REQUIRE(t.conditionExpression != nullptr);
-    CHECK(t.conditionExpression == f.conditionExpression);
+    REQUIRE(t.getConditionExpression() != nullptr);
+    CHECK(t.getConditionExpression() == f.getConditionExpression());
 
-    // Outer construct reachable via syntax-parent walk.
-    auto* innerIf = t.generateConstructSyntax;
+    // The directly-nested outer construct is reachable by continuing the walk.
     auto* outerIf = innerIf->parent;
+    while (outerIf && outerIf->kind != SyntaxKind::IfGenerate)
+        outerIf = outerIf->parent;
     REQUIRE(outerIf != nullptr);
-    CHECK(outerIf->kind == SyntaxKind::IfGenerate);
     CHECK(outerIf != innerIf);
 }
 
@@ -405,21 +425,23 @@ endmodule
     auto& md = root.lookupName<GenerateBlockSymbol>("Top.wrapper.md");
 
     CHECK(wrapper.branchKind == GenerateBranchKind::IfTrue);
-    REQUIRE(wrapper.generateConstructSyntax != nullptr);
-    CHECK(wrapper.generateConstructSyntax->kind == SyntaxKind::IfGenerate);
+    auto* wrapperConstruct = constructOf(wrapper);
+    REQUIRE(wrapperConstruct != nullptr);
+    CHECK(wrapperConstruct->kind == SyntaxKind::IfGenerate);
 
     CHECK(m1.branchKind == GenerateBranchKind::CaseItem);
     CHECK(md.branchKind == GenerateBranchKind::CaseDefault);
-    REQUIRE(m1.generateConstructSyntax != nullptr);
-    CHECK(m1.generateConstructSyntax->kind == SyntaxKind::CaseGenerate);
-    CHECK(m1.generateConstructSyntax == md.generateConstructSyntax);
+    auto* m1Construct = constructOf(m1);
+    REQUIRE(m1Construct != nullptr);
+    CHECK(m1Construct->kind == SyntaxKind::CaseGenerate);
+    CHECK(m1Construct == constructOf(md));
 
-    // Walk up to the enclosing if-generate.
-    auto* cur = m1.generateConstructSyntax->parent;
+    // Walk up from the inner case-generate to the enclosing if-generate.
+    auto* cur = m1Construct->parent;
     while (cur && cur->kind != SyntaxKind::IfGenerate)
         cur = cur->parent;
     REQUIRE(cur != nullptr);
-    CHECK(cur == wrapper.generateConstructSyntax);
+    CHECK(cur == wrapperConstruct);
 }
 
 TEST_CASE("Generate provenance with inline genvar") {


### PR DESCRIPTION
## Summary

After elaboration of if-generate, case-generate, and loop-generate constructs, slang binds the control expressions and resolves the associated genvar but then discards them. Downstream tools that want to reason about the original generate structure have to rebind from syntax and re-resolve the genvar. This PR retains that information directly on `GenerateBlockSymbol` and `GenerateBlockArraySymbol` so consumers can reuse values that were already computed during elaboration. Refs #1800.

## Design

The change is purely additive provenance — no behavior change, no new abstraction, no extra allocations. Every new field is populated from a value that `BlockSymbols.cpp` already constructs during elaboration and that is otherwise dropped on return.

### GenerateBlockSymbol

- `branchKind` — new enum (`IfTrue`, `IfFalse`, `CaseItem`, `CaseDefault`, `LoopIteration`, `IllegalUnconditional`) identifying which arm produced the block.
- `generateConstructSyntax` — direct pointer to the originating `IfGenerateSyntax`, `CaseGenerateSyntax`, or `LoopGenerateSyntax`. Kept as a raw `const SyntaxNode*` to match how every other held-syntax pointer in the AST (`Expression::syntax`, `Statement::syntax`, `ParameterSymbol::defaultValSyntax`, etc.) is expressed; the invariant is documented on the field and enforced by a `SLANG_ASSERT` at the assignment site. A typed wrapper/tagged union was considered and rejected as an idiom slang doesn't use elsewhere.
- `conditionExpression` — bound condition of the enclosing if- or case-generate.
- `caseItemExpressions` — bound case-item label expressions.

### GenerateBlockArraySymbol

- `initialExpression`, `stopExpression`, `iterExpression` — bound loop-control expressions.
- `genvar` — the canonical `GenvarSymbol`: for an inline genvar this is the fabricated symbol held as a member of the array; for an external genvar it is the resolved declaration.
- Intentionally no `generateConstructSyntax` on the array: `getSyntax()` already returns the `LoopGenerateSyntax` directly, so a duplicate field would only be surface symmetry. Per-iteration `GenerateBlockSymbol`s do carry the field, because their `getSyntax()` is the block body rather than the construct.

### Directly-nested conditional generate

Per LRM 27.5, inner conditional generates without `begin`/`end` continue to flatten into sibling blocks at the outer scope. Each flattened block now carries its own immediate `generateConstructSyntax`; outer constructs remain reachable via `SyntaxNode::parent` on that pointer, so no nesting information is lost.

### Serialization

`serializeTo` emits the new fields. `generateConstructSyntax` is written as a syntax-kind label (not as a serializable identity reference) — documented at the call site.

## Testing

C++ tests in `HierarchyTests.cpp` cover the flat case plus three nested scenarios: `if`-in-`if` with `begin`/`end`, directly-nested `if`-in-`if`, and `case`-in-`if`. The directly-nested test walks up through `SyntaxNode::parent` to verify that outer structure stays recoverable. Parallel pyslang tests exercise the same paths plus inline-genvar to validate the Python binding surface.

## AI disclosure

Per the project's CONTRIBUTING.md: parts of this patch were drafted with assistance from Claude. I reviewed every line and am fully accountable for the change.