### PR TITLE
Fix segfault in streaming concat reOrder on irregular slice boundary

### DIFF
--- a/source/ast/Bitstream.cpp
+++ b/source/ast/Bitstream.cpp
@@ -695,9 +695,12 @@ ConstantValue Bitstream::reOrder(ConstantValue&& value, uint64_t sliceSize, uint
             auto bit = width - slice;
             result.emplace_back(slicePacked(iter, std::cend(packed), bit, slice));
             width -= slice;
+            // slicePacked already advanced iter past packed[index] (it consumed
+            // the element's last `slice` bits), so do not advance it again.
         }
-
-        iter++;
+        else {
+            iter++;
+        }
         auto nextIndex = index;
         while (++index < rightIndex)
             result.emplace_back(std::move(**iter++));

--- a/tests/unittests/ast/EvalTests.cpp
+++ b/tests/unittests/ast/EvalTests.cpp
@@ -2060,6 +2060,23 @@ localparam logic[7:0] value6 = {<<4{ {<<2{value5}} }};
     CHECK(diags[1].code == diag::BadStreamSize);
 }
 
+TEST_CASE("Streaming concat with irregular packed slice boundary") {
+    // Regression: a right-to-left streaming concatenation whose packed layout
+    // makes a slice land exactly on an element boundary used to crash reOrder
+    // (the packing iterator ran past the end of the packed list). Streaming is
+    // a bit permutation, so the population count must be preserved.
+    ScriptSession session;
+    session.eval("localparam logic [2:0] a = 3'h5;");
+    session.eval("localparam logic b = 1'b1;");
+    session.eval("localparam logic [15:0] s = {<<3{a, a, a, a, a, b}};");
+    CHECK(session.eval("$countones(s)").integer() == 11);
+
+    session.eval("localparam logic [15:0] c = 16'hCAFE;");
+    session.eval("localparam logic [15:0] p = {<<3{ {<<3{c}} }};");
+    CHECK(session.eval("$countones(p)").integer() ==
+          session.eval("$countones(c)").integer());
+}
+
 TEST_CASE("streaming operator target evaluation") {
     ScriptSession session;
     session.eval(R"(

--- a/tests/unittests/ast/EvalTests.cpp
+++ b/tests/unittests/ast/EvalTests.cpp
@@ -2073,8 +2073,7 @@ TEST_CASE("Streaming concat with irregular packed slice boundary") {
 
     session.eval("localparam logic [15:0] c = 16'hCAFE;");
     session.eval("localparam logic [15:0] p = {<<3{ {<<3{c}} }};");
-    CHECK(session.eval("$countones(p)").integer() ==
-          session.eval("$countones(c)").integer());
+    CHECK(session.eval("$countones(p)").integer() == session.eval("$countones(c)").integer());
 }
 
 TEST_CASE("streaming operator target evaluation") {


### PR DESCRIPTION
## Problem

A right-to-left streaming concatenation (`{<<N{...}}`) whose packed layout makes
a slice land exactly on an element boundary crashes slang with a segfault during
constant evaluation.

In `Bitstream::reOrder`, when a block's leading partial slice consumes an element
to its end, `slicePacked` already advances the packing iterator past that
element (it sets `bit == elementWidth` and steps `iter`). The subsequent
unconditional `iter++` then advances it a **second** time, skipping an element —
and for layouts where this happens at the right edge, `iter` runs past the end
of the `packed` list, so the following `sliceOrAppend` / element move
dereferences past the `SmallVector` storage.

### Reproducer

```systemverilog
module m;
  localparam logic [2:0] a = 3'h5;
  localparam logic       b = 1'b1;
  localparam logic [15:0] p = {<<3{ a, a, a, a, a, b }};  // packed [3,3,3,3,3,1], slice 3
endmodule
```

```
$ slang repro.sv
Segmentation fault (core dumped)
```

It is also reachable nested, e.g. `{<<3{ {<<3{a}} }}` on a 16-bit `a`.

Width-aligned layouts (every slice landing on an element boundary because the
element widths equal the slice size) are unaffected: there the leading slice is
`0`, so `slicePacked` is not called and the single `iter++` is correct. Only the
misaligned case double-advances.

## Fix

Advance the iterator only when there was no leading partial slice; when there
was, `slicePacked` has already advanced it past that element. This keeps the
iterator pointing at the correct next element for the rest of the block, so no
element is skipped and the iterator no longer runs past the end.

## Testing

- The reproducers no longer crash. Because a streaming concatenation is a bit
  permutation, I verified `$countones` is preserved for the crash layout and for
  several other irregular layouts (slice sizes 2/3/4/5), and that the
  double-reverse identity `{<<N{{<<N{x}}}} == x` still holds for a width-aligned
  `x`. (The earlier, minimal "guard the out-of-range dereference" approach
  avoided the crash but silently dropped a bit — `$countones` caught that, which
  is why the fix addresses the double-advance instead.)
- New unit test `Streaming concat with irregular packed slice boundary` in
  `tests/unittests/ast/EvalTests.cpp`.
- The full unit-test suite passes.

Disclosure: this contribution was authored with an AI coding assistant (Claude) and reviewed before submission.
