### PR TITLE
Speed up lookup_table visits by doing the kind filter in C++

### DIFF
--- a/bindings/python/PyVisitors.h
+++ b/bindings/python/PyVisitors.h
@@ -6,6 +6,8 @@
 #pragma once
 
 #include "pyslang.h"
+#include <tuple>
+#include <unordered_map>
 
 #include "slang/ast/ASTVisitor.h"
 
@@ -15,7 +17,60 @@ enum class VisitAction {
     Interrupt,
 };
 
-template<typename TDerived, template<class, auto...> class BaseVisitor, auto... baseArgs>
+// A compiled form of a Python `lookup_table` dict.
+//
+// A single lookup_table may mix keys from several different node-kind enum types
+// (e.g. SymbolKind, ExpressionKind, ...). We keep one C++ hash map per enum type,
+// so that during traversal the per-node membership test is a plain C++ lookup on
+// the node's own `kind` enum and Python is only entered for matched nodes.
+//
+// The set of enum types is fixed at compile time by `Kinds...`. handle<T> dispatches
+// on `decltype(t.kind)`, so if a visited node's kind type is not listed here it is a
+// compile error rather than a silently dropped handler.
+template<typename... Kinds>
+struct KindHandlerTables {
+    std::tuple<std::unordered_map<Kinds, py::object>...> maps;
+
+    template<typename KindT>
+    std::unordered_map<KindT, py::object>& mapFor() {
+        return std::get<std::unordered_map<KindT, py::object>>(maps);
+    }
+
+    // Try to place one (key, value) pair into the map for KindT. Returns false if the
+    // key is not an instance of that enum type, so callers can try the next type.
+    template<typename KindT>
+    bool tryInsert(py::handle key, py::handle value) {
+        if (!py::isinstance<KindT>(key))
+            return false;
+        mapFor<KindT>().insert_or_assign(py::cast<KindT>(key),
+                                         py::reinterpret_borrow<py::object>(value));
+        return true;
+    }
+
+    // Compile the Python dict once into the typed maps.
+    void build(const py::dict& table) {
+        for (auto item : table)
+            (tryInsert<Kinds>(item.first, item.second) || ...);
+    }
+
+    template<typename KindT>
+    py::handle find(KindT kind) {
+        auto& m = mapFor<KindT>();
+        auto it = m.find(kind);
+        return it == m.end() ? py::handle() : py::handle(it->second);
+    }
+};
+
+template<typename Tuple>
+struct KindTablesFor;
+
+template<typename... Ks>
+struct KindTablesFor<std::tuple<Ks...>> {
+    using type = KindHandlerTables<Ks...>;
+};
+
+template<typename TDerived, typename KindList, template<class, auto...> class BaseVisitor,
+         auto... baseArgs>
 struct PyVisitorBase : public BaseVisitor<TDerived, baseArgs...> {
     py::object f;
     std::optional<py::dict> lookupTable;
@@ -33,38 +88,65 @@ struct PyVisitorBase : public BaseVisitor<TDerived, baseArgs...> {
         "When `lookup_table` is provided, it should be a dict mapping node kind enum values "
         "to handler functions. The C++ side checks each node's kind before crossing the "
         "Python boundary, calling only the matching handler. Nodes not in the table are "
-        "traversed without invoking Python. `f` is not called in this mode.";
+        "traversed without invoking Python. `f` is not called in this mode.\n\n"
+        "The `lookup_table` is compiled into native lookups when the visit begins and must "
+        "not be mutated during traversal.";
 
     explicit PyVisitorBase(py::object f, std::optional<py::dict> lt = std::nullopt) :
-        f{f}, lookupTable{std::move(lt)} {}
+        f{f}, lookupTable{std::move(lt)}, actionInterrupt{py::cast(VisitAction::Interrupt)},
+        actionSkip{py::cast(VisitAction::Skip)} {
+        if (this->lookupTable)
+            tables.build(*this->lookupTable);
+    }
 
     template<typename T>
     void handle(const T& t) {
         if (this->interrupted)
             return;
 
-        py::object result = py::none();
+        py::object result;
         if (this->lookupTable) {
             if constexpr (requires { t.kind; }) {
-                auto pyKind = py::cast(t.kind);
-                if (this->lookupTable->contains(pyKind)) {
-                    py::object handler{(*this->lookupTable)[pyKind]};
+                py::handle handler = tables.find(t.kind);
+                if (handler)
                     result = handler(&t);
-                }
             }
         }
         else {
             result = this->f(&t);
         }
 
-        if (result.equal(py::cast(VisitAction::Interrupt)))
-            this->interrupted = true;
-        else if (result.not_equal(py::cast(VisitAction::Skip)))
+        if (this->applyResult(result))
             this->visitDefault(t);
     }
+
+protected:
+    // Returns true if the node's children should be visited. Handlers communicate intent by
+    // returning a VisitAction (or None to advance). The VisitAction objects are cached so the
+    // comparison does not re-cast them per node; value comparison (==) is kept to match the
+    // previous behavior, and it only runs on a non-None return.
+    bool applyResult(const py::object& result) {
+        if (!result || result.is_none())
+            return true;
+        if (result.equal(actionInterrupt)) {
+            this->interrupted = true;
+            return false;
+        }
+        return result.not_equal(actionSkip);
+    }
+
+    typename KindTablesFor<KindList>::type tables;
+
+private:
+    py::object actionInterrupt;
+    py::object actionSkip;
 };
 
-struct PyASTVisitor : PyVisitorBase<PyASTVisitor, ASTVisitor, VisitFlags::AllGood> {
+struct PyASTVisitor
+    : PyVisitorBase<PyASTVisitor,
+                    std::tuple<SymbolKind, ExpressionKind, StatementKind, TimingControlKind,
+                               ConstraintKind, AssertionExprKind, BinsSelectExprKind, PatternKind>,
+                    ASTVisitor, VisitFlags::AllGood> {
     using PyVisitorBase::PyVisitorBase;
 };
 

--- a/bindings/python/SyntaxBindings.cpp
+++ b/bindings/python/SyntaxBindings.cpp
@@ -23,7 +23,9 @@ namespace fs = std::filesystem;
 
 namespace {
 
-struct PySyntaxVisitor : public PyVisitorBase<PySyntaxVisitor, SyntaxVisitor> {
+struct PySyntaxVisitor
+    : public PyVisitorBase<PySyntaxVisitor, std::tuple<SyntaxKind, parsing::TokenKind>,
+                           SyntaxVisitor> {
     using PyVisitorBase::PyVisitorBase;
 
     template<typename T>
@@ -37,42 +39,36 @@ struct PySyntaxVisitor : public PyVisitorBase<PySyntaxVisitor, SyntaxVisitor> {
         // at the actual type.
         auto node = static_cast<const SyntaxNode*>(&t);
 
-        py::object result = py::none();
+        py::object result;
         if (this->lookupTable) {
-            auto pyKind = py::cast(t.kind);
-            if (this->lookupTable->contains(pyKind)) {
-                py::object handler{(*this->lookupTable)[pyKind]};
+            py::handle handler = this->tables.find(t.kind);
+            if (handler)
                 result = handler(node);
-            }
         }
         else {
             result = this->f(node);
         }
 
-        if (result.equal(py::cast(VisitAction::Interrupt)))
-            this->interrupted = true;
-        else if (result.not_equal(py::cast(VisitAction::Skip)))
+        if (this->applyResult(result))
             this->visitDefault(t);
     }
 
     void visitToken(parsing::Token t) {
-        if (interrupted)
+        if (this->interrupted)
             return;
 
-        py::object result = py::none();
-        if (lookupTable) {
-            auto pyKind = py::cast(t.kind);
-            if (lookupTable->contains(pyKind)) {
-                py::object handler{(*lookupTable)[pyKind]};
+        py::object result;
+        if (this->lookupTable) {
+            py::handle handler = this->tables.find(t.kind);
+            if (handler)
                 result = handler(t);
-            }
         }
         else {
-            result = f(t);
+            result = this->f(t);
         }
 
-        if (result.equal(py::cast(VisitAction::Interrupt)))
-            interrupted = true;
+        // Tokens are leaves; applyResult records an Interrupt and Skip is a no-op here.
+        this->applyResult(result);
     }
 };
 


### PR DESCRIPTION
## Summary

Fixes #1871. `visit(lookup_table={Kind: handler})` did its kind filter in Python on every node (`py::cast(t.kind)` plus a `dict` lookup, plus two `VisitAction` casts and compares), so the cost of a visit scaled with the whole tree instead of the number of matches. The issue has the full benchmarks and background.

This compiles the `lookup_table` into native C++ maps once when the visit starts, so per node it's just a C++ lookup and Python is only entered for matches. Same fix on both visitors: the AST one (`PyVisitorBase`) and the syntax/token one (`PySyntaxVisitor`).

## Design

A `lookup_table` can mix keys from different node-kind enums (`SymbolKind`, `ExpressionKind`, ... for the AST visitor; `SyntaxKind`/`TokenKind` for the syntax one), and `handle<T>` sees a different `t.kind` type per node, so a single map won't do. `KindHandlerTables<Kinds...>` keeps one `unordered_map<KindT, py::object>` per enum type in a tuple. At visit start each key is sorted into its map with `py::isinstance<KindT>` (the enums are `py::native_enum`). Per node the lookup is `std::get<map<KindT>>(...).find(t.kind)`, one hash lookup, with the map picked at compile time from the node's kind type, and Python entered only on a match. The supported enum list is fixed at compile time, so a missing kind type is a compile error rather than a silently dropped handler.

Result handling is shared in `applyResult`. `None` advances, `Interrupt` stops the visit, and `Skip` prunes children. The `VisitAction` objects are cached once instead of re-cast per node, with a fast path for the common `None` return.

`PySyntaxVisitor` keeps its own `handle`/`visitToken` overrides (it hands Python a `SyntaxNode` through the polymorphic downcaster, and tokens are a separate path), but those now use the same compiled tables and `applyResult`.

The one intentional behavior change is that the `lookup_table` is snapshotted at visit start, so mutating it mid-traversal no longer takes effect (noted on the docstring). Everything else is preserved, including how `VisitAction` returns are compared.

## Testing

The existing `pyslang/tests/test_visitors.py` (17 tests) and the full pyslang suite (109) pass unchanged. They already cover the tricky parts: mixing enum types in one table (with possibly-overlapping underlying integer values), and `Skip`/`Interrupt` on both visitors including the token path.

## Performance

Measured on `NVDLA` from RTLMeter (the suite `tests/benchmarks` already uses), built twice from the same source and toolchain differing only by this patch, best of 4 runs. Match counts are identical before and after.

AST visitor, NVDLA (14,290,371 AST nodes):

| visit | before | after | speedup |
| --- | --- | --- | --- |
| 0 matches | 9.35 s | 0.42 s | ~22x |
| 130,262 instance matches | 9.34 s | 0.42 s | ~22x |
| 249,045 variable matches | 9.31 s | 0.44 s | ~21x |
| `f` over all nodes | 9.60 s | 3.94 s | ~2.4x |

Syntax/token visitor, NVDLA (8,038,664 syntax nodes + tokens):

| visit | before | after | speedup |
| --- | --- | --- | --- |
| 0 matches (`ClassDeclaration`) | 4.89 s | 0.31 s | ~16x |
| 458,508 `IdentifierName` matches | 5.04 s | 0.84 s | ~6.0x |
| 882,772 token matches (`visitToken` path) | 5.36 s | 1.09 s | ~4.9x |
| `f` over all nodes | 6.45 s | 6.41 s | ~1x |

So a selective `lookup_table` visit is now O(N + M). The native walk stays linear in the total nodes N, and only the Python-boundary cost scales with the match count M. The `f`-over-all-nodes path still makes one Python call per node, so its callback count is unchanged; the AST gain there comes from cheaper per-node result handling (cached `VisitAction` objects and a `None` short-circuit), while the syntax `f` path is dominated by per-node node-wrapper cost and barely moves.

## AI disclosure

Per the project's CONTRIBUTING.md: parts of this patch were drafted with assistance from Claude. I reviewed every line and am fully accountable for the change.
