### PR TITLE
pyslang: Check for more invalid names for Enum members

### DIFF
--- a/bindings/python/pyslang.h
+++ b/bindings/python/pyslang.h
@@ -41,6 +41,10 @@ using namespace slang::ast;
             std::string nameStr = std::string(toString(member)); \
             if (nameStr == "None")                               \
                 nameStr = "None_";                               \
+            if (nameStr == "and")                                \
+                nameStr = "and_";                                \
+            if (nameStr == "or")                                 \
+                nameStr = "or_";                                 \
             e.value(nameStr.c_str(), member);                    \
         }                                                        \
         e.finalize();                                            \


### PR DESCRIPTION
Adds checks for "and" and "or" to the existing check for "None" when exposing an Enum. If these are not modified, the stub file that is generated causes issues with type checkers as it has syntax errors with those members.