### PR TITLE
ast: allow embedded covergroup coverage to reference later class members

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 * Fixed a crash when using `super` inside `randomize` calls on arrays of class handles
 * Fixed the ordering of element expressions in assignment patterns with explicit indices targeting arrays with descending indices
 * Fixed a parsing error where a labeled `restrict property` concurrent assertion was rejected
+* Fixed coverage expressions in an embedded covergroup not being able to reference class members that are declared later in the class
 
 ### Tools & Bindings
 #### pyslang

--- a/source/ast/Lookup.cpp
+++ b/source/ast/Lookup.cpp
@@ -2150,6 +2150,17 @@ void Lookup::unqualifiedImpl(const Scope& scope, std::string_view name, LookupLo
         outOfBlockIndex = SymbolIndex(0);
     }
 
+    if (sym.kind == SymbolKind::CovergroupType &&
+        location.getScope()->asSymbol().kind == SymbolKind::ClassType) {
+        // An embedded covergroup is a member of its containing class (IEEE 1800-2023
+        // 19.4), and class members are visible throughout the class body regardless of
+        // textual declaration order (IEEE 1800-2023 8.3). Coverage expressions may
+        // therefore reference class properties that are declared later in the class, so
+        // when we walk up out of the covergroup into the class we drop the
+        // declared-before-use restriction for that class scope only.
+        location = LookupLocation(location.getScope(), UINT_MAX);
+    }
+
     if (sym.kind == SymbolKind::ClassType) {
         // Suppress errors when we fail to find a symbol inside a class that
         // had a problem resolving its base class, since the symbol may be

--- a/tests/unittests/ast/CoverTests.cpp
+++ b/tests/unittests/ast/CoverTests.cpp
@@ -339,6 +339,73 @@ endclass
     NO_COMPILATION_ERRORS;
 }
 
+TEST_CASE("Covergroup in class sees later class members") {
+    // IEEE 1800-2023 19.4 makes an embedded covergroup a class member, and 8.3 makes
+    // class members visible throughout the class body, so coverage expressions may
+    // reference a class property that is declared later in the class.
+    auto tree = SyntaxTree::fromText(R"(
+class xyz;
+    typedef struct packed {
+        bit we;
+    } txn_t;
+
+    covergroup cov1;
+        coverpoint analysis_txn.we;
+    endgroup
+
+    txn_t analysis_txn;
+
+    function new(); cov1 = new; endfunction
+endclass
+)");
+
+    Compilation compilation;
+    compilation.addSyntaxTree(tree);
+    NO_COMPILATION_ERRORS;
+}
+
+TEST_CASE("Covergroup in class still errors on undeclared identifier") {
+    // The forward-reference relaxation must not suppress the undeclared-identifier
+    // diagnostic: a name that exists nowhere in the class must still be an error.
+    auto tree = SyntaxTree::fromText(R"(
+class xyz;
+    covergroup cov1;
+        coverpoint does_not_exist;
+    endgroup
+
+    function new(); cov1 = new; endfunction
+endclass
+)");
+
+    Compilation compilation;
+    compilation.addSyntaxTree(tree);
+
+    auto& diags = compilation.getAllDiagnostics();
+    REQUIRE(diags.size() == 1);
+    CHECK(diags[0].code == diag::UndeclaredIdentifier);
+}
+
+TEST_CASE("Covergroup forward lookup is limited to embedded class covergroups") {
+    // The relaxation is gated to embedded class covergroups; a module-level covergroup
+    // referencing a later module item still cannot see that name.
+    auto tree = SyntaxTree::fromText(R"(
+module m;
+    covergroup cg1;
+        coverpoint later;
+    endgroup
+
+    int later;
+endmodule
+)");
+
+    Compilation compilation;
+    compilation.addSyntaxTree(tree);
+
+    auto& diags = compilation.getAllDiagnostics();
+    REQUIRE(diags.size() == 1);
+    CHECK(diags[0].code == diag::UndeclaredIdentifier);
+}
+
 TEST_CASE("Covergroup built-in methods") {
     auto tree = SyntaxTree::fromText(R"(
 module m;


### PR DESCRIPTION
Full disclosure: AI generated text, via a human in CLI. Per the project's AI
policy: this was produced with AI assistance, read and reviewed by a human
before submission; I am the author and accountable for it, and I'm happy to
answer questions during review.

## Problem

An embedded covergroup whose coverage expression references a class member
declared *later* in the same class is incorrectly rejected with an
undeclared-identifier error:

```systemverilog
class xyz;
    covergroup cov1;
        coverpoint analysis_txn.we;   // error today: analysis_txn declared below
    endgroup

    txn_t analysis_txn;               // declared after the covergroup
    function new(); cov1 = new; endfunction
endclass
```

This pattern is common in UVM-style code, where the covergroup is declared near
the top of a class and the sampled fields/handles are declared further down.

## Why this is a bug (LRM)

- IEEE 1800-2023 §19.4: a covergroup declared inside a class is an *embedded
  covergroup* and is a member of that class.
- IEEE 1800-2023 §8.3: class members are visible throughout the class body
  regardless of the order in which they are declared.

A coverage expression is part of a class member, so it may legally reference any
class member irrespective of textual order.

## Fix

When unqualified lookup walks up out of an embedded covergroup's (anonymous)
`CovergroupType` into its containing `ClassType`, drop the declared-before-use
restriction for that class scope only, by setting the lookup location to the end
of the class scope.

This mirrors slang's existing treatment of class subroutine bodies, which are
already bound with `LookupLocation::max` for the same reason (so a method body
can see the whole class body). The change is a single gated block in
`Lookup::unqualifiedImpl`, placed right after the existing null-scope guard.

## Not a blanket suppression

The relaxation is deliberately narrow and does not weaken diagnostics:

- A genuinely undeclared identifier inside the covergroup still errors with
  `UndeclaredIdentifier`.
- A *module*-level covergroup referencing a later module item still errors — the
  relaxation is gated to the covergroup → class boundary only.

## Tests

Three `TEST_CASE`s added in `tests/unittests/ast/CoverTests.cpp`:

1. embedded covergroup sees a later class member (positive);
2. undeclared identifier inside the covergroup still errors (diagnostic preserved);
3. module-level covergroup forward reference still errors (gating).

Full unit-test suite passes locally (22543 assertions / 2344 cases);
`clang-format --dry-run -Werror` is clean on the changed files; CHANGELOG
updated.

Happy to open a discussion first if you'd prefer that process for this change —
it seemed small and well-scoped enough to send directly, but I'll gladly follow
your lead.
