### PR TITLE
Fix attribute segfault

### DIFF
--- a/source/ast/ElabVisitors.h
+++ b/source/ast/ElabVisitors.h
@@ -503,7 +503,10 @@ struct DiagnosticVisitor : public ASTVisitor<DiagnosticVisitor> {
         }
 
         // Visit all attributes and force their values to resolve.
-        for (auto& [_, attrList] : compilation.attributeMap) {
+        // Map is copied in case binding the expression causes map mutation
+        auto attributeMap = compilation.attributeMap;
+
+        for (auto& [_, attrList] : attributeMap) {
             for (auto attr : attrList)
                 attr->getValue();
         }


### PR DESCRIPTION
This was also hit in less contrived examples because of instance caching, but that example was difficult to reproduce reliably.