### PR TITLE
Add CompilationFlags::IgnoreUninstantiatedModules

### DIFF
--- a/include/slang/ast/Compilation.h
+++ b/include/slang/ast/Compilation.h
@@ -127,9 +127,12 @@ enum class SLANG_EXPORT CompilationFlags {
     /// Allow multiple definitions of the same module, interface, program, or primitive at
     /// the root scope within the same library, keeping the first and silently discarding
     /// subsequent ones, but only when the conflicting definition comes from a library file.
-    AllowLibModuleRedefinition = 1 << 16
+    AllowLibModuleRedefinition = 1 << 16,
+
+    /// Don't instantiate unreferenced modules to perform semantic checking on them.
+    IgnoreUninstantiatedModules = 1 << 17
 };
-SLANG_BITMASK(CompilationFlags, AllowLibModuleRedefinition)
+SLANG_BITMASK(CompilationFlags, IgnoreUninstantiatedModules)
 
 /// Contains various options that can control compilation behavior.
 struct SLANG_EXPORT CompilationOptions {

--- a/source/ast/Compilation.cpp
+++ b/source/ast/Compilation.cpp
@@ -544,8 +544,10 @@ const RootSymbol& Compilation::getRoot(bool skipDefParamsAndBinds) {
 
     // For unreferenced definitions, go through and instantiate them with all empty
     // parameter values so that we get at least some semantic checking of the contents.
-    for (auto def : unreferencedDefs)
-        root->addMember(InstanceSymbol::createInvalid(*this, *def));
+    if (!hasFlag(CompilationFlags::IgnoreUninstantiatedModules)) {
+        for (auto def : unreferencedDefs)
+            root->addMember(InstanceSymbol::createInvalid(*this, *def));
+    }
 
     root->topInstances = topList.copy(*this);
     root->compilationUnits = compilationUnits;

--- a/tests/unittests/ast/HierarchyTests.cpp
+++ b/tests/unittests/ast/HierarchyTests.cpp
@@ -2750,3 +2750,21 @@ endmodule
     compilation.addSyntaxTree(tree);
     NO_COMPILATION_ERRORS;
 }
+
+TEST_CASE("Ignore uninstantiated modules") {
+    auto tree = SyntaxTree::fromText(R"(
+module unused;
+  initial undeclared = 1; // normally an error
+endmodule
+
+module top;
+endmodule
+)");
+    CompilationOptions options;
+    options.flags |= CompilationFlags::IgnoreUninstantiatedModules;
+    options.topModules.insert("top");
+
+    Compilation compilation(options);
+    compilation.addSyntaxTree(tree);
+    NO_COMPILATION_ERRORS;
+}


### PR DESCRIPTION
This adds a new compilation flag that suppresses the automatic instantiation of unreferenced modules during compilation.

EDA tools generally completely skip compilation of unreachable modules when a top module is specified by the user. This flag provides an opt-out for tools that need such behavior.