### PR TITLE
Parallelize library search parsing with -j

### DIFF
--- a/include/slang/driver/SourceLoader.h
+++ b/include/slang/driver/SourceLoader.h
@@ -175,12 +175,17 @@ public:
     /// Find a source buffer by searching through libraries added via -y
     SourceBuffer findBuffer(std::string_view name) const;
 
-    /// Load trees using a custom buffer finder function
+    /// Load trees using a custom buffer finder function.
+    ///
+    /// If a thread pool is provided, each dependency depth can be parsed speculatively
+    /// in parallel. Trees are still merged in the same fixed-point worklist order as
+    /// the serial path.
     /// Result is stored in the same syntaxTree list
     static void loadTrees(
         SyntaxTreeList& syntaxTrees, function_ref<SourceBuffer(std::string_view)> findBufferFunc,
         SourceManager& sourceManager, const Bag& optionBag,
-        std::span<const syntax::DefineDirectiveSyntax* const> inheritedMacros = {});
+        std::span<const syntax::DefineDirectiveSyntax* const> inheritedMacros = {},
+        ThreadPool* pool = nullptr);
 
 private:
     // One entry per unit of files + options to compile them.

--- a/include/slang/driver/SourceLoader.h
+++ b/include/slang/driver/SourceLoader.h
@@ -175,11 +175,7 @@ public:
     /// Find a source buffer by searching through libraries added via -y
     SourceBuffer findBuffer(std::string_view name) const;
 
-    /// Load trees using a custom buffer finder function.
-    ///
-    /// If a thread pool is provided, each dependency depth can be parsed speculatively
-    /// in parallel. Trees are still merged in the same fixed-point worklist order as
-    /// the serial path.
+    /// Load trees using a custom buffer finder function
     /// Result is stored in the same syntaxTree list
     static void loadTrees(
         SyntaxTreeList& syntaxTrees, function_ref<SourceBuffer(std::string_view)> findBufferFunc,

--- a/source/driver/SourceLoader.cpp
+++ b/source/driver/SourceLoader.cpp
@@ -8,6 +8,7 @@
 #include "slang/driver/SourceLoader.h"
 
 #include <fmt/core.h>
+#include <iterator>
 
 #include "slang/parsing/Preprocessor.h"
 #include "slang/syntax/AllSyntax.h"
@@ -433,8 +434,8 @@ void SourceLoader::loadTrees(SyntaxTreeList& syntaxTrees,
         findMissingNames(addedTree);
     };
 
-    // Keep the worklist as a LIFO stack. Parallel batches can parse ahead, but trees are
-    // still committed one at a time in the same order as the serial fixed-point search.
+    // The worklist is a LIFO stack. Parsed batches are committed one tree at a time so
+    // newly discovered names can take precedence over older pending loads.
     while (!worklist.empty()) {
         if (!pool || worklist.size() < MinFilesForThreading) {
             auto load = std::move(worklist.back());
@@ -453,10 +454,10 @@ void SourceLoader::loadTrees(SyntaxTreeList& syntaxTrees,
         std::vector<PendingLoad> batch;
         batch.swap(worklist);
 
-        // Buffer lookup stays serial; only parsing the found buffers runs concurrently.
+        // Fill buffers before launching workers so findBufferFunc is only called here.
         std::vector<SourceBuffer> buffers(batch.size());
         for (size_t i = 0; i < batch.size(); i++) {
-            if (!knownNames.contains(batch[i].name) && !batch[i].tree)
+            if (!batch[i].tree && !knownNames.contains(batch[i].name))
                 buffers[i] = findBufferFunc(batch[i].name);
         }
 
@@ -467,7 +468,7 @@ void SourceLoader::loadTrees(SyntaxTreeList& syntaxTrees,
         pool->wait();
 
         for (size_t i = batch.size(); i-- > 0;) {
-            if (knownNames.contains(batch[i].name) || !batch[i].tree)
+            if (!batch[i].tree || knownNames.contains(batch[i].name))
                 continue;
 
             addTree(std::move(batch[i].tree));
@@ -475,16 +476,14 @@ void SourceLoader::loadTrees(SyntaxTreeList& syntaxTrees,
                 std::vector<PendingLoad> newLoads;
                 newLoads.swap(worklist);
 
-                // New names discovered by this tree must be processed before older parsed
-                // pending loads. Push the older loads first so the new loads end up on top
-                // of the LIFO stack.
+                // Keep the new work above older parsed loads on the stack.
                 for (size_t j = 0; j < i; j++) {
                     if (batch[j].tree && !knownNames.contains(batch[j].name))
                         worklist.push_back(std::move(batch[j]));
                 }
 
-                for (auto& load : newLoads)
-                    worklist.push_back(std::move(load));
+                worklist.insert(worklist.end(), std::make_move_iterator(newLoads.begin()),
+                                std::make_move_iterator(newLoads.end()));
                 break;
             }
         }

--- a/source/driver/SourceLoader.cpp
+++ b/source/driver/SourceLoader.cpp
@@ -412,7 +412,7 @@ void SourceLoader::loadTrees(SyntaxTreeList& syntaxTrees,
         auto& meta = tree->getMetadata();
         meta.visitReferencedSymbols([&](std::string_view name) {
             if (!knownNames.contains(name) && missingNames.emplace(name).second)
-                worklist.push_back({name});
+                worklist.push_back({name, nullptr});
         });
     };
 

--- a/source/driver/SourceLoader.cpp
+++ b/source/driver/SourceLoader.cpp
@@ -392,8 +392,12 @@ void SourceLoader::loadTrees(SyntaxTreeList& syntaxTrees,
                              ThreadPool* pool) {
     flat_hash_set<std::string_view> knownNames;
     flat_hash_set<std::string_view> missingNames;
-    flat_hash_map<std::string_view, std::shared_ptr<SyntaxTree>> parsedTreeCache;
-    SmallVector<std::string_view, 8> worklist;
+    struct PendingLoad {
+        std::string_view name;
+        std::shared_ptr<SyntaxTree> tree;
+    };
+
+    std::vector<PendingLoad> worklist;
 
     auto addKnownNames = [&](const std::shared_ptr<SyntaxTree>& tree) {
         auto& meta = tree->getMetadata();
@@ -407,7 +411,7 @@ void SourceLoader::loadTrees(SyntaxTreeList& syntaxTrees,
         auto& meta = tree->getMetadata();
         meta.visitReferencedSymbols([&](std::string_view name) {
             if (!knownNames.contains(name) && missingNames.emplace(name).second)
-                worklist.push_back(name);
+                worklist.push_back({name});
         });
     };
 
@@ -418,123 +422,69 @@ void SourceLoader::loadTrees(SyntaxTreeList& syntaxTrees,
         findMissingNames(tree);
 
     auto parseBuffer = [&](const SourceBuffer& buffer) {
-        auto tree = syntax::SyntaxTree::fromBuffer(buffer, sourceManager, optionBag,
-                                                   inheritedMacros);
+        auto tree = SyntaxTree::fromBuffer(buffer, sourceManager, optionBag, inheritedMacros);
         tree->isLibraryUnit = true;
         return tree;
     };
 
     auto addTree = [&](std::shared_ptr<SyntaxTree> tree) {
-        syntaxTrees.emplace_back(std::move(tree));
-        addKnownNames(syntaxTrees.back());
-        findMissingNames(syntaxTrees.back());
+        auto& addedTree = syntaxTrees.emplace_back(std::move(tree));
+        addKnownNames(addedTree);
+        findMissingNames(addedTree);
     };
 
-    auto loadTree = [&](std::string_view name) {
-        if (knownNames.contains(name)) {
-            parsedTreeCache.erase(name);
-            return;
-        }
-
-        if (auto it = parsedTreeCache.find(name); it != parsedTreeCache.end()) {
-            auto tree = std::move(it->second);
-            parsedTreeCache.erase(it);
-            addTree(std::move(tree));
-            return;
-        }
-
-        if (auto buffer = findBufferFunc(name)) {
-            auto tree = parseBuffer(buffer);
-            addTree(std::move(tree));
-        }
-    };
-
-    struct PendingTree {
-        std::string_view name;
-        SourceBuffer buffer;
-        std::shared_ptr<SyntaxTree> tree;
-    };
-
-    // Process the worklist until exhausted
+    // Keep the worklist as a LIFO stack. Parallel batches can parse ahead, but trees are
+    // still committed one at a time in the same order as the serial fixed-point search.
     while (!worklist.empty()) {
         if (!pool || worklist.size() < MinFilesForThreading) {
-            auto name = worklist.back();
+            auto load = std::move(worklist.back());
             worklist.pop_back();
-            loadTree(name);
+
+            if (knownNames.contains(load.name))
+                continue;
+
+            if (load.tree)
+                addTree(std::move(load.tree));
+            else if (auto buffer = findBufferFunc(load.name))
+                addTree(parseBuffer(buffer));
             continue;
         }
 
-        SmallVector<std::string_view, 8> depthNames;
-        while (!worklist.empty()) {
-            depthNames.push_back(worklist.back());
-            worklist.pop_back();
+        std::vector<PendingLoad> batch;
+        batch.swap(worklist);
+
+        // Buffer lookup stays serial; only parsing the found buffers runs concurrently.
+        std::vector<SourceBuffer> buffers(batch.size());
+        for (size_t i = 0; i < batch.size(); i++) {
+            if (!knownNames.contains(batch[i].name) && !batch[i].tree)
+                buffers[i] = findBufferFunc(batch[i].name);
         }
 
-        std::vector<PendingTree> pendingTrees;
-        pendingTrees.reserve(depthNames.size());
-        size_t parseCount = 0;
-        for (auto name : depthNames) {
-            if (knownNames.contains(name))
+        pool->detach_loop(size_t(0), batch.size(), [&](size_t i) {
+            if (buffers[i])
+                batch[i].tree = parseBuffer(buffers[i]);
+        });
+        pool->wait();
+
+        for (size_t i = batch.size(); i-- > 0;) {
+            if (knownNames.contains(batch[i].name) || !batch[i].tree)
                 continue;
 
-            if (auto it = parsedTreeCache.find(name); it != parsedTreeCache.end()) {
-                pendingTrees.push_back({name, {}, std::move(it->second)});
-                parsedTreeCache.erase(it);
-            }
-            else if (auto buffer = findBufferFunc(name)) {
-                pendingTrees.push_back({name, buffer, nullptr});
-                parseCount++;
-            }
-        }
-
-        if (pendingTrees.empty())
-            continue;
-
-        auto parseDepthBuffer = [&](size_t i) {
-            if (!pendingTrees[i].tree)
-                pendingTrees[i].tree = parseBuffer(pendingTrees[i].buffer);
-        };
-
-        if (parseCount >= MinFilesForThreading) {
-            pool->detach_loop(size_t(0), pendingTrees.size(), parseDepthBuffer);
-            pool->wait();
-        }
-        else {
-            for (size_t i = 0; i < pendingTrees.size(); i++)
-                parseDepthBuffer(i);
-        }
-
-        for (size_t i = 0; i < pendingTrees.size(); i++) {
-            if (knownNames.contains(pendingTrees[i].name))
-                continue;
-
-            if (!pendingTrees[i].tree)
-                continue;
-
-            addTree(std::move(pendingTrees[i].tree));
+            addTree(std::move(batch[i].tree));
             if (!worklist.empty()) {
-                SmallVector<std::string_view, 8> newNames;
-                while (!worklist.empty()) {
-                    newNames.push_back(worklist.back());
-                    worklist.pop_back();
+                std::vector<PendingLoad> newLoads;
+                newLoads.swap(worklist);
+
+                // New names discovered by this tree must be processed before older parsed
+                // pending loads. Push the older loads first so the new loads end up on top
+                // of the LIFO stack.
+                for (size_t j = 0; j < i; j++) {
+                    if (batch[j].tree && !knownNames.contains(batch[j].name))
+                        worklist.push_back(std::move(batch[j]));
                 }
 
-                // New names discovered by this tree must be processed before the older
-                // pending names to preserve the serial fixed-point order. Keep already
-                // parsed trees cached so we don't have to find or parse them again later.
-                for (size_t j = pendingTrees.size() - 1; j > i; j--) {
-                    auto& pending = pendingTrees[j];
-                    if (!pending.tree || knownNames.contains(pending.name))
-                        continue;
-
-                    parsedTreeCache[pending.name] = std::move(pending.tree);
-                    worklist.push_back(pending.name);
-                }
-
-                while (!newNames.empty()) {
-                    worklist.push_back(newNames.back());
-                    newNames.pop_back();
-                }
+                for (auto& load : newLoads)
+                    worklist.push_back(std::move(load));
                 break;
             }
         }

--- a/source/driver/SourceLoader.cpp
+++ b/source/driver/SourceLoader.cpp
@@ -370,7 +370,7 @@ SourceLoader::SyntaxTreeList SourceLoader::loadAndParseSources(const Bag& option
     if (!searchDirectories.empty()) {
         loadTrees(
             syntaxTrees, [this](std::string_view name) { return findBuffer(name); }, sourceManager,
-            optionBag, inheritedMacros);
+            optionBag, inheritedMacros, pool);
     }
 
     // Collect per-buffer warning options from all separate compilation units.
@@ -388,9 +388,11 @@ SourceLoader::SyntaxTreeList SourceLoader::loadAndParseSources(const Bag& option
 void SourceLoader::loadTrees(SyntaxTreeList& syntaxTrees,
                              function_ref<SourceBuffer(std::string_view)> findBufferFunc,
                              SourceManager& sourceManager, const Bag& optionBag,
-                             std::span<const DefineDirectiveSyntax* const> inheritedMacros) {
+                             std::span<const DefineDirectiveSyntax* const> inheritedMacros,
+                             ThreadPool* pool) {
     flat_hash_set<std::string_view> knownNames;
     flat_hash_set<std::string_view> missingNames;
+    flat_hash_map<std::string_view, std::shared_ptr<SyntaxTree>> parsedTreeCache;
     SmallVector<std::string_view, 8> worklist;
 
     auto addKnownNames = [&](const std::shared_ptr<SyntaxTree>& tree) {
@@ -415,22 +417,126 @@ void SourceLoader::loadTrees(SyntaxTreeList& syntaxTrees,
     for (auto& tree : syntaxTrees)
         findMissingNames(tree);
 
-    // Process the worklist until exhausted
-    while (!worklist.empty()) {
-        std::string_view name = worklist.back();
-        worklist.pop_back();
+    auto parseBuffer = [&](const SourceBuffer& buffer) {
+        auto tree = syntax::SyntaxTree::fromBuffer(buffer, sourceManager, optionBag,
+                                                   inheritedMacros);
+        tree->isLibraryUnit = true;
+        return tree;
+    };
 
-        if (knownNames.contains(name))
-            continue;
+    auto addTree = [&](std::shared_ptr<SyntaxTree> tree) {
+        syntaxTrees.emplace_back(std::move(tree));
+        addKnownNames(syntaxTrees.back());
+        findMissingNames(syntaxTrees.back());
+    };
+
+    auto loadTree = [&](std::string_view name) {
+        if (knownNames.contains(name)) {
+            parsedTreeCache.erase(name);
+            return;
+        }
+
+        if (auto it = parsedTreeCache.find(name); it != parsedTreeCache.end()) {
+            auto tree = std::move(it->second);
+            parsedTreeCache.erase(it);
+            addTree(std::move(tree));
+            return;
+        }
 
         if (auto buffer = findBufferFunc(name)) {
-            auto tree = syntax::SyntaxTree::fromBuffer(buffer, sourceManager, optionBag,
-                                                       inheritedMacros);
-            tree->isLibraryUnit = true;
-            syntaxTrees.emplace_back(tree);
+            auto tree = parseBuffer(buffer);
+            addTree(std::move(tree));
+        }
+    };
 
-            addKnownNames(tree);
-            findMissingNames(tree);
+    struct PendingTree {
+        std::string_view name;
+        SourceBuffer buffer;
+        std::shared_ptr<SyntaxTree> tree;
+    };
+
+    // Process the worklist until exhausted
+    while (!worklist.empty()) {
+        if (!pool || worklist.size() < MinFilesForThreading) {
+            auto name = worklist.back();
+            worklist.pop_back();
+            loadTree(name);
+            continue;
+        }
+
+        SmallVector<std::string_view, 8> depthNames;
+        while (!worklist.empty()) {
+            depthNames.push_back(worklist.back());
+            worklist.pop_back();
+        }
+
+        std::vector<PendingTree> pendingTrees;
+        pendingTrees.reserve(depthNames.size());
+        size_t parseCount = 0;
+        for (auto name : depthNames) {
+            if (knownNames.contains(name))
+                continue;
+
+            if (auto it = parsedTreeCache.find(name); it != parsedTreeCache.end()) {
+                pendingTrees.push_back({name, {}, std::move(it->second)});
+                parsedTreeCache.erase(it);
+            }
+            else if (auto buffer = findBufferFunc(name)) {
+                pendingTrees.push_back({name, buffer, nullptr});
+                parseCount++;
+            }
+        }
+
+        if (pendingTrees.empty())
+            continue;
+
+        auto parseDepthBuffer = [&](size_t i) {
+            if (!pendingTrees[i].tree)
+                pendingTrees[i].tree = parseBuffer(pendingTrees[i].buffer);
+        };
+
+        if (parseCount >= MinFilesForThreading) {
+            pool->detach_loop(size_t(0), pendingTrees.size(), parseDepthBuffer);
+            pool->wait();
+        }
+        else {
+            for (size_t i = 0; i < pendingTrees.size(); i++)
+                parseDepthBuffer(i);
+        }
+
+        for (size_t i = 0; i < pendingTrees.size(); i++) {
+            if (knownNames.contains(pendingTrees[i].name))
+                continue;
+
+            if (!pendingTrees[i].tree)
+                continue;
+
+            addTree(std::move(pendingTrees[i].tree));
+            if (!worklist.empty()) {
+                SmallVector<std::string_view, 8> newNames;
+                while (!worklist.empty()) {
+                    newNames.push_back(worklist.back());
+                    worklist.pop_back();
+                }
+
+                // New names discovered by this tree must be processed before the older
+                // pending names to preserve the serial fixed-point order. Keep already
+                // parsed trees cached so we don't have to find or parse them again later.
+                for (size_t j = pendingTrees.size() - 1; j > i; j--) {
+                    auto& pending = pendingTrees[j];
+                    if (!pending.tree || knownNames.contains(pending.name))
+                        continue;
+
+                    parsedTreeCache[pending.name] = std::move(pending.tree);
+                    worklist.push_back(pending.name);
+                }
+
+                while (!newNames.empty()) {
+                    worklist.push_back(newNames.back());
+                    newNames.pop_back();
+                }
+                break;
+            }
         }
     }
 }

--- a/tests/unittests/DriverTests.cpp
+++ b/tests/unittests/DriverTests.cpp
@@ -11,6 +11,8 @@
 #include "slang/driver/Driver.h"
 #include "slang/driver/SourceLoader.h"
 #include "slang/text/SourceManager.h"
+#include "slang/util/ScopeGuard.h"
+#include "slang/util/ThreadPool.h"
 
 using namespace slang::driver;
 
@@ -184,6 +186,149 @@ endmodule
     CHECK(leafLookups == 0);
     CHECK(trees.size() == 2);
 }
+
+#if defined(SLANG_USE_THREADS)
+TEST_CASE("SourceLoader loads search libraries in parallel depths") {
+    SourceManager sourceManager;
+
+    auto top = SyntaxTree::fromText(R"(
+module top;
+    a a();
+    b b();
+    c c();
+    d d();
+endmodule
+)",
+                                    sourceManager, "", "load_tree_parallel_top.sv");
+
+    SourceLoader::SyntaxTreeList trees;
+    trees.push_back(top);
+
+    flat_hash_map<std::string_view, SourceBuffer> buffers;
+    buffers["a"] = sourceManager.assignText("load_tree_a.sv", "module a; e e(); endmodule");
+    buffers["b"] = sourceManager.assignText("load_tree_b.sv", "module b; f f(); endmodule");
+    buffers["c"] = sourceManager.assignText("load_tree_c.sv", "module c; g g(); endmodule");
+    buffers["d"] = sourceManager.assignText("load_tree_d.sv", "module d; h h(); endmodule");
+    buffers["e"] = sourceManager.assignText("load_tree_e.sv", "module e; endmodule");
+    buffers["f"] = sourceManager.assignText("load_tree_f.sv", "module f; endmodule");
+    buffers["g"] = sourceManager.assignText("load_tree_g.sv", "module g; endmodule");
+    buffers["h"] = sourceManager.assignText("load_tree_h.sv", "module h; endmodule");
+
+    ThreadPool pool(4);
+    SourceLoader::loadTrees(
+        trees,
+        [&](std::string_view name) {
+            if (auto it = buffers.find(name); it != buffers.end())
+                return it->second;
+            return SourceBuffer();
+        },
+        sourceManager, {}, {}, &pool);
+
+    CHECK(trees.size() == 9);
+}
+
+TEST_CASE("SourceLoader skips parallel depth trees satisfied by earlier loads") {
+    SourceManager sourceManager;
+
+    auto top = SyntaxTree::fromText(R"(
+module top;
+    leaf leaf();
+    a a();
+    b b();
+    mid mid();
+endmodule
+)",
+                                    sourceManager, "", "load_tree_parallel_skip_top.sv");
+
+    SourceLoader::SyntaxTreeList trees;
+    trees.push_back(top);
+
+    flat_hash_map<std::string_view, SourceBuffer> buffers;
+    buffers["leaf"] = sourceManager.assignText("load_tree_leaf.sv", "module leaf; endmodule");
+    buffers["mid"] = sourceManager.assignText("load_tree_mid.sv", R"(
+module mid;
+    helper helper();
+endmodule
+)");
+    buffers["helper"] = sourceManager.assignText("load_tree_helper.sv", R"(
+module helper;
+endmodule
+module leaf;
+endmodule
+)");
+    buffers["a"] = sourceManager.assignText("load_tree_a.sv", "module a; endmodule");
+    buffers["b"] = sourceManager.assignText("load_tree_b.sv", "module b; endmodule");
+
+    ThreadPool pool(4);
+    SourceLoader::loadTrees(
+        trees,
+        [&](std::string_view name) {
+            if (auto it = buffers.find(name); it != buffers.end())
+                return it->second;
+            return SourceBuffer();
+        },
+        sourceManager, {}, {}, &pool);
+
+    CHECK(trees.size() == 5);
+
+    Compilation compilation;
+    for (auto& tree : trees)
+        compilation.addSyntaxTree(tree);
+
+    NO_COMPILATION_ERRORS;
+}
+
+TEST_CASE("Driver libdir search loads parallel dependency depths") {
+    auto guard = OS::captureOutput();
+
+    std::error_code ec;
+    auto root = fs::temp_directory_path(ec);
+    REQUIRE(!ec);
+    root /= fmt::format("slang-libdir-{}", OS::getpid());
+    fs::remove_all(root, ec);
+    fs::create_directories(root, ec);
+    REQUIRE(!ec);
+    ScopeGuard cleanup([&] { fs::remove_all(root, ec); });
+
+    auto writeFile = [](const fs::path& path, std::string_view text) {
+        std::ofstream out(path);
+        REQUIRE(out.good());
+        out << text;
+    };
+
+    writeFile(root / "top.sv", R"(
+module top;
+    a a();
+    b b();
+    c c();
+    d d();
+endmodule
+)");
+    writeFile(root / "a.qv", "module a; e e(); endmodule");
+    writeFile(root / "b.qv", "module b; f f(); endmodule");
+    writeFile(root / "c.qv", "module c; g g(); endmodule");
+    writeFile(root / "d.qv", "module d; h h(); endmodule");
+    writeFile(root / "e.qv", "module e; endmodule");
+    writeFile(root / "f.qv", "module f; endmodule");
+    writeFile(root / "g.qv", "module g; endmodule");
+    writeFile(root / "h.qv", "module h; endmodule");
+
+    Driver driver;
+    driver.addStandardArgs();
+
+    auto args = fmt::format("testfoo \"{}\" --libdir \"{}\" --libext .qv --top top -j 4",
+                            (root / "top.sv").string(), root.string());
+    CHECK(driver.parseCommandLine(args));
+    CHECK(driver.processOptions());
+    CHECK(driver.parseAllSources());
+    CHECK(driver.reportParseDiags());
+    CHECK(driver.syntaxTrees.size() == 9);
+
+    auto compilation = driver.createCompilation();
+    driver.reportCompilation(*compilation, true);
+    CHECK(driver.reportDiagnostics(true));
+}
+#endif
 
 TEST_CASE("Driver library files with explicit name") {
     auto guard = OS::captureOutput();


### PR DESCRIPTION
Pass the driver thread pool into SourceLoader library search resolution so -y and -Y discovered files can parse in parallel by dependency depth.

Preserve the serial fixed-point merge order by caching speculatively parsed pending trees whenever an earlier merge discovers new missing names, then replaying them later only if still unresolved.

Add unit and driver coverage for parallel library depths and the order-sensitive case where an earlier library load satisfies a later pending name.