### PR TITLE
SourceLoader: Avoid loading modules twice sometimes in SourceLoader::loadTrees

### DIFF
--- a/source/driver/SourceLoader.cpp
+++ b/source/driver/SourceLoader.cpp
@@ -13,6 +13,7 @@
 #include "slang/syntax/AllSyntax.h"
 #include "slang/syntax/SyntaxTree.h"
 #include "slang/text/SourceManager.h"
+#include "slang/util/SmallVector.h"
 #include "slang/util/String.h"
 #include "slang/util/ThreadPool.h"
 
@@ -388,52 +389,52 @@ void SourceLoader::loadTrees(
     SyntaxTreeList& syntaxTrees, function_ref<SourceBuffer(std::string_view)> findBufferFunc,
     SourceManager& sourceManager, const Bag& optionBag,
     std::span<const syntax::DefineDirectiveSyntax* const> inheritedMacros) {
-    // If library directories are specified, see if we have any unknown instantiations
-    // or package names for which we should search for additional source files to load.
     flat_hash_set<std::string_view> knownNames;
+    flat_hash_set<std::string_view> missingNames;
+    SmallVector<std::string_view, 8> worklist;
+
     auto addKnownNames = [&](const std::shared_ptr<syntax::SyntaxTree>& tree) {
         auto& meta = tree->getMetadata();
-        meta.visitDeclaredSymbols([&](std::string_view name) { knownNames.emplace(name); });
-    };
-
-    auto findMissingNames = [&](const std::shared_ptr<syntax::SyntaxTree>& tree,
-                                flat_hash_set<std::string_view>& missing) {
-        auto& meta = tree->getMetadata();
-        meta.visitReferencedSymbols([&](std::string_view name) {
-            if (knownNames.find(name) == knownNames.end())
-                missing.emplace(name);
+        meta.visitDeclaredSymbols([&](std::string_view name) {
+            knownNames.emplace(name);
+            missingNames.erase(name);
         });
     };
 
+    auto findMissingNames = [&](const std::shared_ptr<syntax::SyntaxTree>& tree) {
+        auto& meta = tree->getMetadata();
+        meta.visitReferencedSymbols([&](std::string_view name) {
+            if (!knownNames.contains(name) && !missingNames.contains(name)) {
+                missingNames.emplace(name);
+                worklist.push_back(name);
+            }
+        });
+    };
+
+    // Initial pass: index existing trees and find what's missing
     for (auto& tree : syntaxTrees)
         addKnownNames(tree);
-
-    flat_hash_set<std::string_view> missingNames;
     for (auto& tree : syntaxTrees)
-        findMissingNames(tree, missingNames);
+        findMissingNames(tree);
 
-    // Keep loading new files as long as we are making forward progress.
-    flat_hash_set<std::string_view> nextMissingNames;
-    while (true) {
-        for (auto name : missingNames) {
-            auto buffer = findBufferFunc(name);
+    // Process the worklist until exhausted
+    while (!worklist.empty()) {
+        std::string_view name = worklist.back();
+        worklist.pop_back();
 
-            if (buffer) {
-                auto tree = syntax::SyntaxTree::fromBuffer(buffer, sourceManager, optionBag,
-                                                           inheritedMacros);
-                tree->isLibraryUnit = true;
-                syntaxTrees.emplace_back(tree);
+        if (knownNames.contains(name))
+            continue;
 
-                addKnownNames(tree);
-                findMissingNames(tree, nextMissingNames);
-            }
+        auto buffer = findBufferFunc(name);
+        if (buffer) {
+            auto tree = syntax::SyntaxTree::fromBuffer(buffer, sourceManager, optionBag,
+                                                       inheritedMacros);
+            tree->isLibraryUnit = true;
+            syntaxTrees.emplace_back(tree);
+
+            addKnownNames(tree);
+            findMissingNames(tree);
         }
-
-        if (nextMissingNames.empty())
-            break;
-
-        missingNames = std::move(nextMissingNames);
-        nextMissingNames = {};
     }
 }
 

--- a/tests/unittests/DriverTests.cpp
+++ b/tests/unittests/DriverTests.cpp
@@ -9,6 +9,7 @@
 #include "slang/ast/symbols/CompilationUnitSymbols.h"
 #include "slang/ast/symbols/InstanceSymbols.h"
 #include "slang/driver/Driver.h"
+#include "slang/driver/SourceLoader.h"
 #include "slang/text/SourceManager.h"
 
 using namespace slang::driver;
@@ -104,6 +105,43 @@ TEST_CASE("Driver command files are processed strictly in order") {
 
     CHECK(fileNames.size() == 4);
     CHECK(std::ranges::is_sorted(fileNames));
+}
+
+TEST_CASE("SourceLoader doesn't reload names satisfied by later worklist entries") {
+    SourceManager sourceManager;
+
+    auto top = SyntaxTree::fromText(R"(
+module top;
+    leaf leaf();
+    mid mid();
+endmodule
+)",
+                                    sourceManager, "", "load_tree_top.sv");
+
+    SourceLoader::SyntaxTreeList trees;
+    trees.push_back(top);
+
+    flat_hash_map<std::string_view, SourceBuffer> buffers;
+    buffers["mid"] = sourceManager.assignText("load_tree_mid.sv", R"(
+module mid;
+endmodule
+module leaf;
+endmodule
+)");
+
+    int leafLookups = 0;
+    SourceLoader::loadTrees(trees,
+                            [&](std::string_view name) {
+                                if (name == "leaf")
+                                    leafLookups++;
+                                if (auto it = buffers.find(name); it != buffers.end())
+                                    return it->second;
+                                return SourceBuffer();
+                            },
+                            sourceManager, {});
+
+    CHECK(leafLookups == 0);
+    CHECK(trees.size() == 2);
 }
 
 static bool contains(std::string_view str, std::string_view value) {


### PR DESCRIPTION
Stacked PRs:
 * #1831
 * #1829
 * #1839
 * #1838
 * #1837
 * #1836
 * #1835
 * #1834
 * #1833
 * __->__#1832
 * #1830


--- --- ---


[View individual changes](https://github.com/AndrewNolte/slang/commit/ece437c1145f15bbc3ae3eb8213d73b4b38313b6)
### SourceLoader: Avoid loading modules twice sometimes in SourceLoader::loadTrees

