### PR TITLE
Fix ICE on queue read at the append index

### DIFF
--- a/include/slang/ast/expressions/SelectExpressions.h
+++ b/include/slang/ast/expressions/SelectExpressions.h
@@ -41,7 +41,8 @@ public:
     bool isEquivalentImpl(const ElementSelectExpression& rhs) const;
 
     std::optional<ConstantRange> evalIndex(EvalContext& context, const ConstantValue& val,
-                                           ConstantValue& associativeIndex, bool& softFail) const;
+                                           ConstantValue& associativeIndex, bool& softFail,
+                                           bool allowQueueAppend = false) const;
 
     void serializeTo(ASTSerializer& serializer) const;
 

--- a/source/ast/expressions/SelectExpressions.cpp
+++ b/source/ast/expressions/SelectExpressions.cpp
@@ -274,7 +274,8 @@ LValue ElementSelectExpression::evalLValueImpl(EvalContext& context) const {
 
     bool softFail = false;
     ConstantValue associativeIndex;
-    auto range = evalIndex(context, loadedVal, associativeIndex, softFail);
+    auto range = evalIndex(context, loadedVal, associativeIndex, softFail,
+                           /*allowQueueAppend=*/true);
     if (!range && associativeIndex.bad()) {
         if (!softFail)
             return nullptr;
@@ -312,7 +313,8 @@ LValue ElementSelectExpression::evalLValueImpl(EvalContext& context) const {
 std::optional<ConstantRange> ElementSelectExpression::evalIndex(EvalContext& context,
                                                                 const ConstantValue& val,
                                                                 ConstantValue& associativeIndex,
-                                                                bool& softFail) const {
+                                                                bool& softFail,
+                                                                bool allowQueueAppend) const {
     auto prevQ = context.getQueueTarget();
     if (val.isQueue())
         context.setQueueTarget(&val);
@@ -365,8 +367,10 @@ std::optional<ConstantRange> ElementSelectExpression::evalIndex(EvalContext& con
     }
 
     if (val) {
+        // A write may target the append slot one past the end of a queue; a
+        // read at that index is out of bounds and returns the element default.
         size_t maxIndex = val.size();
-        if (val.isQueue())
+        if (val.isQueue() && allowQueueAppend)
             maxIndex++;
 
         if (*index < 0 || size_t(*index) >= maxIndex) {

--- a/tests/unittests/ast/EvalTests.cpp
+++ b/tests/unittests/ast/EvalTests.cpp
@@ -608,6 +608,23 @@ TEST_CASE("Dynamic arrays -- out of bounds") {
     CHECK(diags[5].code == diag::ConstEvalEmptyQueue);
 }
 
+TEST_CASE("Queue read at the append index") {
+    // Reading a queue at index == size() (the append slot) is out of bounds; it
+    // must warn and return the element default rather than crash. Writing that
+    // slot is still allowed and appends.
+    ScriptSession session;
+    session.eval("int q[$] = '{10, 20, 30};");
+    CHECK(session.eval("q[3]").integer() == 0);
+    CHECK(session.eval("q[2]").integer() == 30);
+
+    session.eval("q[3] = 40;");
+    CHECK(session.eval("q[3]").integer() == 40);
+
+    auto diags = session.getDiagnostics();
+    REQUIRE(diags.size() == 1);
+    CHECK(diags[0].code == diag::ConstEvalDynamicArrayIndex);
+}
+
 TEST_CASE("Associative array eval") {
     ScriptSession session;
     session.eval("integer arr[string] = '{\"Hello\":4, \"World\":8, default:-1};");


### PR DESCRIPTION
## Problem

Reading a queue at index `== size()` (the append slot) crashes slang with an
internal compiler error instead of returning the element default.

`ElementSelectExpression::evalIndex` intentionally allows an index one past the
end of a queue (`maxIndex = size() + 1`) so that the lvalue append
`q[size] = x` works. But `evalIndex` is shared with the rvalue read path, so a
read `q[size]` also passes the bounds check and then reaches
`std::move(cv).at(size())` on the underlying `std::deque`, which throws
`std::out_of_range` — reported as
`internal compiler error: deque::_M_range_check`.

Per LRM 7.10.1 an out-of-bounds queue read returns the element default. Indices
strictly past the end already do this (with a `-Wdynarray-index` warning); only
the boundary index `== size()` escaped to the throwing path.

### Reproducer

```systemverilog
module m;
  function automatic int f();
    int q[$] = '{10, 20, 30};
    return q[3];
  endfunction
  localparam int P = f();
endmodule
```

```
$ slang repro.sv
internal compiler error: deque::_M_range_check: __n (which is 3) >= this->size() (which is 3)
```

## Fix

Restrict the append slot to the lvalue (write) path. `evalIndex` gains an
`allowQueueAppend` parameter (default `false`), and only `evalLValueImpl` passes
`true`. A read at index `== size()` is then out of bounds like any larger index:
it emits the existing `ConstEvalDynamicArrayIndex` warning and returns the
element default. The append on the lvalue path is unchanged.

With the fix the reproducer no longer crashes, and `q[3]` reports the same
warning as `q[4]`/`q[5]`:

```
warning: invalid index 3 for 'int$[$]' of length 3 [-Wdynarray-index]
```

## Testing

- New unit test `Queue read at the append index` in `EvalTests.cpp`: a
  `q[size()]` read returns the element default with one
  `ConstEvalDynamicArrayIndex` diagnostic, a valid in-range read is unaffected,
  and writing the append slot still appends.
- The full unit-test suite passes (2476 cases). Verified the driver on the
  reproducer and controls (valid read, index past the end, append) before and
  after the change.

Disclosure: this contribution was authored with an AI coding assistant (Claude) and reviewed before submission.
