### PR TITLE
Expressions: Better bad expressions in ConversionExpression::fromSyntax

### DIFF
--- a/source/ast/expressions/ConversionExpression.cpp
+++ b/source/ast/expressions/ConversionExpression.cpp
@@ -268,18 +268,28 @@ static bool actuallyNeededCast(const Type& type, const Expression& operand) {
 Expression& ConversionExpression::fromSyntax(Compilation& comp, const CastExpressionSyntax& syntax,
                                              const ASTContext& context,
                                              const Type* assignmentTarget) {
-    auto& targetExpr = bind(*syntax.left, context, ASTFlags::AllowDataType);
-    if (targetExpr.bad())
-        return badExpr(comp, nullptr);
+    const Type* type = &comp.getErrorType();
+    auto bindOperand = [&](const Type* target = nullptr) -> Expression& {
+        return create(comp, *syntax.right, context, ASTFlags::StreamingAllowed, target);
+    };
+    auto result = [&](Expression& operand, ConversionKind cast = ConversionKind::Explicit) {
+        return comp.emplace<ConversionExpression>(*type, cast, operand, syntax.sourceRange());
+    };
 
-    auto type = &comp.getErrorType();
+    auto& targetExpr = bind(*syntax.left, context, ASTFlags::AllowDataType);
+    if (targetExpr.bad()) {
+        return badExpr(comp, result(bindOperand()));
+    }
+
     Expression* operand;
+
     if (targetExpr.kind == ExpressionKind::DataType) {
         type = targetExpr.type;
+        bool badCastType = false;
         if (!type->isSimpleType() && !type->isError() && !type->isString() &&
             syntax.left->kind != SyntaxKind::TypeReference) {
             context.addDiag(diag::BadCastType, targetExpr.sourceRange) << *type;
-            return badExpr(comp, nullptr);
+            badCastType = true;
         }
 
         // Don't pass type as assignmentTarget for streaming operands: the existing
@@ -289,41 +299,38 @@ Expression& ConversionExpression::fromSyntax(Compilation& comp, const CastExpres
         // check the inner expression kind.
         const bool isStreamingOperand = syntax.right->expression->kind ==
                                         SyntaxKind::StreamingConcatenationExpression;
-        operand = &create(comp, *syntax.right, context, ASTFlags::StreamingAllowed,
-                          isStreamingOperand ? nullptr : type);
-        if (operand->bad())
-            return badExpr(comp, nullptr);
+        operand = &bindOperand(badCastType || isStreamingOperand ? nullptr : type);
+        if (badCastType || operand->bad())
+            return badExpr(comp, result(*operand));
     }
     else {
         auto val = context.evalInteger(targetExpr);
-        if (!val || !context.requireGtZero(val, targetExpr.sourceRange))
-            return badExpr(comp, nullptr);
+        if (!val || !context.requireGtZero(val, targetExpr.sourceRange)) {
+            return badExpr(comp, result(bindOperand()));
+        }
 
         bitwidth_t width = bitwidth_t(*val);
-        if (!context.requireValidBitWidth(width, targetExpr.sourceRange))
-            return badExpr(comp, nullptr);
+        if (!context.requireValidBitWidth(width, targetExpr.sourceRange)) {
+            return badExpr(comp, result(bindOperand()));
+        }
 
-        operand = &create(comp, *syntax.right, context, ASTFlags::StreamingAllowed);
+        operand = &bindOperand();
         if (operand->bad())
-            return badExpr(comp, nullptr);
+            return badExpr(comp, result(*operand));
 
         if (!operand->type->isIntegral()) {
             auto& diag = context.addDiag(diag::BadIntegerCast, syntax.apostrophe.location());
             diag << *operand->type;
             diag << targetExpr.sourceRange << operand->sourceRange;
-            return badExpr(comp, nullptr);
+            return badExpr(comp, result(*operand));
         }
 
         type = &comp.getType(width, operand->type->getIntegralFlags());
     }
 
-    auto result = [&](ConversionKind cast = ConversionKind::Explicit) {
-        return comp.emplace<ConversionExpression>(*type, cast, *operand, syntax.sourceRange());
-    };
-
     if (!type->isCastCompatible(*operand->type)) {
         if (!Bitstream::checkClassAccess(*type, context, targetExpr.sourceRange)) {
-            return badExpr(comp, result());
+            return badExpr(comp, result(*operand));
         }
 
         if (operand->kind == ExpressionKind::Streaming) {
@@ -332,20 +339,20 @@ Expression& ConversionExpression::fromSyntax(Compilation& comp, const CastExpres
                 auto& diag = context.addDiag(diag::BadStreamCast, syntax.apostrophe.location());
                 diag << *type;
                 diag << targetExpr.sourceRange << operand->sourceRange;
-                return badExpr(comp, result());
+                return badExpr(comp, result(*operand));
             }
         }
         else if (!type->isBitstreamCastable(*operand->type)) {
             auto& diag = context.addDiag(diag::BadConversion, syntax.apostrophe.location());
             diag << *operand->type << *type;
             diag << targetExpr.sourceRange << operand->sourceRange;
-            return badExpr(comp, result());
+            return badExpr(comp, result(*operand));
         }
         else if (!Bitstream::checkClassAccess(*operand->type, context, operand->sourceRange)) {
-            return badExpr(comp, result());
+            return badExpr(comp, result(*operand));
         }
 
-        return *result(ConversionKind::BitstreamCast);
+        return *result(*operand, ConversionKind::BitstreamCast);
     }
 
     // We have a useless cast if the type of the operand matches what we're casting to, unless:
@@ -396,7 +403,7 @@ Expression& ConversionExpression::fromSyntax(Compilation& comp, const CastExpres
         selfDetermined(context, operand);
     }
 
-    return *result();
+    return *result(*operand);
 }
 
 Expression& ConversionExpression::fromSyntax(Compilation& compilation,

--- a/tests/unittests/ast/ExpressionTests.cpp
+++ b/tests/unittests/ast/ExpressionTests.cpp
@@ -354,6 +354,69 @@ TEST_CASE("Expression types") {
     CHECK(diags[7].code == diag::NotBooleanConvertible);
 }
 
+TEST_CASE("Invalid cast target still binds operand") {
+    auto tree = SyntaxTree::fromText(R"(
+module m;
+    initial missing_t'(missing_value);
+endmodule
+)");
+
+    Compilation compilation;
+    compilation.addSyntaxTree(tree);
+
+    auto& diags = compilation.getAllDiagnostics();
+    REQUIRE(diags.size() == 2);
+    CHECK(diags[0].code == diag::UndeclaredIdentifier);
+    CHECK(diags[1].code == diag::UndeclaredIdentifier);
+}
+
+TEST_CASE("Invalid cast type still binds operand") {
+    auto tree = SyntaxTree::fromText(R"(
+module m;
+    initial struct { int i; }'(missing_value);
+endmodule
+)");
+
+    Compilation compilation;
+    compilation.addSyntaxTree(tree);
+
+    auto& diags = compilation.getAllDiagnostics();
+    REQUIRE(diags.size() == 2);
+    CHECK(diags[0].code == diag::BadCastType);
+    CHECK(diags[1].code == diag::UndeclaredIdentifier);
+}
+
+TEST_CASE("Invalid sized cast width still binds operand") {
+    auto tree = SyntaxTree::fromText(R"(
+module m;
+    initial 16777216'(missing_value);
+endmodule
+)");
+
+    Compilation compilation;
+    compilation.addSyntaxTree(tree);
+
+    auto& diags = compilation.getAllDiagnostics();
+    REQUIRE(diags.size() == 2);
+    CHECK(diags[0].code == diag::ValueExceedsMaxBitWidth);
+    CHECK(diags[1].code == diag::UndeclaredIdentifier);
+}
+
+TEST_CASE("Invalid sized cast operand type") {
+    auto tree = SyntaxTree::fromText(R"(
+module m;
+    initial 4'(1.0);
+endmodule
+)");
+
+    Compilation compilation;
+    compilation.addSyntaxTree(tree);
+
+    auto& diags = compilation.getAllDiagnostics();
+    REQUIRE(diags.size() == 1);
+    CHECK(diags[0].code == diag::BadIntegerCast);
+}
+
 TEST_CASE("Expression - bad name references") {
     auto tree = SyntaxTree::fromText(R"(
 module m1;


### PR DESCRIPTION
Stacked PRs:
 * #1831
 * #1837
 * #1836
 * __->__#1829
 * #1839


--- --- ---


[View individual changes](https://github.com/AndrewNolte/slang/commit/a05d487a2d075376651d4d8fecddf31cfb6fe7e3)
### Expressions: Better bad expressions in ConversionExpression::fromSyntax

