### PR TITLE
Driver: Fix include files being added to module deps

### DIFF
--- a/source/driver/Driver.cpp
+++ b/source/driver/Driver.cpp
@@ -966,6 +966,11 @@ void Driver::optionallyWriteDepFiles() {
     if (!options.includeDepfile && !options.moduleDepfile && !options.allDepfile)
         return;
 
+    if (options.depfileTrim == true && options.singleUnit.value_or(false)) {
+        printError("--depfile-trim cannot be combined with --single-unit");
+        return;
+    }
+
     std::vector<const SyntaxTree*> depTrees;
     if (options.depfileTrim == true || options.depfileSort == true) {
         depTrees = getSortedDependencies(*this, syntaxTrees, options.depfileTrim == true);
@@ -1003,12 +1008,12 @@ void Driver::optionallyWriteDepFiles() {
     flat_hash_set<fs::path> seenPaths;
     if (options.includeDepfile || options.allDepfile) {
         for (auto& tree : depTrees) {
-            for (auto& inc : tree->getIncludeDirectives()) {
-                if (inc.isSystem)
-                    continue;
-
-                auto p = sourceManager.getFullPath(inc.buffer.id);
-                if (seenPaths.insert(p).second)
+            auto bufferIds = tree->getSourceBufferIds();
+            // The first id is the top-level source file; the rest were pushed
+            // via `include directives.
+            for (size_t i = 1; i < bufferIds.size(); ++i) {
+                auto p = sourceManager.getFullPath(bufferIds[i]);
+                if (!p.empty() && seenPaths.insert(p).second)
                     includePaths.emplace_back(getProximatePathStr(p));
             }
         }
@@ -1020,8 +1025,9 @@ void Driver::optionallyWriteDepFiles() {
     std::vector<std::string> modulePaths;
     if (options.moduleDepfile || options.allDepfile) {
         for (auto& tree : depTrees) {
-            for (auto bufferId : tree->getSourceBufferIds()) {
-                auto path = sourceManager.getFullPath(bufferId);
+            auto bufferIds = tree->getSourceBufferIds();
+            if (!bufferIds.empty()) {
+                auto path = sourceManager.getFullPath(bufferIds.front());
                 if (!path.empty())
                     modulePaths.emplace_back(getProximatePathStr(path));
             }

--- a/tests/regression/driver/dep-files-system-include.sv
+++ b/tests/regression/driver/dep-files-system-include.sv
@@ -1,0 +1,15 @@
+// SPDX-FileCopyrightText: Michael Popoloski
+// SPDX-License-Identifier: MIT
+
+// A `include <foo>` system-style include that resolves through --isystem is a
+// real build dependency and should appear in the depfile, just like a `include
+// "foo"`. Previously the depfile writer dropped all system includes.
+// RUN: %slang %s --isystem %data --Mall - 2>&1
+// CHECK: file_defn.svh
+// CHECK-NEXT: dep-files-system-include.sv
+
+`include <file_defn.svh>
+
+module m;
+    string s = `FOO;
+endmodule

--- a/tests/regression/driver/dep-files.sv
+++ b/tests/regression/driver/dep-files.sv
@@ -9,9 +9,11 @@
 
 // RUN: %slang %s -I %data --Mmodule - 2>&1
 // CHECK: dep-files.sv
+// CHECK-NOT: file_defn.svh
 
 // RUN: %slang %s -I %data --Mmodule - --depfile-target target 2>&1
 // CHECK: target:{{.*}}dep-files.sv
+// CHECK-NOT: file_defn.svh
 
 // RUN: %slang %s -I %data --Mall - 2>&1
 // CHECK: file_defn.svh
@@ -19,6 +21,10 @@
 
 // RUN: %slang %s -I %data --Mall - --depfile-target target 2>&1
 // CHECK: target:{{.*}}file_defn.svh{{.*}}dep-files.sv
+
+// --depfile-trim is incompatible with --single-unit; combining them errors out.
+// RUN: %slang %s --single-unit --depfile-trim --Mmodule - --top m 2>&1 || true
+// CHECK: --depfile-trim cannot be combined with --single-unit
 
 `include "file_defn.svh"
 `define ID(x) x


### PR DESCRIPTION
Stacked PRs:
 * #1855
 * __->__#1854


--- --- ---

This was a regression from https://github.com/MikePopoloski/slang/pull/1836, since included buffer ids were added to the list now.


[View individual changes](https://github.com/AndrewNolte/slang/commit/8e2179a15aefbdca95e7d3ceddcd245c60916a80)
### Driver: Fix include files being added to module deps

