### PR TITLE
--allow-toplevel-iface-ports: Apply $static_assert iface param overrides

### DIFF
--- a/source/ast/symbols/InstanceSymbols.cpp
+++ b/source/ast/symbols/InstanceSymbols.cpp
@@ -856,8 +856,236 @@ void InstanceSymbol::resolvePortConnections() const {
     connections = conns.copy(comp);
 }
 
+struct IfaceParamAccess {
+    std::string_view portName;
+    std::string_view paramName;
+    SmallVector<const syntax::ExpressionSyntax*, 4> elementSelectors;
+};
+
+static bool parseIfacePortBase(const syntax::ExpressionSyntax& expr, std::string_view& portName,
+                               SmallVectorBase<const syntax::ExpressionSyntax*>& selectors) {
+    if (expr.kind == syntax::SyntaxKind::IdentifierName) {
+        portName = expr.as<syntax::IdentifierNameSyntax>().identifier.valueText();
+        return true;
+    }
+
+    if (expr.kind == syntax::SyntaxKind::IdentifierSelectName) {
+        auto& selected = expr.as<syntax::IdentifierSelectNameSyntax>();
+        portName = selected.identifier.valueText();
+        for (auto select : selected.selectors) {
+            if (!select->selector || select->selector->kind != syntax::SyntaxKind::BitSelect)
+                return false;
+            selectors.push_back(select->selector->as<syntax::BitSelectSyntax>().expr);
+        }
+        return true;
+    }
+
+    if (expr.kind == syntax::SyntaxKind::ElementSelectExpression) {
+        auto& selected = expr.as<syntax::ElementSelectExpressionSyntax>();
+        if (!selected.select->selector ||
+            selected.select->selector->kind != syntax::SyntaxKind::BitSelect) {
+            return false;
+        }
+
+        if (!parseIfacePortBase(*selected.left, portName, selectors))
+            return false;
+        selectors.push_back(selected.select->selector->as<syntax::BitSelectSyntax>().expr);
+        return true;
+    }
+
+    return false;
+}
+
+// Returns the port and parameter names if `expr` is `<port>.<param>`. The access can parse either
+// as a member-access expression or, when the left side could be a scope, as a dotted scoped name.
+static std::optional<IfaceParamAccess> asPortParamAccess(const syntax::ExpressionSyntax& expr) {
+    if (expr.kind == syntax::SyntaxKind::MemberAccessExpression) {
+        auto& access = expr.as<syntax::MemberAccessExpressionSyntax>();
+        IfaceParamAccess result;
+        if (!parseIfacePortBase(*access.left, result.portName, result.elementSelectors))
+            return std::nullopt;
+        result.paramName = access.name.valueText();
+        return result;
+    }
+
+    if (expr.kind == syntax::SyntaxKind::ScopedName) {
+        auto& scoped = expr.as<syntax::ScopedNameSyntax>();
+        if (scoped.separator.kind != parsing::TokenKind::Dot)
+            return std::nullopt;
+        if (scoped.right->kind != syntax::SyntaxKind::IdentifierName)
+            return std::nullopt;
+
+        IfaceParamAccess result;
+        if (!parseIfacePortBase(*scoped.left, result.portName, result.elementSelectors))
+            return std::nullopt;
+        result.paramName = scoped.right->as<syntax::IdentifierNameSyntax>().identifier.valueText();
+        return result;
+    }
+
+    return std::nullopt;
+}
+
+using IfacePortMap = SmallMap<std::string_view, const InterfacePortSymbol*, 8>;
+
+struct IfaceParamConstraintMatch {
+    const InterfacePortSymbol* port;
+    std::string_view paramName;
+    const syntax::ExpressionSyntax* constraintExpr;
+    SmallVector<const syntax::ExpressionSyntax*, 4> elementSelectors;
+    bool isType;
+};
+
+// Given a `$static_assert` condition expression, see if it pins an interface port parameter to a
+// constant. Two shapes are recognized (with either operand on the left):
+//   - value:  `<port>.<param> == <expr>`
+//   - type:   `type(<port>.<param>) == type(<expr>)`
+static std::optional<IfaceParamConstraintMatch> matchIfaceParamConstraint(
+    const syntax::ExpressionSyntax& condition, const IfacePortMap& ifacePorts) {
+    if (condition.kind != syntax::SyntaxKind::EqualityExpression)
+        return std::nullopt;
+
+    auto& binExpr = condition.as<syntax::BinaryExpressionSyntax>();
+    const syntax::ExpressionSyntax* paramExpr = binExpr.left;
+    const syntax::ExpressionSyntax* constraintExpr = binExpr.right;
+
+    // In the type form both sides are `type(...)` references. Keep the full constraint expression
+    // for use as the parameter assignment, but unwrap the candidate parameter expression for
+    // matching the port access.
+    bool isType = paramExpr->kind == syntax::SyntaxKind::TypeReference &&
+                  constraintExpr->kind == syntax::SyntaxKind::TypeReference;
+    auto getParamAccess = [&](const syntax::ExpressionSyntax& expr)
+        -> std::optional<std::pair<const InterfacePortSymbol*, IfaceParamAccess>> {
+        auto& access = isType ? *expr.as<syntax::TypeReferenceSyntax>().expr : expr;
+        auto result = asPortParamAccess(access);
+        if (!result)
+            return std::nullopt;
+
+        auto portIt = ifacePorts.find(result->portName);
+        if (portIt == ifacePorts.end())
+            return std::nullopt;
+        return std::pair{portIt->second, std::move(*result)};
+    };
+
+    auto paramAccess = getParamAccess(*paramExpr);
+    if (!paramAccess) {
+        std::swap(paramExpr, constraintExpr);
+        paramAccess = getParamAccess(*paramExpr);
+    }
+
+    if (!paramAccess)
+        return std::nullopt;
+
+    return IfaceParamConstraintMatch{paramAccess->first, paramAccess->second.paramName,
+                                     constraintExpr,
+                                     std::move(paramAccess->second.elementSelectors), isType};
+}
+
+struct IfaceParamAssignment {
+    std::string_view paramName;
+    const syntax::ExpressionSyntax* constraintExpr;
+};
+
+using IfaceParamAssignmentMap =
+    flat_hash_map<const InterfacePortSymbol*, SmallVector<IfaceParamAssignment>>;
+
+// Scan direct-body `$static_assert`s once and collect the parameter assignments they imply for
+// each interface port. Asserts nested in generate blocks are skipped because their constraints are
+// conditional, but parameter assignments must be applied before elaborating generate branches.
+static IfaceParamAssignmentMap collectIfaceParamAssignments(
+    const syntax::ModuleDeclarationSyntax* topBody, const IfacePortMap& ifacePorts,
+    const ASTContext& context) {
+    IfaceParamAssignmentMap result;
+    if (!topBody)
+        return result;
+
+    for (auto member : topBody->members) {
+        if (member->kind != syntax::SyntaxKind::ElabSystemTask)
+            continue;
+
+        auto& task = member->as<syntax::ElabSystemTaskSyntax>();
+        if (SemanticFacts::getElabSystemTaskKind(task.name) != ElabSystemTaskKind::StaticAssert)
+            continue;
+        if (!task.arguments || task.arguments->parameters.empty())
+            continue;
+
+        auto firstArg = task.arguments->parameters[0];
+        if (firstArg->kind != syntax::SyntaxKind::OrderedArgument)
+            continue;
+
+        // Unwrap the property/sequence wrappers down to a plain expression.
+        auto& propExpr = *firstArg->as<syntax::OrderedArgumentSyntax>().expr;
+        if (propExpr.kind != syntax::SyntaxKind::SimplePropertyExpr)
+            continue;
+
+        auto& seqExpr = *propExpr.as<syntax::SimplePropertyExprSyntax>().expr;
+        if (seqExpr.kind != syntax::SyntaxKind::SimpleSequenceExpr)
+            continue;
+
+        auto& simpleSeq = seqExpr.as<syntax::SimpleSequenceExprSyntax>();
+        if (simpleSeq.repetition)
+            continue;
+
+        auto match = matchIfaceParamConstraint(*simpleSeq.expr, ifacePorts);
+        if (!match)
+            continue;
+
+        // Only override parameters the interface actually declares, and require the constraint
+        // form to agree with the parameter kind. Localparams cannot be overridden.
+        auto& def = *match->port->interfaceDef;
+        auto declIt = std::ranges::find(def.parameters, match->paramName,
+                                        &DefinitionSymbol::ParameterDecl::name);
+        if (declIt == def.parameters.end() || declIt->isLocalParam ||
+            declIt->isTypeParam != match->isType) {
+            continue;
+        }
+
+        auto dims = match->port->getDeclaredRange();
+        if (!dims || dims->size() != match->elementSelectors.size())
+            continue;
+
+        // An interface instance array has one shared parameterization. The selectors identify a
+        // valid element whose parameter can appear in the assertion; the inferred assignment is
+        // applied to every element below.
+        bool validPath = true;
+        for (size_t i = 0; i < dims->size(); i++) {
+            auto& selectorExpr = Expression::bind(*match->elementSelectors[i], context);
+            auto selectorValue = context.tryEval(selectorExpr);
+            auto index = selectorValue.isInteger() ? selectorValue.integer().as<int32_t>()
+                                                   : std::optional<int32_t>{};
+            if (selectorExpr.hasHierarchicalReference() || !index ||
+                !(*dims)[i].containsPoint(*index)) {
+                validPath = false;
+                break;
+            }
+        }
+        if (!validPath)
+            continue;
+
+        // The assignment is bound before default interface instances exist, so values that
+        // traverse the instance hierarchy could observe stale parameter defaults. Restrict
+        // inference to expressions that are constant without any hierarchical references.
+        if (!match->isType) {
+            auto& expr = Expression::bind(*match->constraintExpr, context);
+            if (expr.hasHierarchicalReference() || !context.tryEval(expr))
+                continue;
+        }
+        else {
+            auto& typeRef = match->constraintExpr->as<syntax::TypeReferenceSyntax>();
+            auto access = asPortParamAccess(*typeRef.expr);
+            if (access && ifacePorts.contains(access->portName))
+                continue;
+        }
+
+        result[match->port].push_back({match->paramName, match->constraintExpr});
+    }
+
+    return result;
+}
+
 static Symbol* recurseDefaultIfaceInst(Compilation& comp, const InterfacePortSymbol& port,
                                        const InstanceSymbol*& firstInst,
+                                       std::span<const IfaceParamAssignment> paramAssignments,
+                                       const ASTContext& assignmentContext,
                                        std::span<const ConstantRange>::iterator it,
                                        std::span<const ConstantRange>::iterator end) {
     if (it == end) {
@@ -866,6 +1094,11 @@ static Symbol* recurseDefaultIfaceInst(Compilation& comp, const InterfacePortSym
         if (comp.hasFlag(CompilationFlags::AllowInvalidTop)) {
             paramBuilder.setSuppressErrors(true);
         }
+
+        paramBuilder.setInstanceContext(assignmentContext);
+        for (auto& assignment : paramAssignments)
+            paramBuilder.addAssignment(assignment.paramName, *assignment.constraintExpr);
+
         auto& body = InstanceBodySymbol::fromDefinition(comp, def, port.location, paramBuilder,
                                                         InstanceFlags::None);
 
@@ -882,7 +1115,8 @@ static Symbol* recurseDefaultIfaceInst(Compilation& comp, const InterfacePortSym
 
     SmallVector<const Symbol*> elements;
     for (uint32_t i = 0; i < range.width(); i++) {
-        auto symbol = recurseDefaultIfaceInst(comp, port, firstInst, it, end);
+        auto symbol = recurseDefaultIfaceInst(comp, port, firstInst, paramAssignments,
+                                              assignmentContext, it, end);
         symbol->name = "";
         elements.push_back(symbol);
     }
@@ -901,18 +1135,44 @@ void InstanceSymbol::connectDefaultIfacePorts() const {
 
     auto& comp = parent->getCompilation();
     ASTContext context(*parent, LookupLocation::max);
+    ASTContext assignmentContext(body, LookupLocation::max);
+
+    // The body of the instantiating module may contain `$static_assert` constraints that
+    // pin interface-port parameters to specific values; we honor those when synthesizing
+    // the default interface instances below. Ideally one day the language will allow
+    // specifying these constraints in the port declaration itself, or typdefing parameterized
+    // interfaces.
+    auto bodySyntax = body.getSyntax() ? body.getSyntax()->as_if<syntax::ModuleDeclarationSyntax>()
+                                       : nullptr;
+    auto ports = body.getPortList();
+    IfacePortMap ifacePorts;
+    for (auto port : ports) {
+        if (port->kind == SymbolKind::InterfacePort) {
+            auto& ifacePort = port->as<InterfacePortSymbol>();
+            if (ifacePort.interfaceDef)
+                ifacePorts.emplace(ifacePort.name, &ifacePort);
+        }
+    }
+    auto ifaceParamAssignments = collectIfaceParamAssignments(bodySyntax, ifacePorts,
+                                                              assignmentContext);
 
     SmallVector<const PortConnection*> conns;
-    for (auto port : body.getPortList()) {
+    for (auto port : ports) {
         if (port->kind == SymbolKind::InterfacePort) {
             auto& ifacePort = port->as<InterfacePortSymbol>();
             if (ifacePort.interfaceDef) {
+                std::span<const IfaceParamAssignment> paramAssignments;
+                if (auto it = ifaceParamAssignments.find(&ifacePort);
+                    it != ifaceParamAssignments.end()) {
+                    paramAssignments = it->second;
+                }
+
                 Symbol* inst;
                 const ModportSymbol* modport = nullptr;
                 if (auto dims = ifacePort.getDeclaredRange()) {
                     const InstanceSymbol* firstInst = nullptr;
-                    inst = recurseDefaultIfaceInst(comp, ifacePort, firstInst, dims->begin(),
-                                                   dims->end());
+                    inst = recurseDefaultIfaceInst(comp, ifacePort, firstInst, paramAssignments,
+                                                   assignmentContext, dims->begin(), dims->end());
 
                     if (firstInst) {
                         auto portRange = SourceRange{port->location,

--- a/source/ast/symbols/ParameterBuilder.h
+++ b/source/ast/symbols/ParameterBuilder.h
@@ -30,6 +30,11 @@ public:
     bool hasErrors() const { return anyErrors; }
 
     void setAssignments(const syntax::ParameterValueAssignmentSyntax& syntax, bool isFromConfig);
+
+    void addAssignment(std::string_view name, const syntax::ExpressionSyntax& syntax) {
+        assignments.emplace(name, std::make_pair(&syntax, false));
+    }
+
     void setOverrides(const HierarchyOverrideNode* newVal) { overrideNode = newVal; }
     void setForceInvalidValues(bool set) { forceInvalidValues = set; }
     void setSuppressErrors(bool set) { suppressErrors = set; }

--- a/tests/unittests/ast/InterfaceTests.cpp
+++ b/tests/unittests/ast/InterfaceTests.cpp
@@ -1011,6 +1011,297 @@ parameter p = foo();
     CHECK(diags[0].code == diag::ConstEvalVifType);
 }
 
+// A `$static_assert` written directly in a top-level module body can pin an interface-port
+// parameter to a value/type; the override is applied to the auto-instantiated interface. The
+// feature is gated on AllowTopLevelIfacePorts: without it the module can't be a top at all
+// (diag::TopModuleIfacePort) and the override path never runs, so each case checks both. On the
+// flag-on side we inspect the *elaborated* parameter of the connected interface to prove the
+// assert actually drove the value.
+TEST_CASE("Top-level iface port params from $static_assert") {
+    auto compile = [](std::string_view source, bool allowIfacePorts) {
+        CompilationOptions options;
+        if (allowIfacePorts)
+            options.flags |= CompilationFlags::AllowTopLevelIfacePorts;
+        else
+            options.flags &= ~CompilationFlags::AllowTopLevelIfacePorts;
+        auto comp = std::make_unique<Compilation>(options);
+        comp->addSyntaxTree(SyntaxTree::fromText(source));
+        return comp;
+    };
+    auto diagCodes = [](Compilation& c) {
+        std::vector<DiagCode> codes;
+        for (auto& d : c.getAllDiagnostics())
+            codes.push_back(d.code);
+        return codes;
+    };
+    // The interface instance or array connected to the named interface port of the (single) top.
+    auto connectedIfaceSymbol = [](Compilation& c, std::string_view portName) -> const Symbol& {
+        auto& tops = c.getRoot().topInstances;
+        REQUIRE(tops.size() == 1);
+        for (auto conn : tops[0]->getPortConnections()) {
+            if (conn->port.kind == SymbolKind::InterfacePort && conn->port.name == portName) {
+                auto sym = conn->getIfaceConn().first;
+                REQUIRE(sym);
+                return *sym;
+            }
+        }
+        FAIL("no connected interface instance for port");
+        SLANG_UNREACHABLE;
+    };
+    auto connectedIface = [&](Compilation& c, std::string_view portName) -> const InstanceSymbol& {
+        auto& sym = connectedIfaceSymbol(c, portName);
+        REQUIRE(sym.kind == SymbolKind::Instance);
+        return sym.as<InstanceSymbol>();
+    };
+    auto paramValue = [&](Compilation& c, std::string_view port, std::string_view param) {
+        auto& sym = connectedIface(c, port).body.find(param)->as<ParameterSymbol>();
+        return *sym.getValue().integer().as<int>();
+    };
+
+    // Most cases share this interface; MY_PARAM defaults to 1, making `data` a single bit.
+    auto withIface = [](std::string_view body) {
+        return std::string(R"(
+interface my_if #(parameter int MY_PARAM = 1);
+    logic [MY_PARAM-1:0] data;
+endinterface
+module test_module()" + std::string(body));
+    };
+
+    SECTION("value param override past the default") {
+        // MY_PARAM defaults to 1 but the assert forces it to 2, so `data[1]` is in range.
+        auto src = withIface(R"(my_if my_if, output logic out);
+    $static_assert(my_if.MY_PARAM == 2);
+    assign out = my_if.data[1];
+endmodule
+)");
+        auto c = compile(src, true);
+        CHECK(diagCodes(*c).empty());
+        CHECK(paramValue(*c, "my_if", "MY_PARAM") == 2);
+        CHECK(diagCodes(*compile(src, false)) == std::vector{diag::TopModuleIfacePort});
+    }
+
+    SECTION("constant on the left") {
+        auto src = withIface(R"(my_if my_if, output logic out);
+    $static_assert(2 == my_if.MY_PARAM);
+    assign out = my_if.data[1];
+endmodule
+)");
+        auto c = compile(src, true);
+        CHECK(diagCodes(*c).empty());
+        CHECK(paramValue(*c, "my_if", "MY_PARAM") == 2);
+    }
+
+    SECTION("operand resolves in the containing module") {
+        auto src = R"(
+interface my_if #(parameter int MY_PARAM = 1);
+    logic [MY_PARAM-1:0] data;
+endinterface
+module test_module #(parameter int REQUIRED = 2)(my_if my_if, output logic out);
+    $static_assert(my_if.MY_PARAM == REQUIRED);
+    assign out = my_if.data[1];
+endmodule
+)";
+        auto c = compile(src, true);
+        CHECK(diagCodes(*c).empty());
+        CHECK(paramValue(*c, "my_if", "MY_PARAM") == 2);
+    }
+
+    SECTION("operand resolves in a package") {
+        auto src = R"(
+package pkg;
+    parameter int REQUIRED = 2;
+endpackage
+interface my_if #(parameter int MY_PARAM = 1);
+    logic [MY_PARAM-1:0] data;
+endinterface
+module test_module(my_if my_if, output logic out);
+    $static_assert(my_if.MY_PARAM == pkg::REQUIRED);
+    assign out = my_if.data[1];
+endmodule
+)";
+        auto c = compile(src, true);
+        CHECK(diagCodes(*c).empty());
+        CHECK(paramValue(*c, "my_if", "MY_PARAM") == 2);
+    }
+
+    SECTION("one array element constrains the whole array") {
+        auto src = R"(
+interface my_if #(parameter int MY_PARAM = 1);
+    logic [MY_PARAM-1:0] data;
+endinterface
+module test_module(my_if my_if[3:2], output logic [1:0] out);
+    $static_assert(my_if[2].MY_PARAM == 2);
+    assign out[0] = my_if[2].data[1];
+    assign out[1] = my_if[3].data[1];
+endmodule
+)";
+        auto c = compile(src, true);
+        CHECK(diagCodes(*c).empty());
+
+        auto& array = connectedIfaceSymbol(*c, "my_if").as<InstanceArraySymbol>();
+        REQUIRE(array.elements.size() == 2);
+        auto getValue = [](const Symbol& element) {
+            auto& param = element.as<InstanceSymbol>().body.find("MY_PARAM")->as<ParameterSymbol>();
+            return *param.getValue().integer().as<int>();
+        };
+        CHECK(getValue(*array.elements[0]) == 2);
+        CHECK(getValue(*array.elements[1]) == 2);
+    }
+
+    SECTION("override still bounds-checks") {
+        // With MY_PARAM forced to 2, `data` is 2 bits, so an access at index 2 is still oob.
+        auto src = withIface(R"(my_if my_if, output logic out);
+    $static_assert(my_if.MY_PARAM == 2);
+    assign out = my_if.data[2];
+endmodule
+)");
+        auto c = compile(src, true);
+        CHECK(diagCodes(*c) == std::vector{diag::IndexOOB});
+        CHECK(paramValue(*c, "my_if", "MY_PARAM") == 2);
+    }
+
+    SECTION("type param override") {
+        // `$static_assert(type(port.T) == type(X))` overrides the type parameter with X. DT
+        // defaults to `logic` (1 bit) but is forced to pkg::my_t (8 bits), so `data[7]` is ok.
+        auto src = R"(
+package pkg;
+    typedef logic [7:0] my_t;
+endpackage
+interface my_if #(parameter type DT = logic);
+    DT data;
+endinterface
+module test_module(my_if my_if, output logic out);
+    $static_assert(type(my_if.DT) == type(pkg::my_t));
+    assign out = my_if.data[7];
+endmodule
+)";
+        auto c = compile(src, true);
+        CHECK(diagCodes(*c).empty());
+        auto& iface = connectedIface(*c, "my_if");
+        CHECK(iface.body.find("DT")->as<TypeParameterSymbol>().targetType.getType().toString() ==
+              "pkg::my_t");
+        CHECK(iface.body.find("data")->as<VariableSymbol>().getType().getBitWidth() == 8);
+
+        // Without the flag DT stays `logic`, so the assert itself also fails.
+        CHECK(diagCodes(*compile(src, false)) ==
+              std::vector{diag::TopModuleIfacePort, diag::StaticAssert});
+    }
+
+    SECTION("multiple constraints accumulate for one port") {
+        auto src = R"(
+interface my_if #(parameter int P = 1, Q = 1);
+    logic [P+Q-1:0] data;
+endinterface
+module test_module(my_if my_if, output logic out);
+    $static_assert(my_if.P == 2);
+    $static_assert(my_if.Q == 3);
+    assign out = my_if.data[4];
+endmodule
+)";
+        auto c = compile(src, true);
+        CHECK(diagCodes(*c).empty());
+        CHECK(paramValue(*c, "my_if", "P") == 2);
+        CHECK(paramValue(*c, "my_if", "Q") == 3);
+    }
+
+    SECTION("invalid type constraint propagates") {
+        auto src = R"(
+interface my_if #(parameter type DT = logic);
+    DT data;
+endinterface
+module test_module(my_if my_if);
+    $static_assert(type(my_if.DT) == type(missing_t));
+endmodule
+)";
+        auto c = compile(src, true);
+        auto& dt = connectedIface(*c, "my_if").body.find("DT")->as<TypeParameterSymbol>();
+        CHECK(dt.targetType.getType().isError());
+
+        auto codes = diagCodes(*c);
+        CHECK(std::ranges::find(codes, diag::UndeclaredIdentifier) != codes.end());
+    }
+
+    SECTION("unrelated assert only affects its own port") {
+        auto src = withIface(R"(my_if my_if, my_if other_if, output logic out);
+    $static_assert(other_if.MY_PARAM == 2);
+    assign out = my_if.data[1];
+endmodule
+)");
+        auto c = compile(src, true);
+        // my_if keeps its default of 1, leaving data[1] out of range.
+        CHECK(diagCodes(*c) == std::vector{diag::IndexOOB});
+        CHECK(paramValue(*c, "my_if", "MY_PARAM") == 1);
+        CHECK(paramValue(*c, "other_if", "MY_PARAM") == 2);
+    }
+
+    SECTION("constraint cannot depend on another interface port") {
+        auto src = withIface(R"(my_if my_if, my_if other_if, output logic out);
+    $static_assert(other_if.MY_PARAM == 2);
+    $static_assert(my_if.MY_PARAM == other_if.MY_PARAM);
+    assign out = my_if.data[1] & other_if.data[1];
+endmodule
+)");
+        auto c = compile(src, true);
+        auto codes = diagCodes(*c);
+        CHECK(std::ranges::count(codes, diag::StaticAssert) == 1);
+        CHECK(std::ranges::count(codes, diag::IndexOOB) == 1);
+        CHECK(paramValue(*c, "my_if", "MY_PARAM") == 1);
+        CHECK(paramValue(*c, "other_if", "MY_PARAM") == 2);
+    }
+
+    SECTION("localparam is not overridden") {
+        auto src = R"(
+interface my_if #(localparam int MY_PARAM = 1);
+    logic [MY_PARAM-1:0] data;
+endinterface
+module test_module(my_if my_if, output logic out);
+    $static_assert(my_if.MY_PARAM == 2);
+    assign out = my_if.data[1];
+endmodule
+)";
+        auto c = compile(src, true);
+        CHECK(diagCodes(*c) == std::vector{diag::StaticAssert, diag::IndexOOB});
+        CHECK(paramValue(*c, "my_if", "MY_PARAM") == 1);
+    }
+
+    SECTION("non-const operand is skipped without spurious diagnostics") {
+        // The operand `o.P` references a sibling instance's parameter, which isn't a constant we
+        // can resolve when building the interface. The override is skipped (MY_PARAM stays 1, so
+        // `data[1]` is oob), and we don't emit a spurious binding error: the only assert-related
+        // diagnostic is the real $static_assert's own ConstEvalHierarchicalName.
+        auto src = R"(
+interface my_if #(parameter int MY_PARAM = 1);
+    logic [MY_PARAM-1:0] data;
+endinterface
+module other #(parameter int P = 2);
+endmodule
+module test_module(my_if my_if, output logic out);
+    other o();
+    $static_assert(my_if.MY_PARAM == o.P);
+    assign out = my_if.data[1];
+endmodule
+)";
+        auto c = compile(src, true);
+        CHECK(diagCodes(*c) == std::vector{diag::ConstEvalHierarchicalName, diag::IndexOOB});
+        CHECK(paramValue(*c, "my_if", "MY_PARAM") == 1);
+    }
+
+    SECTION("assert in a generate block is ignored") {
+        // Generate-block asserts are conditional on branch selection (unknown when the override
+        // is applied), so they don't pin a param: MY_PARAM stays 1 and `data[1]` is oob.
+        auto src = withIface(R"(my_if my_if, output logic out);
+    if (1) begin : g
+        $static_assert(my_if.MY_PARAM == 1);
+    end
+    assign out = my_if.data[1];
+endmodule
+)");
+        auto c = compile(src, true);
+        CHECK(diagCodes(*c) == std::vector{diag::IndexOOB});
+        CHECK(paramValue(*c, "my_if", "MY_PARAM") == 1);
+    }
+}
+
 TEST_CASE("Virtual interface instance access regress -- GH #1765") {
     auto tree = SyntaxTree::fromText(R"(
 interface A;


### PR DESCRIPTION
Stacked PRs:
 * #1927
 * #1926
 * #1925
 * __->__#1910


--- --- ---


[View individual changes](https://github.com/AndrewNolte/slang/commit/6c9bf2328a60d346f795253310c2d950ef3aff41)
### --allow-toplevel-iface-ports: Apply $static_assert iface param overrides


This allows users to pin iface port params, allowing for better LSP features outside of a design context.
The body will be inspected for $static_asserts, and will use those to fill in the expected parameter values for iface ports.
Related issue: https://github.com/hudson-trading/slang-server/issues/401
