### PR TITLE
all-or-nothing boost detection

### DIFF
--- a/include/slang/util/ConcurrentMap.h
+++ b/include/slang/util/ConcurrentMap.h
@@ -10,7 +10,8 @@
 #include "slang/util/Hash.h"
 
 #define BOOST_UNORDERED_DISABLE_PARALLEL_ALGORITHMS
-#if __has_include(<boost/unordered/concurrent_flat_map.hpp>)
+#if __has_include(<boost/unordered/concurrent_flat_map.hpp>) && \
+    __has_include(<boost/unordered/unordered_flat_map.hpp>)
 #    include <boost/unordered/concurrent_flat_map.hpp>
 #    include <boost/unordered/concurrent_flat_set.hpp>
 #else

--- a/include/slang/util/FlatMap.h
+++ b/include/slang/util/FlatMap.h
@@ -9,7 +9,8 @@
 
 #include "slang/util/Hash.h"
 
-#if __has_include(<boost/unordered/unordered_flat_map.hpp>)
+#if __has_include(<boost/unordered/unordered_flat_map.hpp>) && \
+    __has_include(<boost/unordered/concurrent_flat_map.hpp>)
 #    include <boost/unordered/unordered_flat_map.hpp>
 #    include <boost/unordered/unordered_flat_set.hpp>
 #else


### PR DESCRIPTION
Redefinition errors abound on systems with one but not the other.