### PR TITLE
waivers: reject unknown keys in waiver TOML files

### DIFF
--- a/source/diagnostics/WaiverManager.cpp
+++ b/source/diagnostics/WaiverManager.cpp
@@ -113,6 +113,13 @@ std::string WaiverManager::loadFromFile(const fs::path& path,
     if (!waivers)
         return tomlErr(*waiversNode, "'waivers' must be an array of tables");
 
+    // Reject unknown top-level keys so a misspelled table name (e.g. '[[waviers]]')
+    // surfaces as a load error instead of being silently ignored.
+    for (auto& [k, v] : root) {
+        if (k.str() != "waivers")
+            return tomlErr(k, fmt::format("unknown top-level key '{}'", k.str()));
+    }
+
     for (auto& currNode : *waivers) {
         auto entry = currNode.as_table();
         if (!entry)

--- a/tests/unittests/diagnostics/WaiverTests.cpp
+++ b/tests/unittests/diagnostics/WaiverTests.cpp
@@ -263,6 +263,16 @@ TEST_CASE("Waiver Manager - TOML loading and validation") {
         CHECK(contains(errors, "error: unknown key 'file_glob'"));
     }
 
+    // Unknown top-level key (e.g. a misspelled '[[waviers]]' table name)
+    {
+        TempFile waiver("[[waivers]]\nfile = \"rtl/**\"\n"
+                        "[[waviers]]\nfile = \"rtl/**\"\n",
+                        ".toml");
+        WaiverManager mgr;
+        auto errors = mgr.loadFromFile(waiver.path, engine);
+        CHECK(contains(errors, "error: unknown top-level key 'waviers'"));
+    }
+
     {
         TempFile waiver("[[waivers]]\nfile = \"rtl/**\"\n"
                         "diagnostic = \"unused-variable\"\n"


### PR DESCRIPTION
A misspelled waiver table name (e.g. the typo '[[waviers]]' written alongside a valid '[[waivers]]') was silently ignored by the loader.

This fix rejects any unknown top-level keys so such typos surface as a load error.