### PR TITLE
Preserve self-determined types for unknown module port connections

### DIFF
--- a/include/slang/ast/ASTContext.h
+++ b/include/slang/ast/ASTContext.h
@@ -184,8 +184,14 @@ enum class SLANG_EXPORT ASTFlags : uint64_t {
 
     /// AST binding is for a wildcard port connection.
     WildcardPortConn = 1ull << 42,
+
+    /// AST binding is for a port connection of an unknown / uninstantiated module
+    /// instance. The target port type is not known, so expressions are bound
+    /// self-determined and diagnostics that would otherwise require a context
+    /// (target) type are suppressed.
+    UnknownPortConn = 1ull << 43,
 };
-SLANG_BITMASK(ASTFlags, WildcardPortConn)
+SLANG_BITMASK(ASTFlags, UnknownPortConn)
 
 /// Various flags that can be applied to a constant expression evaluation.
 enum class SLANG_EXPORT EvalFlags : uint8_t {

--- a/source/ast/expressions/AssignmentExpressions.cpp
+++ b/source/ast/expressions/AssignmentExpressions.cpp
@@ -794,7 +794,7 @@ Expression& Expression::bindAssignmentPattern(Compilation& comp,
     }
 
     if (!assignmentTarget || assignmentTarget->isError()) {
-        if (!assignmentTarget)
+        if (!assignmentTarget && !context.flags.has(ASTFlags::UnknownPortConn))
             context.addDiag(diag::AssignmentPatternNoContext, syntax.sourceRange());
         return badExpr(comp, &bindInvalidAssignmentPattern(context, p));
     }

--- a/source/ast/expressions/MiscExpressions.cpp
+++ b/source/ast/expressions/MiscExpressions.cpp
@@ -1602,8 +1602,10 @@ Expression& TaggedUnionExpression::fromSyntax(Compilation& compilation,
                                               const ASTContext& context,
                                               const Type* assignmentTarget) {
     if (!assignmentTarget || !assignmentTarget->isTaggedUnion()) {
-        if (!assignmentTarget || !assignmentTarget->isError())
+        if ((!assignmentTarget || !assignmentTarget->isError()) &&
+            !context.flags.has(ASTFlags::UnknownPortConn)) {
             context.addDiag(diag::TaggedUnionTarget, syntax.sourceRange());
+        }
         return badExpr(compilation, nullptr);
     }
 

--- a/source/ast/expressions/OperatorExpressions.cpp
+++ b/source/ast/expressions/OperatorExpressions.cpp
@@ -1943,7 +1943,8 @@ Expression& ConcatenationExpression::fromSyntax(Compilation& comp,
 
         if (!type.isIntegral()) {
             errored = true;
-            context.addDiag(diag::BadConcatExpression, arg->sourceRange) << type;
+            if (!context.flags.has(ASTFlags::UnknownPortConn))
+                context.addDiag(diag::BadConcatExpression, arg->sourceRange) << type;
             break;
         }
 
@@ -1987,7 +1988,8 @@ Expression& ConcatenationExpression::fromSyntax(Compilation& comp,
         }
 
         if (!anyStrings && totalWidth == 0) {
-            context.addDiag(diag::EmptyConcatNotAllowed, syntax.sourceRange());
+            if (!context.flags.has(ASTFlags::UnknownPortConn))
+                context.addDiag(diag::EmptyConcatNotAllowed, syntax.sourceRange());
             errored = true;
         }
     }
@@ -2013,8 +2015,10 @@ Expression& ConcatenationExpression::fromEmpty(Compilation& comp,
                                                const Type* assignmentTarget) {
     // Empty concatenation can only target arrays.
     if (!assignmentTarget || !assignmentTarget->isUnpackedArray()) {
-        if (!assignmentTarget || !assignmentTarget->isError())
+        if ((!assignmentTarget || !assignmentTarget->isError()) &&
+            !context.flags.has(ASTFlags::UnknownPortConn)) {
             context.addDiag(diag::EmptyConcatNotAllowed, syntax.sourceRange());
+        }
         return badExpr(comp, nullptr);
     }
 

--- a/source/ast/symbols/InstanceSymbols.cpp
+++ b/source/ast/symbols/InstanceSymbols.cpp
@@ -1298,7 +1298,8 @@ static const AssertionExpr* bindUnknownPortConn(const ASTContext& context,
     // We have to check for a simple reference to an interface instance or port here,
     // since we don't know whether this is an interface port connection or even
     // a normal connection with a virtual interface type.
-    const auto flags = ASTFlags::AllowUnboundedLiteral | ASTFlags::StreamingAllowed;
+    const auto flags = ASTFlags::AllowUnboundedLiteral | ASTFlags::StreamingAllowed |
+                       ASTFlags::UnknownPortConn;
     const SyntaxNode* node = &syntax;
     if (node->kind == SyntaxKind::SimplePropertyExpr) {
         node = node->as<SimplePropertyExprSyntax>().expr;
@@ -1331,9 +1332,11 @@ static const AssertionExpr* bindUnknownPortConn(const ASTContext& context,
                     }
                 }
 
-                return comp.emplace<SimpleAssertionExpr>(
-                    Expression::bindRValue(comp.getErrorType(), *expr, {}, context, flags),
-                    std::nullopt);
+                // Bind self-determined so that typeable connections keep their real
+                // type. The UnknownPortConn flag suppresses diagnostics for the
+                // genuinely context-dependent expressions that have no such type.
+                return comp.emplace<SimpleAssertionExpr>(Expression::bind(*expr, context, flags),
+                                                         std::nullopt);
             }
         }
     }

--- a/tests/unittests/ast/HierarchyTests.cpp
+++ b/tests/unittests/ast/HierarchyTests.cpp
@@ -2756,6 +2756,71 @@ endmodule
     NO_COMPILATION_ERRORS;
 }
 
+TEST_CASE("Uninstantiated def port connections keep self-determined types") {
+    auto tree = SyntaxTree::fromText(R"(
+module top;
+    logic [7:0] x, y;
+    hard u(.a(x), .b(8'hAB), .c(x + y), .d('{default:'0}));
+endmodule
+)");
+    CompilationOptions options;
+    options.flags |= CompilationFlags::IgnoreUnknownModules;
+
+    Compilation compilation(options);
+    compilation.addSyntaxTree(tree);
+    NO_COMPILATION_ERRORS;
+
+    auto& u = compilation.getRoot().lookupName<UninstantiatedDefSymbol>("top.u");
+    auto conns = u.getPortConnections();
+    REQUIRE(conns.size() == 4);
+
+    auto typeOf = [&](size_t i) -> const Type& {
+        return *conns[i]->as<SimpleAssertionExpr>().expr.type;
+    };
+
+    CHECK(!typeOf(0).isError());
+    CHECK(!typeOf(1).isError());
+    CHECK(typeOf(1).getBitWidth() == 8);
+    CHECK(!typeOf(2).isError());
+
+    CHECK(typeOf(3).isError());
+}
+
+TEST_CASE("Uninstantiated def port connections with no self-determined type") {
+    auto tree = SyntaxTree::fromText(R"(
+module top;
+    int a[];
+    int b;
+    hard h1({});
+    hard h2('{default:0});
+    hard h3(tagged A);
+    hard h4({<<{a with [b]}});
+    hard h5({a, b});
+endmodule
+)");
+    CompilationOptions options;
+    options.flags |= CompilationFlags::IgnoreUnknownModules;
+
+    Compilation compilation(options);
+    compilation.addSyntaxTree(tree);
+
+    NO_COMPILATION_ERRORS;
+
+    auto exprOf = [&](std::string_view name) -> const Expression& {
+        auto& sym = compilation.getRoot().lookupName<UninstantiatedDefSymbol>(name);
+        auto conns = sym.getPortConnections();
+        REQUIRE(conns.size() == 1);
+        return conns[0]->as<SimpleAssertionExpr>().expr;
+    };
+
+    CHECK(exprOf("top.h1").type->isError()); // {}
+    CHECK(exprOf("top.h2").type->isError()); // '{default:0}
+    CHECK(exprOf("top.h3").type->isError()); // tagged A
+    CHECK(exprOf("top.h5").type->isError()); // {a, b} with a dynamic array
+
+    CHECK(exprOf("top.h4").kind == ExpressionKind::Streaming);
+}
+
 TEST_CASE("Ignore uninstantiated modules") {
     auto tree = SyntaxTree::fromText(R"(
 module unused;


### PR DESCRIPTION
Closes https://github.com/MikePopoloski/slang/issues/1885