### PR TITLE
Improve boost detection

### DIFF
--- a/include/slang/util/ConcurrentMap.h
+++ b/include/slang/util/ConcurrentMap.h
@@ -11,6 +11,7 @@
 
 #define BOOST_UNORDERED_DISABLE_PARALLEL_ALGORITHMS
 #if __has_include(<boost/unordered/concurrent_flat_map.hpp>) && \
+    __has_include(<boost/unordered/concurrent_flat_set.hpp>) && \
     __has_include(<boost/unordered/unordered_flat_map.hpp>)
 #    include <boost/unordered/concurrent_flat_map.hpp>
 #    include <boost/unordered/concurrent_flat_set.hpp>

--- a/include/slang/util/FlatMap.h
+++ b/include/slang/util/FlatMap.h
@@ -10,7 +10,8 @@
 #include "slang/util/Hash.h"
 
 #if __has_include(<boost/unordered/unordered_flat_map.hpp>) && \
-    __has_include(<boost/unordered/concurrent_flat_map.hpp>)
+    __has_include(<boost/unordered/concurrent_flat_map.hpp>) && \
+    __has_include(<boost/unordered/concurrent_flat_set.hpp>)
 #    include <boost/unordered/unordered_flat_map.hpp>
 #    include <boost/unordered/unordered_flat_set.hpp>
 #else


### PR DESCRIPTION
This improves checks added in #1849 for the cases like Boost 1.83 at Ubuntu 24.04 where we do have `concurrent_flat_map.hpp` but not `concurrent_flat_set.hpp`

Example failure : https://github.com/povik/yosys-slang/actions/runs/27532593503/job/81374106454?pr=340