### PR TITLE
Fix pyslang 'extract_logic_names' example

### DIFF
--- a/pyslang/examples/extract_logic_names.py
+++ b/pyslang/examples/extract_logic_names.py
@@ -16,13 +16,15 @@ all logic declarations found in the code.
 
 from typing import Union
 
+from pyslang import DiagnosticEngine, TextDiagnosticClient
 from pyslang.ast import Compilation, PackedArrayType, ScalarType, VariableSymbol
 from pyslang.parsing import Token
 from pyslang.syntax import SyntaxNode, SyntaxTree
 
 
 class LogicDeclarationExtractor:
-    """Visitor class to extract names of all logic declarations.
+    """
+    Visitor class to extract names of all logic declarations.
 
     This visitor traverses the AST and collects the names of all variables
     that are declared with the 'logic' type. It demonstrates how to:
@@ -36,7 +38,8 @@ class LogicDeclarationExtractor:
         self.logic_names = []
 
     def _is_logic_type(self, var_type) -> bool:
-        """Check if a type represents a logic type, including nested arrays.
+        """
+        Check if a type represents a logic type, including nested arrays.
 
         Args:
             var_type: The type to check (ScalarType or PackedArrayType)
@@ -57,7 +60,8 @@ class LogicDeclarationExtractor:
         return False
 
     def __call__(self, obj: Union[Token, SyntaxNode]) -> None:
-        """Visit method called for each node in the AST.
+        """
+        Visit method called for each node in the AST.
 
         Args:
             obj: The current AST node being visited. Can be a Token or SyntaxNode.
@@ -74,49 +78,51 @@ class LogicDeclarationExtractor:
 
 
 def extract_logic_declaration_names(systemverilog_code: str) -> list[str]:
-    """Extract logic declaration names from SystemVerilog code.
+    """
+    Extract logic declaration names from SystemVerilog code.
 
     Args:
         systemverilog_code: A string containing SystemVerilog source code.
 
     Returns:
         A list of strings containing the names of all logic declarations.
-
-    Raises:
-        Exception: If there are parsing errors or compilation issues.
     """
-    try:
-        # Parse the SystemVerilog code into a syntax tree
-        tree = SyntaxTree.fromText(systemverilog_code)
+    # Parse the SystemVerilog code into a syntax tree
+    tree = SyntaxTree.fromText(systemverilog_code)
 
-        # Create a compilation unit and add the syntax tree
-        compilation = Compilation()
-        compilation.addSyntaxTree(tree)
+    # Create a compilation unit and add the syntax tree
+    compilation = Compilation()
+    compilation.addSyntaxTree(tree)
 
-        # Check for any diagnostics (errors/warnings) during compilation
-        diagnostics = compilation.getAllDiagnostics()
-        if diagnostics:
-            error_messages = []
-            for diag in diagnostics:
-                if diag.isError():
-                    error_messages.append(str(diag))
-            if error_messages:
-                raise Exception(f"Compilation errors: {'; '.join(error_messages)}")
+    # Handle diagnostics.
+    diagnostics = compilation.getAllDiagnostics()
 
-        # Create our visitor to extract logic declaration names
-        extractor = LogicDeclarationExtractor()
+    diagClient = TextDiagnosticClient()
+    diagEngine = DiagnosticEngine(compilation.sourceManager)
+    diagEngine.addClient(diagClient)
 
-        # Visit all nodes in the compilation root
-        compilation.getRoot().visit(extractor)
+    has_error = False
+    for diag in diagnostics:
+        diagEngine.issue(diag)
+        has_error = diag.isError() or has_error
 
-        return extractor.logic_names
+    print(diagClient.getString())
 
-    except Exception as e:
-        raise Exception(f"Failed to extract logic declarations: {e}")
+    if has_error:
+        raise Exception("Compilation had errors")
+
+    # Create our visitor to extract logic declaration names
+    extractor = LogicDeclarationExtractor()
+
+    # Visit all nodes in the compilation root
+    compilation.getRoot().visit(extractor)
+
+    return extractor.logic_names
 
 
 def extract_logic_declarations_from_file(filepath: str) -> list[str]:
-    """Extract logic declaration names from a SystemVerilog file.
+    """
+    Extract logic declaration names from a SystemVerilog file.
 
     Args:
         filepath: Path to a SystemVerilog file.
@@ -124,14 +130,9 @@ def extract_logic_declarations_from_file(filepath: str) -> list[str]:
     Returns:
         A list of strings containing the names of all logic declarations.
     """
-    try:
-        with open(filepath, "r", encoding="utf-8") as file:
-            content = file.read()
-        return extract_logic_declaration_names(content)
-    except FileNotFoundError:
-        raise Exception(f"File not found: {filepath}")
-    except Exception as e:
-        raise Exception(f"Failed to process file {filepath}: {e}")
+    with open(filepath, "r", encoding="utf-8") as file:
+        content = file.read()
+    return extract_logic_declaration_names(content)
 
 
 def main():

--- a/pyslang/tests/conftest.py
+++ b/pyslang/tests/conftest.py
@@ -1,0 +1,7 @@
+# SPDX-FileCopyrightText: Michael Popoloski
+# SPDX-License-Identifier: MIT
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "examples"))

--- a/pyslang/tests/test_extract_logic_names.py
+++ b/pyslang/tests/test_extract_logic_names.py
@@ -1,137 +1,58 @@
 # SPDX-FileCopyrightText: Michael Popoloski
 # SPDX-License-Identifier: MIT
 
-"""Tests for the logic declaration name extractor example.
+"""Tests for the logic declaration name extractor example."""
 
-Note: This test replicates the logic extractor functionality directly
-rather than importing from the example to avoid import path issues.
-"""
+import pytest
 
-from typing import Union
-
-from pyslang.ast import Compilation, PackedArrayType, ScalarType, VariableSymbol
-from pyslang.parsing import Token
-from pyslang.syntax import SyntaxNode, SyntaxTree
-
-
-class LogicDeclarationExtractor:
-    """Visitor class to extract names of all logic declarations."""
-
-    def __init__(self):
-        """Initialize the extractor with an empty list of logic variable names."""
-        self.logic_names = []
-
-    def _is_logic_type(self, var_type) -> bool:
-        """Check if a type represents a logic type, including nested arrays.
-
-        Args:
-            var_type: The type to check (ScalarType or PackedArrayType)
-
-        Returns:
-            True if the type is logic or an array of logic types
-        """
-        # Check if it's a scalar logic type
-        if isinstance(var_type, ScalarType):
-            return var_type.scalarKind == ScalarType.Kind.Logic
-
-        # Check if it's a packed array type
-        elif isinstance(var_type, PackedArrayType):
-            # Recursively check the element type
-            return self._is_logic_type(var_type.elementType)
-
-        # Not a logic type
-        return False
-
-    def __call__(self, obj: Union[Token, SyntaxNode]) -> None:
-        """Visit method called for each node in the AST."""
-        # Check if this is a variable symbol (includes logic declarations)
-        if isinstance(obj, VariableSymbol):
-            # Get the type of the variable
-            var_type = obj.type
-
-            # Check if this is a logic type (handles scalars, arrays, and multi-dimensional arrays)
-            if self._is_logic_type(var_type):
-                self.logic_names.append(obj.name)
-
-
-def extract_logic_declaration_names(systemverilog_code: str) -> list[str]:
-    """Extract logic declaration names from SystemVerilog code."""
-    # Parse the SystemVerilog code into a syntax tree
-    tree = SyntaxTree.fromText(systemverilog_code)
-
-    # Create a compilation unit and add the syntax tree
-    compilation = Compilation()
-    compilation.addSyntaxTree(tree)
-
-    # Create our visitor to extract logic declaration names
-    extractor = LogicDeclarationExtractor()
-
-    # Visit all nodes in the compilation root
-    compilation.getRoot().visit(extractor)
-
-    return extractor.logic_names
+from extract_logic_names import (
+    LogicDeclarationExtractor,
+    extract_logic_declaration_names,
+    extract_logic_declarations_from_file,
+)
+from pyslang.ast import Compilation
+from pyslang.syntax import SyntaxTree
 
 
 def test_logic_declaration_extractor():
     """Test the LogicDeclarationExtractor class directly."""
 
-    # Simple SystemVerilog code with various declarations
     code = """
     module test_module;
-        logic        clk;           // logic declaration
-        logic [7:0]  data;          // logic array declaration
-        bit          bit_sig;       // bit declaration (should be ignored)
-        reg [3:0]    reg_sig;       // reg declaration (should be ignored)
-        logic        enable;        // another logic declaration
-        int          counter;       // int declaration (should be ignored)
-        logic [1:0]  state;         // logic array declaration
+        logic        clk;
+        logic [7:0]  data;
+        bit          bit_sig;
+        reg [3:0]    reg_sig;
+        logic        enable;
+        int          counter;
+        logic [1:0]  state;
     endmodule
     """
 
-    # Parse and create compilation
     tree = SyntaxTree.fromText(code)
     compilation = Compilation()
     compilation.addSyntaxTree(tree)
 
-    # Extract logic names
     extractor = LogicDeclarationExtractor()
     compilation.getRoot().visit(extractor)
 
-    # Check results - should find the logic declarations but not bit, reg, int
-    expected_names = {"clk", "data", "enable", "state"}
-    actual_names = set(extractor.logic_names)
-
-    assert actual_names == expected_names, (
-        f"Expected {expected_names}, got {actual_names}"
-    )
+    assert set(extractor.logic_names) == {"clk", "data", "enable", "state"}
 
 
 def test_extract_logic_declaration_names_function():
-    """Test the extract_logic_declaration_names function."""
-
     code = """
     module simple_test;
         logic        reset;
         logic [15:0] address;
-        bit          ready;         // should be ignored
+        bit          ready;
         logic        valid;
     endmodule
     """
 
-    logic_names = extract_logic_declaration_names(code)
-
-    # Should find reset, address, and valid, but not ready (which is bit)
-    expected_names = {"reset", "address", "valid"}
-    actual_names = set(logic_names)
-
-    assert actual_names == expected_names, (
-        f"Expected {expected_names}, got {actual_names}"
-    )
+    assert set(extract_logic_declaration_names(code)) == {"reset", "address", "valid"}
 
 
 def test_no_logic_declarations():
-    """Test with code that has no logic declarations."""
-
     code = """
     module no_logic;
         bit        a;
@@ -141,14 +62,10 @@ def test_no_logic_declarations():
     endmodule
     """
 
-    logic_names = extract_logic_declaration_names(code)
-
-    assert len(logic_names) == 0, f"Expected no logic declarations, got {logic_names}"
+    assert extract_logic_declaration_names(code) == []
 
 
 def test_complex_module_with_ports():
-    """Test with a more complex module including port declarations."""
-
     code = """
     module complex_test(
         input  logic        clk,
@@ -159,56 +76,50 @@ def test_complex_module_with_ports():
     );
         logic [3:0]  internal_counter;
         logic        internal_enable;
-        bit          bit_flag;        // should be ignored
-        reg [1:0]    reg_state;       // should be ignored
+        bit          bit_flag;
+        reg [1:0]    reg_state;
         logic        ready;
     endmodule
     """
 
-    logic_names = extract_logic_declaration_names(code)
-
-    # Should find all logic declarations: ports + internal variables
-    expected_names = {
+    assert set(extract_logic_declaration_names(code)) == {
         "clk",
         "reset_n",
         "data_in",
         "data_out",
-        "valid",  # port declarations
+        "valid",
         "internal_counter",
         "internal_enable",
-        "ready",  # internal declarations
+        "ready",
     }
-    actual_names = set(logic_names)
-
-    assert actual_names == expected_names, (
-        f"Expected {expected_names}, got {actual_names}"
-    )
 
 
 def test_logic_arrays_and_vectors():
-    """Test with various logic array and vector declarations."""
-
     code = """
     module array_test;
         logic           single_bit;
         logic [7:0]     byte_vector;
         logic [15:0]    word_vector;
         logic [31:0]    dword_vector;
-        logic [1:0][7:0] multi_dim;    // multi-dimensional
+        logic [1:0][7:0] multi_dim;
     endmodule
     """
 
-    logic_names = extract_logic_declaration_names(code)
-
-    expected_names = {
+    assert set(extract_logic_declaration_names(code)) == {
         "single_bit",
         "byte_vector",
         "word_vector",
         "dword_vector",
         "multi_dim",
     }
-    actual_names = set(logic_names)
 
-    assert actual_names == expected_names, (
-        f"Expected {expected_names}, got {actual_names}"
-    )
+
+def test_extract_from_file(tmp_path):
+    sv_file = tmp_path / "module.sv"
+    sv_file.write_text("module m; logic foo; bit b; endmodule")
+    assert extract_logic_declarations_from_file(str(sv_file)) == ["foo"]
+
+
+def test_extract_from_missing_file(tmp_path):
+    with pytest.raises(FileNotFoundError):
+        extract_logic_declarations_from_file(str(tmp_path / "missing.sv"))


### PR DESCRIPTION
- Fix pyslang imports.
- Fix diagnositics handling.
- Remove duplication of LogicDeclarationExtractor and extract_logic_declaration_names.
- Refactoring of exception handling.
- Add example to test set.