### PR TITLE
fix data race in getState() that corrupts the heap during parallel analysis

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -171,6 +171,18 @@
       }
     },
     {
+      "name": "gcc-asan",
+      "displayName": "GCC ASan",
+      "description": "GCC debug shared build with AddressSanitizer + UBSan",
+      "inherits": "gcc-debug-shared",
+      "cacheVariables": {
+        "CMAKE_CXX_FLAGS": "-DSLANG_ASSERT_ENABLED -fsanitize=address,undefined -fno-sanitize-recover=undefined -fno-omit-frame-pointer -g",
+        "CMAKE_EXE_LINKER_FLAGS": "-fsanitize=address,undefined",
+        "CMAKE_SHARED_LINKER_FLAGS": "-fsanitize=address,undefined",
+        "SLANG_USE_MIMALLOC": "OFF"
+      }
+    },
+    {
       "name": "gcc-debug-noexcept",
       "displayName": "GCC Debug No Exceptions",
       "inherits": [

--- a/include/slang/analysis/AnalysisManager.h
+++ b/include/slang/analysis/AnalysisManager.h
@@ -7,6 +7,7 @@
 //------------------------------------------------------------------------------
 #pragma once
 
+#include <atomic>
 #include <exception>
 #include <functional>
 #include <memory>
@@ -240,6 +241,10 @@ private:
 
     const AnalysisOptions options;
     std::vector<WorkerState> workerStates;
+
+    // Hands out a distinct workerStates slot to each thread that participates in
+    // analysis; see getState() for why we don't use the thread pool's own index.
+    std::atomic<size_t> nextWorkerSlot{0};
 
     concurrent_map<const ast::Scope*, std::optional<const AnalyzedScope*>> analyzedScopes;
     concurrent_map<const ast::SubroutineSymbol*, std::unique_ptr<AnalyzedProcedure>>

--- a/source/analysis/AnalysisManager.cpp
+++ b/source/analysis/AnalysisManager.cpp
@@ -444,8 +444,23 @@ void AnalysisManager::handleAssertion(std::unique_ptr<AnalyzedAssertion>&& asser
 
 AnalysisManager::WorkerState& AnalysisManager::getState() {
 #if defined(SLANG_USE_THREADS)
-    if (threadPool)
-        return workerStates[BS::this_thread::get_index().value_or(workerStates.size() - 1)];
+    if (threadPool) {
+        // Map each participating thread to a distinct worker state. We can't rely on
+        // BS::this_thread::get_index() here: it reads an inline thread_local from the
+        // thread-pool header which, under hidden visibility, can be a *different*
+        // instance in this shared object than the one the pool's worker threads write
+        // to (when the pool is instantiated in another module). That made every worker
+        // fall back to the same slot and race on a shared WorkerState. Instead we hand
+        // out slots ourselves, lazily, the first time a thread asks for its state.
+        thread_local const AnalysisManager* cachedManager = nullptr;
+        thread_local size_t cachedSlot = 0;
+        if (cachedManager != this) {
+            cachedManager = this;
+            cachedSlot = nextWorkerSlot.fetch_add(1, std::memory_order_relaxed);
+            SLANG_ASSERT(cachedSlot < workerStates.size());
+        }
+        return workerStates[cachedSlot];
+    }
 #endif
     return workerStates[0];
 }


### PR DESCRIPTION
  ### What

Under parallel analysis multiple worker threads could share the **same** `WorkerState`, racing on its `Diagnostics` vector. Result: heap corruption (use-after-free / overflow in `SmallVector<Diagnostic>::emplaceRealloc` via `addUnusedDiag` to `Diagnostics::add`), showing up as random SIGSEGV/SIGABRT or allocator assertions. First seen on `gcc-debug-shared` -  it's the source of the  intermittent failures on that preset (for example here - https://github.com/MikePopoloski/slang/actions/runs/27310618389/job/80679614776). Needs ≥ 2 cores and is timing/layout  sensitive (≈100% in the `unittests` binary, ~never in `slang`), hence the  flakiness.

  ### Why

`getState()` picked the per-thread state with `BS::this_thread::get_index()`.  That index lives in an `inline static thread_local` in the vendored   `BS_thread_pool.hpp`. Under `-fvisibility=hidden` (shared build) it isn't exported, so each module gets its **own copy**: the pool's workers (instantiated  in the executable) set one copy, while `getState()` in `libsvlang.so` reads another that's never written then `get_index()` returns `nullopt` then every worker  falls into the same fallback slot and shares one `WorkerState`.

  ### Fix

Don't rely on the cross-module thread index. `AnalysisManager` hands out a  distinct `workerStates` slot per thread via an atomic counter, cached in a `thread_local` inside the non-inline `getState()` (a single symbol in the .so, so it can't duplicate like `my_index` did).

  ### Also: `gcc-asan` preset

The bug is a heap UAF, which **TSan doesn't report** - so the existing TSan-only `clang-sanitize` preset stayed clean. ASan pinpointed it immediately. Adding a `gcc-asan` preset (inherits `gcc-debug-shared`, `-fsanitize=address`,  mimalloc off) gives an in-tree heap-error build for this class of bug.
