### PR TITLE
Fix Indirect Package exports with refactor

### DIFF
--- a/bindings/python/SymbolBindings.cpp
+++ b/bindings/python/SymbolBindings.cpp
@@ -175,7 +175,6 @@ void registerSymbols(py::module_& m) {
                                [](const PackageSymbol& self) { return &self.defaultNetType; })
         .def_readonly("timeScale", &PackageSymbol::timeScale)
         .def_readonly("defaultLifetime", &PackageSymbol::defaultLifetime)
-        .def_readonly("exportDecls", &PackageSymbol::exportDecls)
         .def_readonly("hasExportAll", &PackageSymbol::hasExportAll)
         .def("findForImport", &PackageSymbol::findForImport, byrefint, "name"_a);
 
@@ -493,13 +492,11 @@ void registerSymbols(py::module_& m) {
     py::classh<ExplicitImportSymbol, Symbol>(m, "ExplicitImportSymbol")
         .def_readonly("packageName", &ExplicitImportSymbol::packageName)
         .def_readonly("importName", &ExplicitImportSymbol::importName)
-        .def_readonly("isFromExport", &ExplicitImportSymbol::isFromExport)
         .def_property_readonly("package", &ExplicitImportSymbol::package)
         .def_property_readonly("importedSymbol", &ExplicitImportSymbol::importedSymbol);
 
     py::classh<WildcardImportSymbol, Symbol>(m, "WildcardImportSymbol")
         .def_readonly("packageName", &WildcardImportSymbol::packageName)
-        .def_readonly("isFromExport", &WildcardImportSymbol::isFromExport)
         .def_property_readonly("package", &WildcardImportSymbol::getPackage);
 
     py::classh<ModportPortSymbol, ValueSymbol>(m, "ModportPortSymbol")

--- a/include/slang/ast/symbols/CompilationUnitSymbols.h
+++ b/include/slang/ast/symbols/CompilationUnitSymbols.h
@@ -50,7 +50,6 @@ public:
     const NetType& defaultNetType;
     std::optional<TimeScale> timeScale;
     VariableLifetime defaultLifetime;
-    std::span<const syntax::PackageImportItemSyntax* const> exportDecls;
     bool hasExportAll = false;
 
     PackageSymbol(Compilation& compilation, std::string_view name, SourceLocation loc,
@@ -61,7 +60,9 @@ public:
     /// exported from the package.
     const Symbol* findForImport(std::string_view name) const;
 
-    void checkExplicitExports() const;
+    /// Validates this package's export declarations and populates the export maps.
+    /// Idempotent; does nothing if the package has no export declarations.
+    void resolveExports() const;
 
     void serializeTo(ASTSerializer&) const {}
 
@@ -73,9 +74,23 @@ public:
     static bool isKind(SymbolKind kind) { return kind == SymbolKind::Package; }
 
 private:
-    // Checks whether the given symbol, which was imported into this package from
-    // another package, is re-exported by this package via an export declaration.
-    bool isExported(const Symbol& symbol) const;
+    struct ExportData {
+        // All `export p::x` and `export p::*` declaration items in source order.
+        std::span<const syntax::PackageImportItemSyntax* const> decls;
+
+        // Explicit exports that have been imported and validated, keyed by exported member name.
+        SymbolMap* explicitExportSyms = nullptr;
+
+        // Validated star exports, keyed by exported package name.
+        SymbolMap* wildcardExportPackages = nullptr;
+
+        // Tracks whether the export declarations have been validated and maps populated.
+        mutable bool resolved = false;
+    };
+
+    // Optional package export state, present only when the package has explicit
+    // or star export declaration items.
+    ExportData* exportData = nullptr;
 };
 
 /// Represents the entirety of a design, along with all contained compilation units.

--- a/include/slang/ast/symbols/MemberSymbols.h
+++ b/include/slang/ast/symbols/MemberSymbols.h
@@ -58,7 +58,6 @@ class SLANG_EXPORT ExplicitImportSymbol final : public Symbol {
 public:
     std::string_view packageName;
     std::string_view importName;
-    bool isFromExport = false;
 
     ExplicitImportSymbol(std::string_view packageName, std::string_view importName,
                          SourceLocation location) :
@@ -68,9 +67,6 @@ public:
     const PackageSymbol* package() const;
     const Symbol* importedSymbol() const;
 
-    void noteCorrespondingImport() const { correspondingImport = true; }
-    bool sawCorrespondingImport() const { return correspondingImport; }
-
     void serializeTo(ASTSerializer& serializer) const;
 
     static bool isKind(SymbolKind kind) { return kind == SymbolKind::ExplicitImport; }
@@ -79,7 +75,6 @@ private:
     mutable const PackageSymbol* package_ = nullptr;
     mutable const Symbol* import = nullptr;
     mutable bool initialized = false;
-    mutable bool correspondingImport = false;
 };
 
 /// Represents a wildcard import declaration. This symbol is special in
@@ -89,7 +84,6 @@ private:
 class SLANG_EXPORT WildcardImportSymbol final : public Symbol {
 public:
     std::string_view packageName;
-    bool isFromExport = false;
 
     WildcardImportSymbol(std::string_view packageName, SourceLocation location) :
         Symbol(SymbolKind::WildcardImport, "", location), packageName(packageName) {}

--- a/source/ast/ElabVisitors.h
+++ b/source/ast/ElabVisitors.h
@@ -73,7 +73,7 @@ struct DiagnosticVisitor : public ASTVisitor<DiagnosticVisitor> {
     void handle(const PackageSymbol& symbol) {
         if (!handleDefault(symbol))
             return;
-        symbol.checkExplicitExports();
+        symbol.resolveExports();
     }
 
     void handle(const InterfacePortSymbol& symbol) {

--- a/source/ast/Scope.cpp
+++ b/source/ast/Scope.cpp
@@ -241,31 +241,8 @@ void Scope::addMembers(const SyntaxNode& syntax) {
             break;
         }
         case SyntaxKind::PackageExportDeclaration: {
-            auto& exportDecl = syntax.as<PackageExportDeclarationSyntax>();
-            for (auto item : exportDecl.items) {
-                if (item->item.kind == TokenKind::Star) {
-                    // These are handled manually as "wildcard imports" but don't get
-                    // added to the import list. This is done just so that the package
-                    // name itself gets validated and the attributes have somewhere to live.
-                    // The actual export functionality is handled in PackageSymbol.
-                    auto import = compilation.emplace<WildcardImportSymbol>(
-                        item->package.valueText(), item->item.location());
-
-                    import->setSyntax(*item);
-                    import->setAttributes(*this, exportDecl.attributes);
-                    import->isFromExport = true;
-                    addMember(*import);
-                }
-                else {
-                    auto import = compilation.emplace<ExplicitImportSymbol>(
-                        item->package.valueText(), item->item.valueText(), item->item.location());
-
-                    import->setSyntax(*item);
-                    import->setAttributes(*this, exportDecl.attributes);
-                    import->isFromExport = true;
-                    addMember(*import);
-                }
-            }
+            // Package exports are tracked separately by PackageSymbol so that they don't collide
+            // with ordinary package members in this scope's name map.
             break;
         }
         case SyntaxKind::HierarchyInstantiation:
@@ -707,16 +684,6 @@ void Scope::handleNameConflict(const Symbol& member, const Symbol*& existing) co
     }
 
     if (existing->kind == SymbolKind::ExplicitImport && member.kind == SymbolKind::ExplicitImport) {
-        // If one of these is an import and the other is an export we should note
-        // that there was a corresponding import for the export so we don't error later.
-        auto& ei = existing->as<ExplicitImportSymbol>();
-        auto& mi = member.as<ExplicitImportSymbol>();
-        if (ei.isFromExport != mi.isFromExport) {
-            // It doesn't hurt anything to set it for both, even though only one is an export.
-            ei.noteCorrespondingImport();
-            mi.noteCorrespondingImport();
-        }
-
         // These can't be checked until we can resolve the imports and
         // see if they point to the same symbol.
         compilation.noteNameConflict(member);
@@ -814,12 +781,10 @@ void Scope::checkImportConflict(const Symbol& member, const Symbol& existing) co
         return;
 
     if (s1 == s2) {
-        if (!mei.isFromExport && !eei.isFromExport) {
-            // Duplicate explicit imports are specifically allowed,
-            // so just ignore the other one (with a warning).
-            auto& diag = addDiag(diag::DuplicateImport, member.location);
-            diag.addNote(diag::NotePreviousDefinition, existing.location);
-        }
+        // Duplicate explicit imports are specifically allowed,
+        // so just ignore the other one (with a warning).
+        auto& diag = addDiag(diag::DuplicateImport, member.location);
+        diag.addNote(diag::NotePreviousDefinition, existing.location);
     }
     else {
         reportNameConflict(member, existing);

--- a/source/ast/symbols/CompilationUnitSymbols.cpp
+++ b/source/ast/symbols/CompilationUnitSymbols.cpp
@@ -15,6 +15,7 @@
 #include "slang/ast/symbols/MemberSymbols.h"
 #include "slang/ast/types/NetType.h"
 #include "slang/diagnostics/DeclarationsDiags.h"
+#include "slang/diagnostics/LookupDiags.h"
 #include "slang/syntax/AllSyntax.h"
 #include "slang/syntax/SyntaxTree.h"
 
@@ -83,6 +84,8 @@ PackageSymbol& PackageSymbol::fromSyntax(const Scope& scope, const ModuleDeclara
     std::optional<SourceRange> unitsRange;
     std::optional<SourceRange> precisionRange;
     SmallVector<const PackageImportItemSyntax*> exportDecls;
+    bool hasExplicitExports = false;
+    bool hasStarExports = false;
 
     for (auto member : syntax.members) {
         if (member->kind == SyntaxKind::TimeUnitsDeclaration) {
@@ -101,42 +104,203 @@ PackageSymbol& PackageSymbol::fromSyntax(const Scope& scope, const ModuleDeclara
             result->hasExportAll = true;
         }
         else if (member->kind == SyntaxKind::PackageExportDeclaration) {
-            for (auto item : member->as<PackageExportDeclarationSyntax>().items)
+            auto& exportDecl = member->as<PackageExportDeclarationSyntax>();
+            for (auto item : exportDecl.items) {
                 exportDecls.push_back(item);
+                if (item->item.kind == TokenKind::Star)
+                    hasStarExports = true;
+                else
+                    hasExplicitExports = true;
+            }
         }
 
         result->addMembers(*member);
     }
 
-    result->exportDecls = exportDecls.copy(comp);
+    if (!exportDecls.empty()) {
+        result->exportData = comp.emplace<ExportData>();
+        result->exportData->decls = exportDecls.copy(comp);
+
+        if (hasExplicitExports)
+            result->exportData->explicitExportSyms = comp.allocSymbolMap();
+
+        if (hasStarExports)
+            result->exportData->wildcardExportPackages = comp.allocSymbolMap();
+    }
 
     SemanticFacts::populateTimeScale(result->timeScale, scope, directiveTimeScale, unitsRange,
                                      precisionRange);
     return *result;
 }
 
-const Symbol* PackageSymbol::findForImport(std::string_view lookupName) const {
-    auto& scopeNameMap = getNameMap();
+static const PackageSymbol* findPackageForExport(std::string_view packageName,
+                                                 const PackageSymbol& lookupScope,
+                                                 SourceLocation errorLoc) {
+    auto& comp = lookupScope.getCompilation();
+    auto package = comp.getPackage(packageName);
+    if (!package) {
+        if (!packageName.empty() && !comp.hasFlag(CompilationFlags::LintMode))
+            lookupScope.addDiag(diag::UnknownPackage, errorLoc) << packageName;
+    }
+    // Unlike the general import case (see findPackage in MemberSymbols.cpp), an export
+    // always originates directly in a package body, so a self-reference can only be the
+    // package itself; there's no need to walk parent scopes.
+    else if (package == &lookupScope) {
+        lookupScope.addDiag(diag::PackageExportSelf, errorLoc);
+        return nullptr;
+    }
+
+    return package;
+}
+
+static const Symbol& unwrapTransparent(const Symbol& symbol) {
+    auto result = &symbol;
+    while (result->kind == SymbolKind::TransparentMember)
+        result = &result->as<TransparentMemberSymbol>().wrapped;
+    return *result;
+}
+
+// Checks that the given explicitly-exported symbol is actually imported into the
+// package, which is required for the export to be valid. Emits the appropriate
+// diagnostic and returns false if it is not.
+static bool checkExportIsImported(const PackageSymbol& package, const PackageImportItemSyntax& item,
+                                  const Symbol& exported) {
+    auto lookupName = item.item.valueText();
+
+    auto notImported = [&] {
+        package.addDiag(diag::PackageExportNotImported, item.item.location()) << lookupName;
+        return false;
+    };
+
+    auto& scopeNameMap = package.getNameMap();
     if (auto it = scopeNameMap.find(lookupName); it != scopeNameMap.end()) {
-        auto symbol = it->second;
-        while (symbol->kind == SymbolKind::TransparentMember)
-            symbol = &symbol->as<TransparentMemberSymbol>().wrapped;
+        auto& symbol = unwrapTransparent(*it->second);
+        if (auto ei = symbol.as_if<ExplicitImportSymbol>())
+            return ei->importedSymbol() == &exported ? true : notImported();
+
+        auto& diag = package.addDiag(diag::Redefinition, symbol.location);
+        diag << lookupName;
+        diag.addNote(diag::NotePreviousDefinition, item.item.location());
+        return false;
+    }
+
+    auto wildcardData = package.getWildcardImportData();
+    if (!wildcardData)
+        return notImported();
+
+    if (auto it = wildcardData->importedSymbols.find(lookupName);
+        it != wildcardData->importedSymbols.end()) {
+        if (it->second == &exported)
+            return true;
+
+        auto& diag = package.addDiag(diag::ImportNameCollision, item.item.range());
+        diag << lookupName;
+        diag.addNote(diag::NoteDeclarationHere, item.item.location());
+        diag.addNote(diag::NoteDeclarationHere, it->second->location);
+        return false;
+    }
+
+    for (auto import : wildcardData->wildcardImports) {
+        auto importPackage = import->getPackage();
+        if (!importPackage || importPackage->name != item.package.valueText())
+            continue;
+
+        return importPackage->findForImport(lookupName) == &exported ? true : notImported();
+    }
+
+    return notImported();
+}
+
+void PackageSymbol::resolveExports() const {
+    auto data = exportData;
+    if (!data || data->resolved)
+        return;
+
+    // Set this before doing any work; resolving an export can re-enter findForImport
+    // on this same package, and we want those lookups to see the maps we're building
+    // rather than recursing forever.
+    data->resolved = true;
+
+    // Resolve star exports first so that any re-entrant lookup performed while
+    // validating the explicit exports below sees a populated star map.
+    if (data->wildcardExportPackages) {
+        for (auto item : data->decls) {
+            if (item->item.kind != TokenKind::Star)
+                continue;
+
+            if (auto package = findPackageForExport(item->package.valueText(), *this,
+                                                    item->package.location())) {
+                data->wildcardExportPackages->emplace(item->package.valueText(), package);
+            }
+        }
+    }
+
+    if (data->explicitExportSyms) {
+        for (auto item : data->decls) {
+            if (item->item.kind == TokenKind::Star)
+                continue;
+
+            auto lookupName = item->item.valueText();
+            auto package = findPackageForExport(item->package.valueText(), *this,
+                                                item->package.location());
+            if (!package)
+                continue;
+
+            auto exported = package->findForImport(lookupName);
+            if (!exported) {
+                addDiag(diag::UnknownPackageMember, item->item.location())
+                    << lookupName << item->package.valueText();
+                continue;
+            }
+
+            if (!checkExportIsImported(*this, *item, *exported))
+                continue;
+
+            auto [it, inserted] = data->explicitExportSyms->emplace(lookupName, exported);
+            if (!inserted && it->second != exported) {
+                auto& diag = addDiag(diag::ImportNameCollision, item->item.range());
+                diag << lookupName;
+                diag.addNote(diag::NoteDeclarationHere, item->item.location());
+                diag.addNote(diag::NoteDeclarationHere, it->second->location);
+            }
+        }
+    }
+}
+
+// Walks up the parent scopes of the given symbol to find the package that owns it.
+static const Symbol& findOwningPackage(const Symbol& symbol) {
+    auto scope = symbol.getParentScope();
+    while (true) {
+        SLANG_ASSERT(scope);
+        auto& parent = scope->asSymbol();
+        if (parent.kind == SymbolKind::Package)
+            return parent;
+
+        scope = parent.getParentScope();
+    }
+}
+
+const Symbol* PackageSymbol::findForImport(std::string_view lookupName) const {
+    // A plain member (or forwarding typedef) is resolved without consulting exports,
+    // so handle those before resolving exports. This matters because resolveExports
+    // can re-enter findForImport on other packages; resolving eagerly for every
+    // lookup would break packages that mutually export from each other.
+    const ExplicitImportSymbol* eis = nullptr;
+    auto& scopeNameMap = getNameMap();
+    // Either find the symbol defined in the scope, or it's explicit import
+    if (auto it = scopeNameMap.find(lookupName); it != scopeNameMap.end()) {
+        auto symbol = &unwrapTransparent(*it->second);
 
         switch (symbol->kind) {
-            case SymbolKind::ExplicitImport: {
+            case SymbolKind::ExplicitImport:
                 // Items that are imported into a package are not made visible to
                 // things that subsequently import this package, unless they are
-                // also exported (see IEEE 1800-2017 section 26.6).
-                auto& eis = symbol->as<ExplicitImportSymbol>();
-                auto imported = eis.importedSymbol();
-                if (eis.isFromExport)
-                    return imported;
-
-                if (imported && isExported(*imported))
-                    return imported;
-
-                return nullptr;
-            }
+                // also exported (see IEEE 1800-2017 section 26.6). Fall through to
+                // the shared export resolution below to determine that.
+                eis = &symbol->as<ExplicitImportSymbol>();
+                if (!eis->importedSymbol())
+                    return nullptr;
+                break;
             case SymbolKind::ForwardingTypedef:
                 return nullptr;
             default:
@@ -144,8 +308,42 @@ const Symbol* PackageSymbol::findForImport(std::string_view lookupName) const {
         }
     }
 
+    resolveExports();
+
+    // If it was explicit imported, check that it was exported via explicit, export all, or wildcard
+    // export.
+    if (eis) {
+        auto imported = eis->importedSymbol();
+        if (exportData && exportData->explicitExportSyms) {
+            auto exportIt = exportData->explicitExportSyms->find(lookupName);
+            if (exportIt != exportData->explicitExportSyms->end() && exportIt->second == imported) {
+                return imported;
+            }
+        }
+
+        if (hasExportAll || (exportData && exportData->wildcardExportPackages &&
+                             exportData->wildcardExportPackages->contains(eis->packageName))) {
+            return imported;
+        }
+
+        return nullptr;
+    }
+
+    // The name isn't a direct member or explicit import, but it may still be
+    // explicitly exported -- e.g. `export p::x` where x was brought in via a
+    // wildcard import, so it never became a named member of this scope.
+    // explicitExportSyms only ever contains exports that resolveExports() has already
+    // confirmed are imported (see isImportedForExport), so no re-check is needed here.
+    if (exportData && exportData->explicitExportSyms) {
+        if (auto it = exportData->explicitExportSyms->find(lookupName);
+            it != exportData->explicitExportSyms->end()) {
+            return it->second;
+        }
+    }
+
+    // Now check our wildcard imports, if any
     auto wildcardData = getWildcardImportData();
-    if (!wildcardData || (!hasExportAll && exportDecls.empty()))
+    if (!wildcardData || (!hasExportAll && (!exportData || !exportData->wildcardExportPackages)))
         return nullptr;
 
     // We need to force-elaborate the entire package body because any
@@ -155,84 +353,21 @@ const Symbol* PackageSymbol::findForImport(std::string_view lookupName) const {
         getCompilation().forceElaborate(*this);
     }
 
-    // Look through symbols that have been wildcard imported with this name.
-    // If we don't have an export-all directive then we need to check whether
-    // we actually wanted to export this symbol.
+    // Look through symbols that have been wildcard imported with this name, and verify it's also
+    // exported.
     if (auto it = wildcardData->importedSymbols.find(lookupName);
         it != wildcardData->importedSymbols.end()) {
-        if (isExported(*it->second))
+        if (hasExportAll)
             return it->second;
+
+        if (exportData && exportData->wildcardExportPackages) {
+            auto& owningPackage = findOwningPackage(*it->second);
+            if (exportData->wildcardExportPackages->contains(owningPackage.name))
+                return it->second;
+        }
     }
 
     return nullptr;
-}
-
-bool PackageSymbol::isExported(const Symbol& symbol) const {
-    if (hasExportAll)
-        return true;
-
-    // Find the package that owns the target symbol.
-    const Symbol* packageParent;
-    auto targetScope = symbol.getParentScope();
-    while (true) {
-        SLANG_ASSERT(targetScope);
-        packageParent = &targetScope->asSymbol();
-        if (packageParent->kind == SymbolKind::Package)
-            break;
-
-        targetScope = packageParent->getParentScope();
-    }
-
-    // Look for a matching export.
-    for (auto decl : exportDecls) {
-        if (decl->package.valueText() != packageParent->name)
-            continue;
-
-        if (decl->item.kind == TokenKind::Star || decl->item.valueText() == symbol.name)
-            return true;
-    }
-
-    return false;
-}
-
-void PackageSymbol::checkExplicitExports() const {
-    // If we have an explicit export declaration, make sure that the
-    // referenced symbol is actually imported into the package.
-    auto& scopeNameMap = getNameMap();
-    auto wildcardData = getWildcardImportData();
-    for (auto& decl : exportDecls) {
-        if (decl->item.kind == TokenKind::Star)
-            continue;
-
-        auto lookupName = decl->item.valueText();
-        if (auto it = scopeNameMap.find(lookupName); it != scopeNameMap.end()) {
-            auto ei = it->second->as_if<ExplicitImportSymbol>();
-            if (ei && ei->isFromExport && !ei->sawCorrespondingImport() && ei->importedSymbol()) {
-                bool found = false;
-                if (wildcardData) {
-                    if (wildcardData->importedSymbols.contains(lookupName)) {
-                        // If the target symbol was already wildcard imported then we're done.
-                        found = true;
-                    }
-                    else {
-                        // There was no explicit import for this export, but if there is a viable
-                        // candidate for import then this export counts as a sufficient reference.
-                        for (auto import : wildcardData->wildcardImports) {
-                            auto package = import->getPackage();
-                            if (!package || package->name != decl->package.valueText())
-                                continue;
-
-                            found = package->findForImport(lookupName) != nullptr;
-                            break;
-                        }
-                    }
-                }
-
-                if (!found)
-                    addDiag(diag::PackageExportNotImported, decl->item.range()) << lookupName;
-            }
-        }
-    }
 }
 
 DefinitionSymbol::ParameterDecl::ParameterDecl(

--- a/source/ast/symbols/MemberSymbols.cpp
+++ b/source/ast/symbols/MemberSymbols.cpp
@@ -69,7 +69,7 @@ const PackageSymbol* ExplicitImportSymbol::package() const {
 }
 
 static const PackageSymbol* findPackage(std::string_view packageName, const Scope& lookupScope,
-                                        SourceLocation errorLoc, bool isFromExport) {
+                                        SourceLocation errorLoc) {
     auto& comp = lookupScope.getCompilation();
     auto package = comp.getPackage(packageName);
     if (!package) {
@@ -82,10 +82,7 @@ static const PackageSymbol* findPackage(std::string_view packageName, const Scop
         do {
             auto& sym = currScope->asSymbol();
             if (package == &sym) {
-                if (isFromExport)
-                    lookupScope.addDiag(diag::PackageExportSelf, errorLoc);
-                else
-                    lookupScope.addDiag(diag::PackageImportSelf, errorLoc);
+                lookupScope.addDiag(diag::PackageImportSelf, errorLoc);
                 return nullptr;
             }
 
@@ -107,7 +104,7 @@ const Symbol* ExplicitImportSymbol::importedSymbol() const {
         if (auto syntax = getSyntax())
             loc = syntax->as<PackageImportItemSyntax>().package.location();
 
-        package_ = findPackage(packageName, *scope, loc, isFromExport);
+        package_ = findPackage(packageName, *scope, loc);
         if (!package_)
             return nullptr;
 
@@ -127,7 +124,6 @@ const Symbol* ExplicitImportSymbol::importedSymbol() const {
 }
 
 void ExplicitImportSymbol::serializeTo(ASTSerializer& serializer) const {
-    serializer.write("isFromExport", isFromExport);
     if (auto pkg = package())
         serializer.writeLink("package", *pkg);
 
@@ -148,13 +144,12 @@ const PackageSymbol* WildcardImportSymbol::getPackage() const {
         if (auto syntax = getSyntax(); syntax)
             loc = syntax->as<PackageImportItemSyntax>().package.location();
 
-        package = findPackage(packageName, *scope, loc, isFromExport);
+        package = findPackage(packageName, *scope, loc);
     }
     return *package;
 }
 
 void WildcardImportSymbol::serializeTo(ASTSerializer& serializer) const {
-    serializer.write("isFromExport", isFromExport);
     if (auto pkg = getPackage())
         serializer.writeLink("package", *pkg);
 }

--- a/tests/unittests/ast/LookupTests.cpp
+++ b/tests/unittests/ast/LookupTests.cpp
@@ -1929,12 +1929,14 @@ endmodule
 
     auto diags = compilation.getAllDiagnostics().filter(
         {diag::StaticInitOrder, diag::StaticInitValue});
-    REQUIRE(diags.size() == 5);
+    REQUIRE(diags.size() == 7);
     CHECK(diags[0].code == diag::Redefinition);
     CHECK(diags[1].code == diag::UnknownPackage);
     CHECK(diags[2].code == diag::UnknownPackageMember);
-    CHECK(diags[3].code == diag::ImportNameCollision);
-    CHECK(diags[4].code == diag::UnknownPackageMember);
+    CHECK(diags[3].code == diag::PackageExportNotImported);
+    CHECK(diags[4].code == diag::ImportNameCollision);
+    CHECK(diags[5].code == diag::ImportNameCollision);
+    CHECK(diags[6].code == diag::UnknownPackageMember);
 }
 
 TEST_CASE("Imported names not visible to importers without export -- GH #1877") {
@@ -2017,6 +2019,212 @@ endmodule
     auto& diags = compilation.getAllDiagnostics();
     REQUIRE(diags.size() == 1);
     CHECK(diags[0].code == diag::AmbiguousWildcardImport);
+}
+
+TEST_CASE("Explicit package re-export of imported class") {
+    auto tree = SyntaxTree::fromText(R"(
+package base_pkg;
+    virtual class BaseTxnT;
+    endclass
+endpackage
+
+package model_pkg;
+    import base_pkg::BaseTxnT;
+    export base_pkg::BaseTxnT;
+
+    virtual class RoutedTxnT extends BaseTxnT;
+    endclass
+endpackage
+
+package export_pkg;
+    import model_pkg::RoutedTxnT;
+    export model_pkg::RoutedTxnT;
+endpackage
+
+package indirect_pkg;
+    import export_pkg::RoutedTxnT;
+    export export_pkg::RoutedTxnT;
+endpackage
+
+package user_pkg;
+    import indirect_pkg::RoutedTxnT;
+
+    class UserTxnT extends RoutedTxnT;
+    endclass
+endpackage
+
+module top;
+    import user_pkg::UserTxnT;
+    UserTxnT t;
+endmodule
+)");
+
+    Compilation compilation;
+    compilation.addSyntaxTree(tree);
+    NO_COMPILATION_ERRORS;
+}
+
+TEST_CASE("Explicit export of symbol not imported via a matching wildcard") {
+    // The exported name exists in the target package but is neither explicitly
+    // imported nor wildcard imported from that package into the exporting one, so
+    // the export is invalid. The wildcard import of an unrelated package exercises
+    // the package-name-mismatch skip in the import search.
+    auto tree = SyntaxTree::fromText(R"(
+package p;
+    int x;
+endpackage
+
+package q;
+    int z;
+endpackage
+
+package m;
+    import q::*;
+    export p::x;
+endpackage
+)");
+
+    Compilation compilation;
+    compilation.addSyntaxTree(tree);
+
+    auto& diags = compilation.getAllDiagnostics();
+    REQUIRE(diags.size() == 1);
+    CHECK(diags[0].code == diag::PackageExportNotImported);
+}
+
+TEST_CASE("Explicit exports of the same name from different packages collide") {
+    auto tree = SyntaxTree::fromText(R"(
+package a;
+    int x;
+endpackage
+
+package b;
+    int x;
+endpackage
+
+package m;
+    import a::*;
+    import b::*;
+    export a::x;
+    export b::x;
+endpackage
+)");
+
+    Compilation compilation;
+    compilation.addSyntaxTree(tree);
+
+    auto& diags = compilation.getAllDiagnostics();
+    REQUIRE(diags.size() == 1);
+    CHECK(diags[0].code == diag::ImportNameCollision);
+}
+
+TEST_CASE("Star export doesn't re-export names owned by an unexported package") {
+    // p1::x is wildcard imported into m and referenced, but only p2 is star
+    // exported, so importing m::x from another package must fail.
+    auto tree = SyntaxTree::fromText(R"(
+package p1;
+    int x;
+endpackage
+
+package p2;
+    int y;
+endpackage
+
+package m;
+    import p1::*;
+    import p2::*;
+    export p2::*;
+    int z = x;
+endpackage
+
+package user;
+    import m::x;
+endpackage
+)");
+
+    Compilation compilation;
+    compilation.addSyntaxTree(tree);
+
+    auto diags = compilation.getAllDiagnostics().filter({diag::StaticInitValue});
+    REQUIRE(diags.size() == 1);
+    CHECK(diags[0].code == diag::UnknownPackageMember);
+}
+
+TEST_CASE("Star export re-exports a wildcard-imported enum value") {
+    // The exported symbol (an enum value) is nested inside the enum type rather
+    // than directly in the package, so resolving its owning package requires
+    // walking up more than one scope.
+    auto tree = SyntaxTree::fromText(R"(
+package p1;
+    enum { AVAL, BVAL } e1;
+endpackage
+
+package m;
+    import p1::*;
+    export p1::*;
+    int z = AVAL;
+endpackage
+
+package user;
+    import m::AVAL;
+    int w = AVAL;
+endpackage
+)");
+
+    Compilation compilation;
+    compilation.addSyntaxTree(tree);
+
+    auto diags = compilation.getAllDiagnostics().filter({diag::StaticInitValue});
+    REQUIRE(diags.empty());
+
+    auto p1Aval = compilation.getPackage("p1")->find("AVAL");
+    REQUIRE(p1Aval);
+    CHECK(compilation.getPackage("m")->findForImport("AVAL") == p1Aval);
+}
+
+TEST_CASE("Mutually re-exporting packages resolve without crashing") {
+    // a and b each import a symbol from the other and re-export it, forming a cycle
+    // in the package dependency graph. Such a cycle has no valid separate-compilation
+    // order and other tools reject it; slang doesn't currently diagnose it because it
+    // elaborates the whole design at once. This is a guard that export resolution stays
+    // lazy so we handle this input gracefully (no crash, infinite recursion, or
+    // spurious diagnostics) rather than a statement that cycles are legal -- resolving
+    // exports eagerly at the top of findForImport regresses to bogus errors here.
+    //
+    // TODO: slang should detect package import/export cycles and report an error. When
+    // that lands, this test must be updated to expect that diagnostic instead of clean
+    // resolution.
+    auto tree = SyntaxTree::fromText(R"(
+package a;
+    import b::y;
+    int x;
+    export b::y;
+endpackage
+
+package b;
+    import a::x;
+    int y;
+    export a::x;
+endpackage
+
+module top;
+    import a::y;
+    import b::x;
+    int p = a::y + b::x;
+endmodule
+)");
+
+    Compilation compilation;
+    compilation.addSyntaxTree(tree);
+
+    auto diags = compilation.getAllDiagnostics().filter({diag::StaticInitValue});
+    REQUIRE(diags.empty());
+
+    // The re-exported names resolve to the originating package's declarations.
+    CHECK(compilation.getPackage("a")->findForImport("y") ==
+          compilation.getPackage("b")->find("y"));
+    CHECK(compilation.getPackage("b")->findForImport("x") ==
+          compilation.getPackage("a")->find("x"));
 }
 
 TEST_CASE("Hierarchical lookup of type name") {

--- a/tests/unittests/ast/MemberTests.cpp
+++ b/tests/unittests/ast/MemberTests.cpp
@@ -2408,12 +2408,11 @@ endpackage
     compilation.addSyntaxTree(tree);
 
     auto& diags = compilation.getAllDiagnostics();
-    REQUIRE(diags.size() == 5);
+    REQUIRE(diags.size() == 4);
     CHECK(diags[0].code == diag::PackageImportSelf);
     CHECK(diags[1].code == diag::PackageImportSelf);
     CHECK(diags[2].code == diag::PackageExportSelf);
-    CHECK(diags[3].code == diag::Redefinition);
-    CHECK(diags[4].code == diag::PackageExportSelf);
+    CHECK(diags[3].code == diag::PackageExportSelf);
 }
 
 TEST_CASE("DPI task import has correct return type") {


### PR DESCRIPTION
Stacked PRs:
 * #1902
 * #1901
 * __->__#1904


--- --- ---


[View individual changes](https://github.com/AndrewNolte/slang/commit/c3c241e07525712fa8840a028c9c58e90befb4ee)
### Fix Indirect Package exports with refactor

- Removes exports from AST/Pkg scope, removing ability to easily access symbol attributes
- Cleans up other spurious export diagnostics, adds more correct diags for some cases, and adds more test cases
