### PR TITLE
Default typed input ports to nets, add --infer-input-ports-as-vars

### DIFF
--- a/docs/command-line-ref.dox
+++ b/docs/command-line-ref.dox
@@ -672,6 +672,27 @@ bins at elaboration).
 
 This option is enabled automatically when `--compat=vcs` or `--compat=all` is used.
 
+`--infer-input-ports-as-vars`
+
+Infer ANSI `input` ports that have an explicit data type as variables instead of nets.
+By default slang follows the LRM (and matches Questa) and treats such ports as nets, which
+for example allows them to be connected to `inout` ports. Some tools (notably VCS) treat them
+as variables instead, which rejects such connections but in turn allows them to be connected
+to `ref` ports; this flag selects that behavior.
+
+For example, by default the following is allowed, but is an error when this flag is set:
+
+@code{.sv}
+module m(input logic w);
+    n n(w);
+endmodule
+
+module n(inout logic w);
+endmodule
+@endcode
+
+This option is enabled automatically when `--compat=vcs` or `--compat=all` is used.
+
 `--cmd-ignore <vendor_cmd>,<N>`
 
 Define rule to ignore vendor command &lt;vendor_cmd> with its following &lt;N> parameters.

--- a/include/slang/ast/Compilation.h
+++ b/include/slang/ast/Compilation.h
@@ -135,9 +135,16 @@ enum class SLANG_EXPORT CompilationFlags {
     /// Allow the legacy `cross_auto_bin_max` coverage option to be set on covergroups
     /// and crosses. This option was part of SystemVerilog 3.1a but is not in IEEE 1800;
     /// some tools still accept it for compatibility with older code.
-    AllowCrossAutoBinMax = 1 << 18
+    AllowCrossAutoBinMax = 1 << 18,
+
+    /// Infer an ANSI `input` port that has an explicit data type as a variable
+    /// instead of a net. By default slang follows the LRM (and Questa) and treats
+    /// such ports as nets, which for example allows them to be connected to `inout`
+    /// ports. Some tools (notably VCS) treat them as variables instead; enabling
+    /// this flag selects that behavior.
+    InferInputPortsAsVars = 1 << 19
 };
-SLANG_BITMASK(CompilationFlags, AllowCrossAutoBinMax)
+SLANG_BITMASK(CompilationFlags, InferInputPortsAsVars)
 
 /// Contains various options that can control compilation behavior.
 struct SLANG_EXPORT CompilationOptions {

--- a/include/slang/ast/types/DeclaredType.h
+++ b/include/slang/ast/types/DeclaredType.h
@@ -85,12 +85,18 @@ enum class SLANG_EXPORT DeclaredTypeFlags {
     /// The type is for a variable declaration inside an interface or generate block.
     IfaceOrGenBlkVar = 1 << 16,
 
+    /// The net type was implicitly inferred for an ANSI `input` port that has an
+    /// explicit data type. Such a port is treated as a net per the LRM (and Questa)
+    /// but the data type is allowed to be one that wouldn't otherwise be valid for a
+    /// net, so the usual net type check is suppressed.
+    ImplicitInputNet = 1 << 17,
+
     /// A mask of flags that indicate additional type rules are needed to
     /// be checked after the type itself is resolved.
     NeedsTypeCheck = NetType | UserDefinedNetType | FormalArgMergeVar | Rand | DPIReturnType |
                      DPIArg | RequireSequenceType | CoverageType | IfaceOrGenBlkVar
 };
-SLANG_BITMASK(DeclaredTypeFlags, IfaceOrGenBlkVar)
+SLANG_BITMASK(DeclaredTypeFlags, ImplicitInputNet)
 
 /// Ties together various syntax nodes that declare the type of some parent symbol
 /// along with the logic necessary to resolve that type. Optionally includes an

--- a/pyslang/tests/test_extract_logic_names.py
+++ b/pyslang/tests/test_extract_logic_names.py
@@ -83,9 +83,6 @@ def test_complex_module_with_ports():
     """
 
     assert set(extract_logic_declaration_names(code)) == {
-        "clk",
-        "reset_n",
-        "data_in",
         "data_out",
         "valid",
         "internal_counter",

--- a/source/ast/symbols/PortSymbols.cpp
+++ b/source/ast/symbols/PortSymbols.cpp
@@ -166,24 +166,42 @@ public:
                 // - For output, if we have a data type it's a var, otherwise net
                 // - For ref it's always a var
                 //
-                // Unfortunately, all major simulators ignore the rule for input ports,
-                // and treat them the same as output ports (i.e. it's not a net if there
-                // is a data type specified). This is pretty noticeable as otherwise a
-                // port like this:
-                //    input int i
-                // will throw an error because int is not a valid type for a net. Actually
-                // noticing the other fact, that it's a net port vs a variable port, is very
-                // hard to do, so we go along with everyone else and use the same rule.
-
+                // By default slang follows the LRM here (which also matches Questa):
+                // input and inout ports default to nets even when an explicit data type
+                // is provided. The data type is allowed to be one that wouldn't otherwise
+                // be legal for a net (e.g. `input int i`); that check is suppressed for
+                // this implicitly-inferred case, see DeclaredTypeFlags::ImplicitInputNet.
+                //
+                // Some tools (notably VCS) instead treat a typed input port as a variable,
+                // which for example rejects connecting it to an inout port. The
+                // InferInputPortsAsVars flag selects that behavior.
                 ArgumentDirection direction = getDirection(header.direction);
+                const bool implicitType = header.dataType->kind == SyntaxKind::ImplicitType;
+
                 const NetType* netType = nullptr;
-                if (!header.varKeyword && (direction == ArgumentDirection::InOut ||
-                                           (direction != ArgumentDirection::Ref &&
-                                            header.dataType->kind == SyntaxKind::ImplicitType))) {
-                    netType = &getDefaultNetType(scope, decl.name.location());
+                bool implicitInputNet = false;
+                if (!header.varKeyword && direction != ArgumentDirection::Ref) {
+                    bool isNet;
+                    if (direction == ArgumentDirection::Out)
+                        isNet = implicitType;
+                    else if (direction == ArgumentDirection::In)
+                        isNet = implicitType ||
+                                !comp.hasFlag(CompilationFlags::InferInputPortsAsVars);
+                    else // InOut
+                        isNet = true;
+
+                    if (isNet) {
+                        netType = &getDefaultNetType(scope, decl.name.location());
+
+                        // Suppress the net type validity check for an input port that
+                        // was given an explicit data type, since the user wrote e.g.
+                        // `input bit w` and expects it to act like a net port anyway.
+                        implicitInputNet = direction == ArgumentDirection::In && !implicitType;
+                    }
                 }
 
-                return add(decl, direction, header.dataType, netType, syntax.attributes);
+                return add(decl, direction, header.dataType, netType, syntax.attributes,
+                           implicitInputNet);
             }
             case SyntaxKind::NetPortHeader: {
                 auto& header = syntax.header->as<NetPortHeaderSyntax>();
@@ -220,6 +238,7 @@ public:
         lastDirection = port->direction;
         lastType = nullptr;
         lastNetType = nullptr;
+        lastImplicitInputNet = false;
         lastInterface = nullptr;
         lastModport = ""sv;
         lastGenericIface = false;
@@ -240,12 +259,13 @@ private:
         if (!lastType && !lastNetType)
             lastType = &comp.createEmptyTypeSyntax(decl.getFirstToken().location());
 
-        return add(decl, lastDirection, lastType, lastNetType, attrs);
+        return add(decl, lastDirection, lastType, lastNetType, attrs, lastImplicitInputNet);
     }
 
     Symbol* add(const DeclaratorSyntax& decl, ArgumentDirection direction,
                 const DataTypeSyntax* type, const NetType* netType,
-                std::span<const AttributeInstanceSyntax* const> attrs) {
+                std::span<const AttributeInstanceSyntax* const> attrs,
+                bool implicitInputNet = false) {
         auto port = comp.emplace<PortSymbol>(decl.name.valueText(), decl.name.location(),
                                              /* isAnsiPort */ true);
         port->direction = direction;
@@ -296,6 +316,9 @@ private:
                     symbol->getDeclaredType()->setDimensionSyntax(decl.dimensions);
             }
 
+            if (implicitInputNet)
+                symbol->getDeclaredType()->addFlags(DeclaredTypeFlags::ImplicitInputNet);
+
             symbol->setSyntax(decl);
             symbol->setAttributes(scope, attrs);
             port->internalSymbol = symbol;
@@ -321,6 +344,7 @@ private:
         lastDirection = direction;
         lastType = type;
         lastNetType = netType;
+        lastImplicitInputNet = implicitInputNet;
         lastInterface = nullptr;
         lastModport = ""sv;
         lastGenericIface = false;
@@ -344,6 +368,7 @@ private:
         lastDirection = ArgumentDirection::InOut;
         lastType = nullptr;
         lastNetType = nullptr;
+        lastImplicitInputNet = false;
         lastInterface = iface;
         lastModport = modport;
         lastGenericIface = isGeneric;
@@ -358,6 +383,7 @@ private:
     ArgumentDirection lastDirection = ArgumentDirection::InOut;
     const DataTypeSyntax* lastType = nullptr;
     const NetType* lastNetType = nullptr;
+    bool lastImplicitInputNet = false;
     const DefinitionSymbol* lastInterface = nullptr;
     std::string_view lastModport;
     bool lastGenericIface = false;

--- a/source/ast/types/DeclaredType.cpp
+++ b/source/ast/types/DeclaredType.cpp
@@ -253,7 +253,8 @@ void DeclaredType::checkType(const ASTContext& context) const {
     switch (masked) {
         case uint32_t(DeclaredTypeFlags::NetType): {
             auto& net = parent.as<NetSymbol>();
-            if (net.netType.netKind != NetType::UserDefined && !isValidForNet(*type))
+            if (net.netType.netKind != NetType::UserDefined && !isValidForNet(*type) &&
+                !flags.has(DeclaredTypeFlags::ImplicitInputNet))
                 context.addDiag(diag::InvalidNetType, parent.location) << *type;
             else if (type->getBitWidth() == 1 && net.expansionHint != NetSymbol::None)
                 context.addDiag(diag::SingleBitVectored, parent.location);

--- a/source/driver/CompatSettings.cpp
+++ b/source/driver/CompatSettings.cpp
@@ -37,7 +37,8 @@ using namespace analysis;
     CompilationFlags::AllowMergingAnsiPorts, \
     CompilationFlags::AllowArrayConcatAssignPattern, \
     CompilationFlags::AllowLibModuleRedefinition, \
-    CompilationFlags::AllowCrossAutoBinMax
+    CompilationFlags::AllowCrossAutoBinMax, \
+    CompilationFlags::InferInputPortsAsVars
 
 static constexpr CompilationFlags vcsCompFlags[] = {VCS_COMP_FLAGS};
 static constexpr CompilationFlags allCompFlags[] = {

--- a/source/driver/Driver.cpp
+++ b/source/driver/Driver.cpp
@@ -265,6 +265,9 @@ void Driver::addStandardArgs() {
     addCompFlag(CompilationFlags::AllowCrossAutoBinMax, "--allow-cross-auto-bin-max",
                 "Allow the legacy SystemVerilog 3.1a cross_auto_bin_max coverage option to "
                 "be set on covergroups and crosses. The option is accepted and ignored.");
+    addCompFlag(CompilationFlags::InferInputPortsAsVars, "--infer-input-ports-as-vars",
+                "Infer ANSI input ports that have an explicit data type as variables instead "
+                "of nets. By default such ports are treated as nets, following the LRM.");
 
     cmdLine.add("--top", options.topModules,
                 "One or more top-level modules to instantiate "

--- a/tests/unittests/analysis/MultiAssignTests.cpp
+++ b/tests/unittests/analysis/MultiAssignTests.cpp
@@ -841,7 +841,7 @@ endmodule
     auto diags = analyze(code, compilation, analysisManager);
     REQUIRE(diags.size() == 4);
     CHECK(diags[0].code == diag::InputPortAssign);
-    CHECK(diags[1].code == diag::InputPortAssign);
+    CHECK(diags[1].code == diag::InputPortCoercion);
     CHECK(diags[2].code == diag::InputPortAssign);
     CHECK(diags[3].code == diag::MixedVarAssigns);
 }

--- a/tests/unittests/ast/LookupTests.cpp
+++ b/tests/unittests/ast/LookupTests.cpp
@@ -2355,13 +2355,14 @@ endmodule
     compilation.addSyntaxTree(tree);
 
     auto& diags = compilation.getAllDiagnostics();
-    REQUIRE(diags.size() == 6);
-    CHECK(diags[0].code == diag::UndeclaredIdentifier);
+    REQUIRE(diags.size() == 7);
+    CHECK(diags[0].code == diag::ImplicitNetPortNoDefault);
     CHECK(diags[1].code == diag::UndeclaredIdentifier);
     CHECK(diags[2].code == diag::UndeclaredIdentifier);
-    CHECK(diags[3].code == diag::ImplicitNamedPortNotFound);
-    CHECK(diags[4].code == diag::UndeclaredIdentifier);
-    CHECK(diags[5].code == diag::ImplicitNamedPortNotFound);
+    CHECK(diags[3].code == diag::UndeclaredIdentifier);
+    CHECK(diags[4].code == diag::ImplicitNamedPortNotFound);
+    CHECK(diags[5].code == diag::UndeclaredIdentifier);
+    CHECK(diags[6].code == diag::ImplicitNamedPortNotFound);
 }
 
 TEST_CASE("Enum in inherited class lookup regress -- GH #1177") {

--- a/tests/unittests/ast/PortTests.cpp
+++ b/tests/unittests/ast/PortTests.cpp
@@ -1385,6 +1385,66 @@ endmodule
     CHECK(diags[1].code == diag::InOutVarPortConn);
 }
 
+TEST_CASE("Typed input port is a net by default -- GH #1853") {
+    auto tree = SyntaxTree::fromText(R"(
+module m(input logic w);
+    n n(w);
+endmodule
+
+module n(inout logic w);
+endmodule
+)");
+
+    Compilation compilation;
+    compilation.addSyntaxTree(tree);
+    NO_COMPILATION_ERRORS;
+}
+
+TEST_CASE("Typed input port as variable with InferInputPortsAsVars -- GH #1853") {
+    auto tree = SyntaxTree::fromText(R"(
+module m(input logic w);
+    n n(w);
+endmodule
+
+module n(inout logic w);
+endmodule
+)");
+
+    CompilationOptions options;
+    options.flags |= CompilationFlags::InferInputPortsAsVars;
+
+    Compilation compilation(options);
+    compilation.addSyntaxTree(tree);
+
+    auto& diags = compilation.getAllDiagnostics();
+    REQUIRE(diags.size() == 1);
+    CHECK(diags[0].code == diag::InOutVarPortConn);
+}
+
+TEST_CASE("Typed input port with non-net data type -- GH #1853") {
+    auto tree = SyntaxTree::fromText(R"(
+module m(input bit a, input int b);
+endmodule
+)");
+
+    Compilation compilation;
+    compilation.addSyntaxTree(tree);
+    NO_COMPILATION_ERRORS;
+
+    // An explicit net keyword with such a type is still an error.
+    auto tree2 = SyntaxTree::fromText(R"(
+module m(input wire bit a);
+endmodule
+)");
+
+    Compilation compilation2;
+    compilation2.addSyntaxTree(tree2);
+
+    auto& diags = compilation2.getAllDiagnostics();
+    REQUIRE(diags.size() == 1);
+    CHECK(diags[0].code == diag::InvalidNetType);
+}
+
 TEST_CASE("Unconnected ref port errors") {
     auto tree = SyntaxTree::fromText(R"(
 module m(a[1:0]);
@@ -1473,7 +1533,7 @@ module o({a, b});
     input b;
 endmodule
 
-module q(input int b);
+module q(input var int b);
 endmodule
 
 module top;

--- a/tools/tidy/tests/NoLatchesOnDesignTest.cpp
+++ b/tools/tidy/tests/NoLatchesOnDesignTest.cpp
@@ -12,7 +12,7 @@ module top (
     output logic b
 );
     always_latch begin
-        a <= b;
+        b <= a;
     end
 endmodule
 )");
@@ -26,7 +26,7 @@ module top (
     output logic b
 );
     always_comb begin
-        a = b;
+        b = a;
     end
 endmodule
 )");


### PR DESCRIPTION
  PR description:
  Fixes [#1853](https://github.com/MikePopoloski/slang/issues/1853)

  Per §23.2.2.3, an ANSI `input`/`inout` port with omitted port kind defaults to
  a net. slang followed VCS and treated a typed `input` port (e.g. `input logic w`)
  as a variable, making it illegal to connect to an `inout` port.

  This changes the default to match the LRM (and Questa), and moves the old VCS
  behavior behind a new flag `--infer-input-ports-as-vars`, enabled automatically
  under `--compat=vcs`/`--compat=all`. This is a breaking change, but permissive
  enough that most designs are unaffected.

  - Typed ANSI `input` ports now default to nets; non-net data types like
    `input bit w` are accepted (net type check suppressed), while explicit
    `input wire bit w` is still an error.
  - New `CompilationFlags::InferInputPortsAsVars` restores the VCS behavior.
  - Scope is ANSI ports only (non-ANSI unchanged).
