### PR TITLE
Allow legacy cross_auto_bin_max coverage option

### DIFF
--- a/bindings/python/CompBindings.cpp
+++ b/bindings/python/CompBindings.cpp
@@ -69,6 +69,7 @@ void registerCompilation(py::module_& m, py::module_& ast, py::module_& driver) 
         .value("AllowUnnamedGenerate", CompilationFlags::AllowUnnamedGenerate)
         .value("AllowVirtualIfaceWithOverride", CompilationFlags::AllowVirtualIfaceWithOverride)
         .value("AllowArrayConcatAssignPattern", CompilationFlags::AllowArrayConcatAssignPattern)
+        .value("AllowCrossAutoBinMax", CompilationFlags::AllowCrossAutoBinMax)
         .finalize();
 
     py::classh<CompilationOptions>(ast, "CompilationOptions")

--- a/docs/command-line-ref.dox
+++ b/docs/command-line-ref.dox
@@ -662,6 +662,16 @@ redefinition produces a `duplicate-definition` warning and a different-kind rede
 
 This option is enabled automatically when `--compat=vcs` or `--compat=all` is used.
 
+`--allow-cross-auto-bin-max`
+
+Allow the legacy `cross_auto_bin_max` coverage option to be set on covergroups and crosses.
+This option was part of the SystemVerilog 3.1a coverage option set but was removed from
+IEEE 1800; some tools still accept it for compatibility with older code. When this flag is
+set, the option is accepted and parsed but has no effect (slang does not compute coverage
+bins at elaboration).
+
+This option is enabled automatically when `--compat=vcs` or `--compat=all` is used.
+
 `--cmd-ignore <vendor_cmd>,<N>`
 
 Define rule to ignore vendor command &lt;vendor_cmd> with its following &lt;N> parameters.

--- a/include/slang/ast/Compilation.h
+++ b/include/slang/ast/Compilation.h
@@ -130,9 +130,14 @@ enum class SLANG_EXPORT CompilationFlags {
     AllowLibModuleRedefinition = 1 << 16,
 
     /// Don't instantiate unreferenced modules to perform semantic checking on them.
-    IgnoreUninstantiatedModules = 1 << 17
+    IgnoreUninstantiatedModules = 1 << 17,
+
+    /// Allow the legacy `cross_auto_bin_max` coverage option to be set on covergroups
+    /// and crosses. This option was part of SystemVerilog 3.1a but is not in IEEE 1800;
+    /// some tools still accept it for compatibility with older code.
+    AllowCrossAutoBinMax = 1 << 18
 };
-SLANG_BITMASK(CompilationFlags, IgnoreUninstantiatedModules)
+SLANG_BITMASK(CompilationFlags, AllowCrossAutoBinMax)
 
 /// Contains various options that can control compilation behavior.
 struct SLANG_EXPORT CompilationOptions {

--- a/source/ast/symbols/CoverSymbols.cpp
+++ b/source/ast/symbols/CoverSymbols.cpp
@@ -171,6 +171,8 @@ CovergroupBodySymbol::CovergroupBodySymbol(Compilation& comp, SourceLocation loc
     option.addField("comment"sv, string_t);
     option.addField("at_least"sv, int_t);
     option.addField("auto_bin_max"sv, int_t, VariableFlags::ImmutableCoverageOption);
+    if (comp.hasFlag(CompilationFlags::AllowCrossAutoBinMax))
+        option.addField("cross_auto_bin_max"sv, int_t, VariableFlags::ImmutableCoverageOption);
     option.addField("cross_num_print_missing"sv, int_t);
     if (lv >= LanguageVersion::v1800_2023)
         option.addField("cross_retain_auto_bins"sv, bit_t, VariableFlags::ImmutableCoverageOption);
@@ -908,6 +910,8 @@ CoverCrossSymbol::CoverCrossSymbol(Compilation& comp, std::string_view name, Sou
     option.addField("goal"sv, int_t);
     option.addField("comment"sv, string_t);
     option.addField("at_least"sv, int_t);
+    if (comp.hasFlag(CompilationFlags::AllowCrossAutoBinMax))
+        option.addField("cross_auto_bin_max"sv, int_t, VariableFlags::ImmutableCoverageOption);
     option.addField("cross_num_print_missing"sv, int_t);
     if (lv >= LanguageVersion::v1800_2023)
         option.addField("cross_retain_auto_bins"sv, bit_t, VariableFlags::ImmutableCoverageOption);

--- a/source/driver/CompatSettings.cpp
+++ b/source/driver/CompatSettings.cpp
@@ -36,7 +36,8 @@ using namespace analysis;
     CompilationFlags::AllowSelfDeterminedStreamConcat, \
     CompilationFlags::AllowMergingAnsiPorts, \
     CompilationFlags::AllowArrayConcatAssignPattern, \
-    CompilationFlags::AllowLibModuleRedefinition
+    CompilationFlags::AllowLibModuleRedefinition, \
+    CompilationFlags::AllowCrossAutoBinMax
 
 static constexpr CompilationFlags vcsCompFlags[] = {VCS_COMP_FLAGS};
 static constexpr CompilationFlags allCompFlags[] = {

--- a/source/driver/Driver.cpp
+++ b/source/driver/Driver.cpp
@@ -262,6 +262,9 @@ void Driver::addStandardArgs() {
                 "primitive at the root scope within the same library when the conflicting "
                 "definition comes from a library file (-v / --libfile); the first definition "
                 "is kept and subsequent library-file redefinitions are silently discarded");
+    addCompFlag(CompilationFlags::AllowCrossAutoBinMax, "--allow-cross-auto-bin-max",
+                "Allow the legacy SystemVerilog 3.1a cross_auto_bin_max coverage option to "
+                "be set on covergroups and crosses. The option is accepted and ignored.");
 
     cmdLine.add("--top", options.topModules,
                 "One or more top-level modules to instantiate "

--- a/tests/unittests/ast/CoverTests.cpp
+++ b/tests/unittests/ast/CoverTests.cpp
@@ -882,3 +882,81 @@ endmodule
     REQUIRE(diags.size() == 1);
     CHECK(diags[0].code == diag::CrossIdentInBinsof);
 }
+
+TEST_CASE("Legacy cross_auto_bin_max option -- error without flag") {
+    auto tree = SyntaxTree::fromText(R"(
+module m;
+    bit clk;
+    logic [1:0] a, b;
+    covergroup cg @(posedge clk);
+        cp_a : coverpoint a;
+        cp_b : coverpoint b;
+        x : cross cp_a, cp_b {
+            option.cross_auto_bin_max = 0;
+        }
+    endgroup
+    cg c = new;
+endmodule
+)");
+
+    Compilation compilation;
+    compilation.addSyntaxTree(tree);
+
+    auto& diags = compilation.getAllDiagnostics();
+    REQUIRE(diags.size() == 1);
+    CHECK(diags[0].code == diag::UnknownMember);
+}
+
+TEST_CASE("Legacy cross_auto_bin_max option -- allowed with flag at covergroup and cross scope") {
+    // SystemVerilog 3.1a Table 20-2: cross_auto_bin_max is allowed at covergroup
+    // scope (as default for crosses) and at cross scope.
+    auto tree = SyntaxTree::fromText(R"(
+module m;
+    bit clk;
+    logic [1:0] a, b;
+    covergroup cg @(posedge clk);
+        option.cross_auto_bin_max = 32;
+        cp_a : coverpoint a;
+        cp_b : coverpoint b;
+        x : cross cp_a, cp_b {
+            option.cross_auto_bin_max = 0;
+        }
+    endgroup
+    cg c = new;
+endmodule
+)");
+
+    CompilationOptions options;
+    options.flags |= CompilationFlags::AllowCrossAutoBinMax;
+
+    Compilation compilation(options);
+    compilation.addSyntaxTree(tree);
+    NO_COMPILATION_ERRORS;
+}
+
+TEST_CASE("Legacy cross_auto_bin_max option -- still rejected at coverpoint scope") {
+    // SystemVerilog 3.1a Table 20-2: cross_auto_bin_max is not allowed at
+    // coverpoint scope even in 3.1a.
+    auto tree = SyntaxTree::fromText(R"(
+module m;
+    bit clk;
+    logic [1:0] a;
+    covergroup cg @(posedge clk);
+        cp_a : coverpoint a {
+            option.cross_auto_bin_max = 0;
+        }
+    endgroup
+    cg c = new;
+endmodule
+)");
+
+    CompilationOptions options;
+    options.flags |= CompilationFlags::AllowCrossAutoBinMax;
+
+    Compilation compilation(options);
+    compilation.addSyntaxTree(tree);
+
+    auto& diags = compilation.getAllDiagnostics();
+    REQUIRE(diags.size() == 1);
+    CHECK(diags[0].code == diag::UnknownMember);
+}


### PR DESCRIPTION
## Summary

Fixes #1843. Adds `--allow-cross-auto-bin-max` so legacy code that uses the SystemVerilog 3.1a `cross_auto_bin_max` coverage option compiles under slang. The issue has the full background (3.1a Table 20-2, commercial tool behavior, reproducer); this PR is just the implementation.

## Design

- New `CompilationFlags::AllowCrossAutoBinMax` flag. When set, adds `cross_auto_bin_max` to the implicit `option` struct on covergroup body and cross, marked `ImmutableCoverageOption` to match the existing `auto_bin_max`. Coverpoint scope is left as-is per 3.1a Table 20-2.
- `--allow-cross-auto-bin-max` is also added to `VCS_COMP_FLAGS`, so `--compat=vcs` and `--compat=all` enable it automatically. Same wiring as `--allow-lib-module-redef` and friends.
- slang doesn't compute coverage bins at elaboration, so the field is accepted and parsed but otherwise inert. That's enough to make the legacy syntax accepted, which is what the issue asked for.

## Testing

Three unit tests in `CoverTests.cpp`:
- without the flag, the issue's reproducer still errors with `UnknownMember`
- with the flag, the option works at both covergroup and cross scope
- with the flag, coverpoint scope still rejects

## AI disclosure

Per the project's CONTRIBUTING.md: parts of this patch were drafted with assistance from Claude. I reviewed every line and am fully accountable for the change.
