### PR TITLE
Required fmt version 12.2 -> 12

### DIFF
--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -5,7 +5,7 @@
 
 # --- fmt lib ---
 if(SLANG_USE_SYSTEM_FMT)
-  find_package(fmt 12.2 REQUIRED)
+  find_package(fmt 12 REQUIRED)
 
   get_target_property(FMT_CFG fmt::fmt IMPORTED_CONFIGURATIONS)
   list(GET FMT_CFG 0 FMT_CFG_FIRST)


### PR DESCRIPTION
`12.2` is literally the cutting edge of `fmt` release less than a month ago. Imo it seems a bit excessive, since I want to use my system library of `fmt` (provided by nix) but its only at `12.1.0`

Are there specific features from 12.2 that slang requires?