### PR TITLE
Narrow mustBeChecker heuristic to tolerate empty port connections

### DIFF
--- a/source/ast/symbols/InstanceSymbols.cpp
+++ b/source/ast/symbols/InstanceSymbols.cpp
@@ -1380,6 +1380,15 @@ std::span<const AssertionExpr* const> UninstantiatedDefSymbol::getPortConnection
         portNames = names.copy(comp);
 
         for (auto port : *ports) {
+            // An InvalidAssertionExpr represents an empty/unconnected
+            // port connection (`.foo()`) — legal SystemVerilog, NOT a
+            // checker marker. The original heuristic mis-classified
+            // any uninstantiated module with an unconnected port as a
+            // checker because `Invalid != Simple` flipped the flag.
+            // Tolerate Invalid explicitly. The strict checker
+            // fingerprint is "non-Simple AND non-Invalid".
+            if (port->kind == AssertionExprKind::Invalid)
+                continue;
             if (port->kind != AssertionExprKind::Simple ||
                 port->as<SimpleAssertionExpr>().repetition) {
                 mustBeChecker = true;


### PR DESCRIPTION
## Summary

`UninstantiatedDefSymbol::getPortConnections()` classifies an uninstantiated module as "must be a checker" if any of its port connections is not a Simple `AssertionExpr`. The intent is to detect the checker-specific port grammar (clocking events, sequences, etc.).

An empty port connection `.foo()` is legal SystemVerilog on a non-checker module: it leaves the port unconnected. The binding code stores it as an `InvalidAssertionExpr(nullptr)` at line 1368 of this file. The heuristic at line 1382-1388 then sees `kind != AssertionExprKind::Simple` and flips `mustBeChecker = true` — even though `Invalid` is the "no connection at all" sentinel, not a checker-specific construct.

Downstream consumers (yosys-slang, Verilator-uvm, slang-tidy) that gate on `isChecker()` then refuse to elaborate the module, producing diagnostics like "checker constructs aren't supported yet" on plain Verilog with a forgotten port.

## Fix

Narrow the heuristic: an `Invalid` port no longer contributes to checker classification. The strict checker fingerprint becomes "non-Simple AND non-Invalid". A real checker's port — Clocking, Sequence, or a Simple with a repetition — still flips the flag.

```diff
 for (auto port : *ports) {
+    // An InvalidAssertionExpr represents an empty/unconnected
+    // port connection (`.foo()`) — legal SystemVerilog, NOT a
+    // checker marker. Tolerate Invalid explicitly. The strict
+    // checker fingerprint is "non-Simple AND non-Invalid".
+    if (port->kind == AssertionExprKind::Invalid)
+        continue;
     if (port->kind != AssertionExprKind::Simple ||
         port->as<SimpleAssertionExpr>().repetition) {
         mustBeChecker = true;
         break;
     }
 }
```

## Repro

```sv
module thing(input logic clk, output logic out);
endmodule

module top;
  logic clk;
  thing inst(.clk(clk), .out());   // <-- empty port connection
endmodule
```

Pre-patch: any consumer of slang's AST that gates on `UninstantiatedDefSymbol::isChecker()` mis-classifies `inst`.
Post-patch: `inst` is correctly classified as a non-checker.

## Real-world impact

CVA6 (Ariane), ETHZ's open-source RV64GC application-class RISC-V core, instantiates `cva6_hpdcache_subsystem` at `cva6.sv:1503` with `.hwpf_base_o(/*FIXME*/)`. The unconnected port flipped `mustBeChecker=true`, yosys-slang then bailed with `LangFeatureUnsupported`, and the entire CVA6 elaboration path was blocked.

Discovered while building an AI-driven power-minimization tool (Autopoietix Pwrtaur) that runs corpus-validate across the four major permissive RISC-V cores (picoRV32, CV32E40P, Snitch, CVA6). The same surface affects any large SystemVerilog design with deliberately-unconnected output ports.

## Related

Companion PR on yosys-slang (povik/yosys-slang#326) silences a separate diagnostic that blocks type-parametric blackbox stubs. Either PR can land independently; together they unblock CVA6 elaboration via `yosys -m slang`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)