### PR TITLE
Fix internal error on streaming 'with' range past the array extent

### DIFF
--- a/source/ast/Bitstream.cpp
+++ b/source/ast/Bitstream.cpp
@@ -930,11 +930,14 @@ ConstantValue Bitstream::resizeToRange(ConstantValue&& value, ConstantRange rang
     }
 
     if (range.lower() > 0 || range.width() != value.size()) {
-        auto upper = static_cast<uint32_t>(range.upper());
-        auto lower = static_cast<uint32_t>(range.lower());
+        // A source-side streaming 'with' range may start beyond the current array/queue
+        // extent (IEEE 1800-2017 11.4.14.3); nonexistent elements are the default value.
+        // Clamp both bounds to the size so the copy range is never reversed, and take the
+        // remaining 'more' elements as default fills, keeping the result range.width() wide.
         auto size = static_cast<uint32_t>(value.size());
-        auto more = upper >= size ? upper - size + 1 : 0;
-        upper = std::min(upper + 1, size);
+        auto lower = std::min(static_cast<uint32_t>(range.lower()), size);
+        auto upper = std::min(static_cast<uint32_t>(range.upper()) + 1, size);
+        auto more = static_cast<uint32_t>(range.width()) - (upper - lower);
 
         if (value.isUnpacked()) {
             const auto old = value.elements();

--- a/tests/unittests/ast/EvalTests.cpp
+++ b/tests/unittests/ast/EvalTests.cpp
@@ -2220,6 +2220,40 @@ endfunction
     NO_SESSION_ERRORS;
 }
 
+TEST_CASE("Streaming 'with' range starting past the array extent") {
+    // Regression: a source-side streaming 'with' range may begin beyond the current
+    // queue/dynamic-array size; the nonexistent elements are streamed as the default
+    // value (IEEE 1800-2017 11.4.14.3). Previously this crashed with an internal error
+    // because the range's lower bound was not clamped to the array size.
+    ScriptSession session;
+    session.eval(R"(
+    function automatic bit [63:0] f_empty_queue();
+        int q[$];
+        return {>>{q with [1:2]}};      // empty queue, indices 1,2 nonexistent -> 0
+    endfunction
+    function automatic bit [63:0] f_empty_dynarray();
+        int d[];
+        return {>>{d with [1:2]}};      // empty dynamic array, indices 1,2 nonexistent -> 0
+    endfunction
+    function automatic bit [63:0] f_small_queue();
+        int q[$] = {7};
+        return {>>{q with [3:4]}};      // size 1, indices 3,4 nonexistent -> 0
+    endfunction
+    function automatic bit [95:0] f_partial();
+        int q[$] = {10, 20, 30};
+        return {>>{q with [1:3]}};      // 20, 30, then default 0 for nonexistent index 3
+    endfunction
+)");
+
+    CHECK(session.eval("f_empty_queue()").integer() == 0);
+    CHECK(session.eval("f_empty_dynarray()").integer() == 0);
+    CHECK(session.eval("f_small_queue()").integer() == 0);
+    CHECK(session.eval("f_partial()").integer() ==
+          session.eval("{32'd20, 32'd30, 32'd0}").integer());
+
+    NO_SESSION_ERRORS;
+}
+
 TEST_CASE("Array reduction methods") {
     ScriptSession session;
     session.eval("byte b[] = { 1, 2, 3, 4 };");


### PR DESCRIPTION
### Summary

A source-side streaming concatenation whose `with` range starts beyond the current size of a queue or dynamic array crashes the compiler with an internal error during constant evaluation. Per IEEE 1800-2017 §11.4.14.3 an out-of-extent `with` range is legal — the nonexistent elements are streamed as the default value — so this input should evaluate, not ICE.

### Reproducer

```systemverilog
module m;
  function automatic bit [63:0] f();
    int q[$];                    // empty queue
    return {>> {q with [1:2]}};  // indices 1,2 do not exist
  endfunction
  localparam bit [63:0] P = f();
endmodule
```

```
internal compiler error: cannot create std::deque larger than max_size()
```

A dynamic array (`int d[];`) reports `internal compiler error: vector::_M_range_insert`, and a non-empty queue whose size is below the lower bound (e.g. `q` of size 1 with `[3:4]`) fails the same way. A single-index out-of-range select (`with [i]`) is already handled and returns the default value; only the range form was affected.

### Cause

In `Bitstream::resizeToRange` the `upper` bound is clamped to the value size but `lower` (`= range.lower()`) is used unclamped. When `range.lower() > value.size()`, the copy range `old.begin() + lower .. old.begin() + upper` is reversed, so the `std::deque` / `std::vector` range constructor throws `length_error`, which surfaces as an internal compiler error.

### Fix

Clamp `lower` to the size just as `upper` already is, and derive the default-fill count from `range.width()`. The copy range is then never reversed, and the result still has exactly `range.width()` elements: the in-extent elements in order followed by default-valued fills for the nonexistent indices. For every previously-working case (`lower <= size`) the computation is identical, so there is no behavioral change outside the crashing path.

`{>> {q with [1:2]}}` on an empty queue now evaluates to `64'h0` (two default `int` elements), the standard-mandated result.

### Testing

- New unit test `Streaming 'with' range starting past the array extent` in `tests/unittests/ast/EvalTests.cpp`, covering an empty queue, an empty dynamic array, a too-small queue, and a partial (in-extent + default-fill) range whose exact streamed value is checked.
- Full unit test suite passes (2480 test cases, 22856 assertions).

Disclosure: this contribution was authored with an AI coding assistant (Claude) and reviewed before submission.