### PR TITLE
Add skip capture override option

### DIFF
--- a/include/slang/util/OS.h
+++ b/include/slang/util/OS.h
@@ -38,6 +38,9 @@ public:
     static void setStdoutColorsEnabled(bool enabled) { showColorsStdout = enabled; }
     static void setStderrColorsEnabled(bool enabled) { showColorsStderr = enabled; }
 
+    /// Sets whether skip capture override should be enabled for the print() functions.
+    static void setSkipCaptureOverride(bool enabled) { captureOverride = enabled; }
+
     /// Reads a file from @a path into memory. If successful, the bytes are placed
     /// into @a buffer -- otherwise, returns false.
     /// Note that the buffer will be null-terminated.
@@ -92,6 +95,7 @@ private:
             capturedStderr += text;
     }
 
+    static inline bool captureOverride = false;
     static inline bool showColorsStdout = false;
     static inline bool showColorsStderr = false;
     static inline std::function<void(std::string_view, bool)> outputCallback;

--- a/source/util/OS.cpp
+++ b/source/util/OS.cpp
@@ -315,7 +315,7 @@ void OS::writeFile(const fs::path& path, std::string_view contents) {
 
 void OS::print(std::string_view text, bool skipCapture) {
     if (outputCallback) {
-        if (!skipCapture)
+        if (!skipCapture || captureOverride)
             outputCallback(text, /* isStdout */ true);
     }
     else {
@@ -325,7 +325,7 @@ void OS::print(std::string_view text, bool skipCapture) {
 
 void OS::print(const fmt::text_style& style, std::string_view text, bool skipCapture) {
     if (outputCallback) {
-        if (!skipCapture)
+        if (!skipCapture || captureOverride)
             outputCallback(text, /* isStdout */ true);
     }
     else if (showColorsStdout) {
@@ -338,7 +338,7 @@ void OS::print(const fmt::text_style& style, std::string_view text, bool skipCap
 
 void OS::printE(std::string_view text, bool skipCapture) {
     if (outputCallback) {
-        if (!skipCapture)
+        if (!skipCapture || captureOverride)
             outputCallback(text, /* isStdout */ false);
     }
     else {
@@ -348,7 +348,7 @@ void OS::printE(std::string_view text, bool skipCapture) {
 
 void OS::printE(const fmt::text_style& style, std::string_view text, bool skipCapture) {
     if (outputCallback) {
-        if (!skipCapture)
+        if (!skipCapture || captureOverride)
             outputCallback(text, /* isStdout */ false);
     }
     else if (showColorsStderr) {

--- a/tests/unittests/util/UtilTests.cpp
+++ b/tests/unittests/util/UtilTests.cpp
@@ -49,10 +49,30 @@ TEST_CASE("OS print helpers capture raw messages") {
     OS::printE("bad thing");
     OS::printE("heads up");
     OS::printE("skipped", /* skipCapture */ true);
+    OS::printE({}, "skipped again", /* skipCapture */ true);
 
     REQUIRE(output.size() == 2);
     CHECK(output[0] == std::pair<std::string, bool>{"bad thing", false});
     CHECK(output[1] == std::pair<std::string, bool>{"heads up", false});
+}
+
+TEST_CASE("OS print helpers skip capture override") {
+    std::vector<std::pair<std::string, bool>> output;
+    auto guard = OS::captureOutput(
+        [&](std::string_view text, bool isStdout) { output.emplace_back(text, isStdout); });
+
+    OS::setSkipCaptureOverride(true);
+    OS::printE("bad thing");
+    OS::printE("heads up");
+    OS::printE("skipped", /* skipCapture */ true);
+    OS::printE({}, "skipped again", /* skipCapture */ true);
+    OS::setSkipCaptureOverride(false);
+
+    REQUIRE(output.size() == 4);
+    CHECK(output[0] == std::pair<std::string, bool>{"bad thing", false});
+    CHECK(output[1] == std::pair<std::string, bool>{"heads up", false});
+    CHECK(output[2] == std::pair<std::string, bool>{"skipped", false});
+    CHECK(output[3] == std::pair<std::string, bool>{"skipped again", false});
 }
 
 TEST_CASE("Bag constructor doesn't accept Bag") {


### PR DESCRIPTION
Output callbacks are useful for testing but doing something like 
```
auto guard = slang::OS::captureOutput([&](std::string_view text, bool) { log("%s", text); });
```
could use main application logging system, but due to `skipCapture` parameter of print functions would also skip some important parts. With this change we can override this and make sure that always all is propagated to our capture funciton.

