### PR TITLE
Use path string for name if not proximate.

### DIFF
--- a/source/text/SourceManager.cpp
+++ b/source/text/SourceManager.cpp
@@ -703,7 +703,7 @@ SourceBuffer SourceManager::cacheBuffer(fs::path&& path, std::string&& pathStr,
     }
 
     if (name.empty())
-        name = getU8Str(path.filename());
+        name = getU8Str(path);
 
     std::unique_lock<std::shared_mutex> lock(mutex);
 


### PR DESCRIPTION
This is a bit of a RFC: currently it seems one can either do proximate or just filename for the buffers in SourceManager (e.g., one can't just populate the SourceManager using path names desired and it gets propagated it does get changed one way or another). Except via chdir which is undesirable in multithreaded context. While we wanted to use absolute paths here.

Would a change like this to enable dictating name via SourceManager be desirable?