### PR TITLE
Fix C++23 incomplete type error in TimeTrace

### DIFF
--- a/source/util/TimeTrace.cpp
+++ b/source/util/TimeTrace.cpp
@@ -21,8 +21,6 @@ using namespace std::chrono;
 
 namespace slang {
 
-std::unique_ptr<TimeTrace::Profiler> TimeTrace::profiler = nullptr;
-
 using DurationType = duration<steady_clock::rep, steady_clock::period>;
 
 static std::string escapeString(std::string_view src) {
@@ -126,6 +124,8 @@ struct TimeTrace::Profiler {
 };
 
 thread_local std::vector<Entry> TimeTrace::Profiler::stack;
+
+std::unique_ptr<TimeTrace::Profiler> TimeTrace::profiler = nullptr;
 
 void TimeTrace::initialize() {
     SLANG_ASSERT(!profiler);


### PR DESCRIPTION
Apple Clang with `-std=c++23` strictly enforces incomplete type rules for `std::unique_ptr`. This fixes the build failure by moving the definition of the `profiler` member after the full definition of `TimeTrace::Profiler`.