### PR TITLE
Fix ICE on tagged packed union member access with unknown tag

### DIFF
--- a/source/ast/expressions/SelectExpressions.cpp
+++ b/source/ast/expressions/SelectExpressions.cpp
@@ -1200,7 +1200,9 @@ static bool checkPackedUnionTag(const Type& valueType, const SVInt& val, uint32_
     if (tagBits) {
         bitwidth_t bits = val.getBitWidth();
         auto tag = val.slice(int32_t(bits - 1), int32_t(bits - tagBits)).as<uint32_t>();
-        if (tag.value() != expectedTag) {
+        // An unknown (x/z) tag can never match a concrete member's tag; treat it
+        // as a mismatch rather than dereferencing the empty optional.
+        if (!tag || *tag != expectedTag) {
             context.addDiag(diag::ConstEvalTaggedUnion, sourceRange) << memberName;
             return false;
         }

--- a/tests/unittests/ast/EvalTests.cpp
+++ b/tests/unittests/ast/EvalTests.cpp
@@ -2377,6 +2377,20 @@ TEST_CASE("Tagged union eval") {
     CHECK(diags[3].code == diag::ConstEvalTaggedUnion);
 }
 
+TEST_CASE("Tagged union eval with unknown tag") {
+    // Accessing a member of a 4-state packed tagged union whose tag bits are
+    // unknown must report a tagged-union access error, not crash: the tag slice
+    // has no known value, so it can never match a member's tag.
+    ScriptSession session;
+    session.eval("union tagged packed { logic [7:0] a; logic [7:0] b; } v;");
+    session.eval("v = 'x;");
+    session.eval("v.a");
+
+    auto diags = session.getDiagnostics();
+    REQUIRE(diags.size() == 1);
+    CHECK(diags[0].code == diag::ConstEvalTaggedUnion);
+}
+
 TEST_CASE("Assignment pattern eval") {
     ScriptSession session;
     session.eval("typedef logic[7:0] bt;");


### PR DESCRIPTION
## Problem

Accessing a member of a **4-state `union tagged packed`** whose tag bits are
unknown crashes the compiler with an internal compiler error rather than
reporting a normal tagged-union access error.

`checkPackedUnionTag` (source/ast/expressions/SelectExpressions.cpp) extracts the
tag from the top bits of the packed value and calls `.value()` on the result:

```cpp
auto tag = val.slice(int32_t(bits - 1), int32_t(bits - tagBits)).as<uint32_t>();
if (tag.value() != expectedTag) {
    context.addDiag(diag::ConstEvalTaggedUnion, sourceRange) << memberName;
    return false;
}
```

`SVInt::as<uint32_t>()` returns `std::nullopt` when the slice has unknown bits.
For a tagged packed union that contains a 4-state member, the whole union is
4-state, so an all-`x` value (e.g. from `'x`) has unknown bits in the tag
region. `tag.value()` then throws `std::bad_optional_access`, which the driver
reports as `internal compiler error: bad optional access`. This is reached on
both the rvalue path (`MemberAccessExpression::evalImpl`) and the lvalue path
(`evalLValueImpl`), which share this helper.

### Reproducer

```systemverilog
module m;
  typedef union tagged packed {
    logic [7:0] a;
    logic [7:0] b;
  } u_t;
  localparam u_t v = 'x;
  localparam logic [7:0] q = v.a;
endmodule
```

```
$ slang repro.sv
internal compiler error: bad optional access
```

A 2-state tagged union (`byte` members — tag is always a known 0/1), a
non-tagged packed union (`tagBits == 0`, so the check is skipped), and a valid
concrete tag value all compile without issue, so the crash is specific to the
unknown-tag path.

## Fix

Treat an unknown/absent tag as a mismatch instead of dereferencing the empty
optional. An `x`/`z` tag can never match a concrete member's tag, so this emits
the existing `ConstEvalTaggedUnion` diagnostic and returns `false` cleanly:

```cpp
if (!tag || *tag != expectedTag) {
```

With the fix, the reproducer now reports the normal error:

```
error: cannot access 'a' because it is not the currently active member of the tagged union
```

## Testing

Added a `Tagged union eval with unknown tag` case to
`tests/unittests/ast/EvalTests.cpp` that accesses a member of an all-`x` 4-state
packed tagged union and checks a single `ConstEvalTaggedUnion` diagnostic is
produced (before the fix this crashes with `bad_optional_access`). Verified the
driver on the reproducer and three controls (2-state members, non-tagged union,
valid tag) before and after the change.

Disclosure: this contribution was authored with an AI coding assistant (Claude) and reviewed before submission.
