### PR TITLE
Extend CommandLine with getHelpOptions

### DIFF
--- a/include/slang/util/CommandLine.h
+++ b/include/slang/util/CommandLine.h
@@ -387,6 +387,9 @@ public:
     /// @a overview text is a human friendly description of what the program does.
     std::string getHelpText(std::string_view overview) const;
 
+    /// Gets a list of help options based on registered flags.
+    std::vector<std::pair<std::string, std::string>> getHelpOptions() const;
+
 private:
     using OptionStorage =
         std::variant<std::optional<bool>*, std::optional<int32_t>*, std::optional<uint32_t>*,

--- a/source/util/CommandLine.cpp
+++ b/source/util/CommandLine.cpp
@@ -582,6 +582,25 @@ std::string CommandLine::getHelpText(std::string_view overview) const {
     return result;
 }
 
+std::vector<std::pair<std::string, std::string>> CommandLine::getHelpOptions() const {
+    std::vector<std::pair<std::string, std::string>> result;
+    result.reserve(orderedOptions.size());
+
+    for (const auto& opt : orderedOptions) {
+        std::string key = opt->allArgNames;
+
+        if (!opt->valueName.empty()) {
+            if (opt->valueName[0] != '=')
+                key += ' ';
+            key += opt->valueName;
+        }
+
+        result.emplace_back(std::move(key), opt->desc);
+    }
+
+    return result;
+}
+
 void CommandLine::handlePlusArg(std::string_view arg, const ParseOptions& options,
                                 bool& hadUnknowns, SourceLocation loc) {
     // Values are plus separated.

--- a/tests/unittests/util/CommandLineTests.cpp
+++ b/tests/unittests/util/CommandLineTests.cpp
@@ -122,6 +122,24 @@ OPTIONS:
   -m,+multi            SDF
   --count              asdf
 )");
+
+    std::vector<std::pair<std::string, std::string>> expected = {
+        {"-a", "SDF"},
+        {"-b", "SDF"},
+        {"-z,-y,-x,--longFlag", "This flag does fun stuff"},
+        {"--longFlag2", "Another\ngood\nthing"},
+        {"-c", "SDF"},
+        {"-d", "SDF"},
+        {"-e,--ext", "Definitely should set me"},
+        {"-f,--ext2 <value>", "Me too!"},
+        {"--biz,--baz <entry>", "SDF"},
+        {"--buz,--boz=<val>", "SDF"},
+        {"--fiz,--faz", "SDF"},
+        {"--fuz,--foz", "SDF"},
+        {"-m,+multi", "SDF"},
+        {"--count", "asdf"},
+    };
+    CHECK(cmdLine.getHelpOptions() == expected);
 }
 
 TEST_CASE("Test CommandLine -- backslash at EOL") {


### PR DESCRIPTION
This PR adds a simple help function to extract help options and their descriptions.

It solves request from https://github.com/MikePopoloski/slang/issues/1875
