### PR TITLE
Preprocessor: prefer ExceededMaxIncludeDepth over CouldNotOpenIncludeFile to avoid reading header file.

### DIFF
--- a/source/parsing/Preprocessor.cpp
+++ b/source/parsing/Preprocessor.cpp
@@ -675,33 +675,37 @@ Trivia Preprocessor::handleIncludeDirective(Token directive) {
         bool isSystem = path[0] == '<';
         path = path.substr(1, path.length() - 2);
 
-        auto buffer = sourceManager.readHeader(path, directive.location(), getCurrentLibrary(),
-                                               isSystem, options.additionalIncludePaths);
-        if (!buffer) {
-            addDiag(diag::CouldNotOpenIncludeFile, fileName.range())
-                << path << buffer.error().message();
-        }
-        else if (includeDepth >= options.maxIncludeDepth) {
+        SourceBuffer sourceBuffer;
+        if (includeDepth >= options.maxIncludeDepth) {
             addDiag(diag::ExceededMaxIncludeDepth, fileName.range());
         }
-        else if (auto onceIt = includeOnceHeaders.find(buffer->data.data());
-                 onceIt == includeOnceHeaders.end() ||
-                 (!onceIt->second.empty() && !isDefined(onceIt->second))) {
-            includeDepth++;
-            hasProtectedCode = false;
-            expectedEndKind = TokenKind::Unknown;
-            pushSource(*buffer);
-
-            includeDirectives.push_back(IncludeMetadata{
-                .syntax = syntax,
-                .path = path,
-                .buffer = *buffer,
-                .isSystem = isSystem,
-            });
+        else {
+            auto buffer = sourceManager.readHeader(path, directive.location(), getCurrentLibrary(),
+                                                   isSystem, options.additionalIncludePaths);
+            if (!buffer) {
+                addDiag(diag::CouldNotOpenIncludeFile, fileName.range())
+                    << path << buffer.error().message();
+            }
+            else if (auto onceIt = includeOnceHeaders.find(buffer->data.data());
+                     onceIt == includeOnceHeaders.end() ||
+                     (!onceIt->second.empty() && !isDefined(onceIt->second))) {
+                includeDepth++;
+                hasProtectedCode = false;
+                expectedEndKind = TokenKind::Unknown;
+                pushSource(*buffer);
+                sourceBuffer = *buffer;
+            }
+            else if (options.bufferChangeCB) {
+                options.bufferChangeCB(buffer->id, false, true);
+                sourceBuffer = *buffer;
+            }
         }
-        else if (options.bufferChangeCB) {
-            options.bufferChangeCB(buffer->id, false, true);
-        }
+        includeDirectives.push_back(IncludeMetadata{
+            .syntax = syntax,
+            .path = path,
+            .buffer = sourceBuffer,
+            .isSystem = isSystem,
+        });
     }
 
     return Trivia(TriviaKind::Directive, syntax);

--- a/tests/unittests/parsing/PreprocessorTests.cpp
+++ b/tests/unittests/parsing/PreprocessorTests.cpp
@@ -3,6 +3,7 @@
 
 #include "Test.h"
 
+#include "slang/diagnostics/PreprocessorDiags.h"
 #include "slang/driver/Driver.h"
 #include "slang/parsing/Parser.h"
 #include "slang/parsing/Preprocessor.h"
@@ -119,7 +120,7 @@ TEST_CASE("Include directive errors") {
     preprocess(text, options);
 
     REQUIRE(diagnostics.size() == 5);
-    CHECK(diagnostics[0].code == diag::CouldNotOpenIncludeFile);
+    CHECK(diagnostics[0].code == diag::ExceededMaxIncludeDepth);
     CHECK(diagnostics[1].code == diag::ExpectedIncludeFileName);
     CHECK(diagnostics[2].code == diag::ExpectedIncludeFileName);
     CHECK(diagnostics[3].code == diag::ExpectedIncludeFileName);


### PR DESCRIPTION
Stacked PRs:
 * #1831
 * #1829
 * #1839
 * #1838
 * #1837
 * #1836
 * __->__#1835
 * #1834
 * #1833
 * #1832
 * #1830


--- --- ---


[View individual changes](https://github.com/AndrewNolte/slang/commit/d859dbeafed0a9719912371f89db048bfa81b59b)
### Preprocessor: prefer ExceededMaxIncludeDepth over CouldNotOpenIncludeFile to avoid reading header file.

