### PR TITLE
Allow ParseOptions in C-style parsing methods

### DIFF
--- a/include/slang/driver/Driver.h
+++ b/include/slang/driver/Driver.h
@@ -389,8 +389,9 @@ public:
     /// This is templated to support both char and wchar_t arg lists.
     /// Any errors encountered will be printed to stderr.
     template<typename TArgs>
-    [[nodiscard]] bool parseCommandLine(int argc, TArgs argv) {
-        if (!cmdLine.parse(argc, argv)) {
+    [[nodiscard]] bool parseCommandLine(int argc, TArgs argv,
+                                        const CommandLine::ParseOptions& parseOptions = {}) {
+        if (!cmdLine.parse(argc, argv, parseOptions)) {
             issueCommandLineErrors(cmdLine);
             return false;
         }

--- a/include/slang/util/CommandLine.h
+++ b/include/slang/util/CommandLine.h
@@ -324,10 +324,6 @@ public:
     /// @returns a string containing an error message if the @a value is malformed.
     std::string addRenameCommand(std::string_view value);
 
-    /// Parse the provided command line (C-style).
-    /// @return true on success, false if any errors occur.
-    bool parse(int argc, const char* const argv[]);
-
     /// Represents an error encountered while parsing command line arguments.
     struct Error {
         /// A human-readable error message.
@@ -364,6 +360,10 @@ public:
 
         ParseOptions() {}
     };
+
+    /// Parse the provided command line (C-style).
+    /// @return true on success, false if any errors occur.
+    bool parse(int argc, const char* const argv[], const ParseOptions& options = {});
 
     /// Parse the provided command line (space delimited, with handling of
     /// quoted arguments).

--- a/source/util/CommandLine.cpp
+++ b/source/util/CommandLine.cpp
@@ -163,12 +163,12 @@ void CommandLine::setPositional(const OptionStrCallback& cb, std::string_view va
     positional->flags = flags;
 }
 
-bool CommandLine::parse(int argc, const char* const argv[]) {
+bool CommandLine::parse(int argc, const char* const argv[], const ParseOptions& options) {
     SmallVector<std::string_view, 8> args{size_t(argc), UninitializedTag()};
     for (int i = 0; i < argc; i++)
         args.push_back(argv[i]);
 
-    return parse(args);
+    return parse(args, options);
 }
 
 bool CommandLine::parse(std::string_view argList, const ParseOptions& options) {

--- a/tests/unittests/DriverTests.cpp
+++ b/tests/unittests/DriverTests.cpp
@@ -523,3 +523,16 @@ TEST_CASE("Driver single-unit gives library files their own tree") {
     CHECK(defaultUnits == 1);
     CHECK(libraryUnits == 1);
 }
+
+TEST_CASE("Driver basic with ParseOptions") {
+    Driver driver;
+    driver.addStandardArgs();
+
+    auto filePath = findTestDir() + "test.sv";
+    const char* argv[] = {"testfoo", filePath.c_str(), "-j", "2", "-j", "1"};
+    slang::CommandLine::ParseOptions parseOptions;
+    parseOptions.ignoreDuplicates = true;
+    CHECK(driver.parseCommandLine(6, argv, parseOptions));
+    CHECK(driver.processOptions());
+    CHECK(driver.options.numThreads == 2);
+}

--- a/tests/unittests/DriverTests.cpp
+++ b/tests/unittests/DriverTests.cpp
@@ -529,10 +529,9 @@ TEST_CASE("Driver basic with ParseOptions") {
     driver.addStandardArgs();
 
     auto filePath = findTestDir() + "test.sv";
-    const char* argv[] = {"testfoo", filePath.c_str(), "-j", "2", "-j", "1"};
+    const char* argv[] = {"testfoo", filePath.c_str(), "--lint-only", "--lint-only"};
     slang::CommandLine::ParseOptions parseOptions;
     parseOptions.ignoreDuplicates = true;
-    CHECK(driver.parseCommandLine(6, argv, parseOptions));
+    CHECK(driver.parseCommandLine(4, argv, parseOptions));
     CHECK(driver.processOptions());
-    CHECK(driver.options.numThreads == 2);
 }


### PR DESCRIPTION
The following Pull Request introduces optional `ParseOptions`-parameter to C-style parsing methods:
```
template<typename TArgs>
bool Driver::parseCommandLine(int argc, TArgs argv);

bool CommandLine::parse(int argc, const char* const argv[]);
```