### PR TITLE
Analysis: Diag ranges instead of locs for unused vars

### DIFF
--- a/include/slang/analysis/AnalysisManager.h
+++ b/include/slang/analysis/AnalysisManager.h
@@ -75,6 +75,9 @@ public:
 
     /// Issues a new diagnostic.
     Diagnostic& addDiag(const ast::Symbol& symbol, DiagCode code, SourceRange sourceRange);
+
+    /// Issues a new diagnostic.
+    Diagnostic& addDiag(const ast::Symbol& symbol, DiagCode code);
 };
 
 /// The analysis manager coordinates running various analyses on AST symbols.
@@ -191,6 +194,7 @@ public:
                                    bool isDisableCondition = false);
 
 private:
+    friend class AnalysisContext;
     friend struct AnalysisScopeVisitor;
     friend class AnalyzedProcedure;
 

--- a/source/analysis/AnalysisManager.cpp
+++ b/source/analysis/AnalysisManager.cpp
@@ -14,6 +14,7 @@
 #include "slang/analysis/DataFlowAnalysis.h"
 #include "slang/ast/ASTDiagMap.h"
 #include "slang/ast/Compilation.h"
+#include "slang/text/SourceManager.h"
 
 namespace slang::analysis {
 
@@ -40,6 +41,16 @@ Diagnostic& AnalysisContext::addDiag(const Symbol& symbol, DiagCode code, Source
 
 Diagnostic& AnalysisContext::addDiag(const Symbol& symbol, DiagCode code, SourceRange sourceRange) {
     return diagnostics.add(symbol, code, sourceRange);
+}
+
+Diagnostic& AnalysisContext::addDiag(const Symbol& symbol, DiagCode code) {
+    if (manager->sourceManager->isMacroLoc(symbol.location)) {
+        return diagnostics.add(symbol, code, symbol.location);
+    }
+    else {
+        return diagnostics.add(
+            symbol, code, SourceRange{symbol.location, symbol.location + symbol.name.length()});
+    }
 }
 
 AnalysisManager::AnalysisManager(AnalysisOptions options, std::shared_ptr<ThreadPool> threadPool) :
@@ -87,8 +98,7 @@ void AnalysisManager::analyze(const Compilation& compilation) {
     if (hasFlag(AnalysisFlags::CheckUnused)) {
         for (auto def : compilation.getUnreferencedDefinitions()) {
             if (!def->name.empty() && def->name != "_"sv && !hasUnusedAttrib(compilation, *def)) {
-                state.context.addDiag(*def, diag::UnusedDefinition, def->location)
-                    << def->getKindString();
+                state.context.addDiag(*def, diag::UnusedDefinition) << def->getKindString();
             }
         }
     }

--- a/source/analysis/AnalysisScopeVisitor.h
+++ b/source/analysis/AnalysisScopeVisitor.h
@@ -7,6 +7,7 @@
 //------------------------------------------------------------------------------
 #pragma once
 
+#include "slang/analysis/AnalysisManager.h"
 #include "slang/analysis/ValueDriver.h"
 #include "slang/ast/ASTVisitor.h"
 #include "slang/ast/EvalContext.h"
@@ -494,8 +495,7 @@ private:
 
         auto [used, _] = isReferenced(*syntax);
         if (!used && shouldWarnUnused(symbol)) {
-            auto& diag = context.addDiag(symbol, isInPackage(symbol) ? packageCode : code,
-                                         symbol.location);
+            auto& diag = context.addDiag(symbol, isInPackage(symbol) ? packageCode : code);
             if constexpr (!std::is_same_v<TKindGetter, std::nullptr_t>) {
                 diag << kindGetter();
             }
@@ -518,7 +518,7 @@ private:
 
     void addUnusedDiag(const Symbol& symbol, DiagCode code) {
         if (shouldWarnUnused(symbol))
-            context.addDiag(symbol, code, symbol.location) << symbol.name;
+            context.addDiag(symbol, code) << symbol.name;
     }
 
     void checkShadowProperty(const ClassPropertySymbol& symbol) {

--- a/tests/unittests/analysis/UnusedTests.cpp
+++ b/tests/unittests/analysis/UnusedTests.cpp
@@ -313,6 +313,59 @@ endmodule
     CHECK(diags[0].isError());
 }
 
+TEST_CASE("Unused diagnostics cover the symbol name") {
+    auto& text = R"(
+module m;
+    int unused_name;
+endmodule
+)";
+
+    Compilation compilation;
+    auto diags = analyze(text, compilation);
+    REQUIRE(diags.size() == 1);
+    CHECK(diags[0].code == diag::UnusedVariable);
+    REQUIRE(diags[0].ranges.size() == 1);
+
+    auto range = diags[0].ranges[0];
+    auto sm = compilation.getSourceManager();
+    CHECK(range.end() - range.start() == 11);
+    CHECK(sm->getColumnNumber(range.start()) == 9);
+    CHECK(sm->getColumnNumber(range.end()) == 20);
+}
+
+TEST_CASE("Unused definition inside macro expansion uses point diagnostic") {
+    auto libTree = SyntaxTree::fromText(R"(
+`define DEFINE_UNUSED_DEF module unused_from_macro; endmodule
+`DEFINE_UNUSED_DEF
+)");
+    libTree->isLibraryUnit = true;
+
+    auto userTree = SyntaxTree::fromText(R"(
+module top;
+endmodule
+)");
+
+    Compilation compilation;
+    compilation.addSyntaxTree(libTree);
+    compilation.addSyntaxTree(userTree);
+
+    auto diags = compilation.getAllDiagnostics();
+    compilation.freeze();
+
+    AnalysisOptions options;
+    options.flags = AnalysisFlags::CheckUnused;
+    AnalysisManager analysisManager(options);
+    analysisManager.analyze(compilation);
+
+    diags.append_range(analysisManager.getDiagnostics());
+    REQUIRE(diags.size() == 1);
+    CHECK(diags[0].code == diag::UnusedDefinition);
+    REQUIRE(diags[0].args.size() == 1);
+    CHECK(std::get<std::string>(diags[0].args[0]) == "module");
+    CHECK(compilation.getSourceManager()->isMacroLoc(diags[0].location));
+    CHECK(diags[0].ranges.empty());
+}
+
 TEST_CASE("Undriven net via unused modport writer") {
     auto& text = R"(
 interface status_if;


### PR DESCRIPTION
Stacked PRs:
 * #1910
 * __->__#1902


--- --- ---


[View individual changes](https://github.com/AndrewNolte/slang/commit/3f0a7c51430d465642946bef5071ff3ee71db50e)
### Analysis: Diag ranges instead of locs for unused vars


For slang-server we want these to cover the whole id.
Related issue: https://github.com/hudson-trading/slang-server/issues/187
