### PR TITLE
Fix internal error on %u/%z formatting of an unpacked union

### DIFF
--- a/source/ast/SFormat.cpp
+++ b/source/ast/SFormat.cpp
@@ -270,6 +270,13 @@ static void formatRaw2(std::string& result, const ConstantValue& value) {
         return;
     }
 
+    if (value.isUnion()) {
+        // An unpacked union stores its active member; emit that member's raw
+        // representation, mirroring the unpacked struct/array recursion above.
+        formatRaw2(result, value.unionVal()->value);
+        return;
+    }
+
     SVInt sv = value.integer();
     sv.flattenUnknowns();
 
@@ -290,6 +297,13 @@ static void formatRaw4(std::string& result, const ConstantValue& value) {
     if (value.isUnpacked()) {
         for (auto& elem : value.elements())
             formatRaw4(result, elem);
+        return;
+    }
+
+    if (value.isUnion()) {
+        // An unpacked union stores its active member; emit that member's raw
+        // representation, mirroring the unpacked struct/array recursion above.
+        formatRaw4(result, value.unionVal()->value);
         return;
     }
 

--- a/tests/unittests/ast/EvalTests.cpp
+++ b/tests/unittests/ast/EvalTests.cpp
@@ -1264,6 +1264,39 @@ TEST_CASE("sformatf with real conversion") {
     CHECK(session.eval("$sformatf(\"%0d\", 3.14)"s).str() == "3");
 }
 
+TEST_CASE("Raw format specifiers (%u/%z) on an unpacked union") {
+    // Regression: %u and %z on an unpacked union previously aborted with an internal
+    // error (std::get on the wrong ConstantValue variant). The active member's raw
+    // representation must be emitted -- identical to formatting that member directly.
+    ScriptSession session;
+    session.eval(R"(
+typedef union { byte a; byte b; } u_t;
+typedef struct { u_t u; byte c; } s_t;
+typedef struct { byte a; byte c; } s2_t;
+function automatic bit chk_u();
+    u_t u; u.a = 8'h41;
+    return ($sformatf("%u", u) == $sformatf("%u", byte'(8'h41)));
+endfunction
+function automatic bit chk_z();
+    u_t u; u.a = 8'h41;
+    return ($sformatf("%z", u) == $sformatf("%z", byte'(8'h41)));
+endfunction
+function automatic bit chk_struct();
+    // A struct containing a union must format the same as the struct with the
+    // union replaced by its (byte) active member.
+    s_t s;
+    s2_t s2;
+    s.u.a = 8'h41; s.c = 8'h42;
+    s2.a = 8'h41; s2.c = 8'h42;
+    return ($sformatf("%u", s) == $sformatf("%u", s2));
+endfunction
+)");
+    CHECK(session.eval("chk_u()").integer() == 1);
+    CHECK(session.eval("chk_z()").integer() == 1);
+    CHECK(session.eval("chk_struct()").integer() == 1);
+    NO_SESSION_ERRORS;
+}
+
 TEST_CASE("Concat assignments") {
     ScriptSession session;
     session.eval("logic [2:0] foo;");


### PR DESCRIPTION
### Summary

`$sformatf` / `$display` with the raw format specifiers `%u` or `%z` crashes the compiler with an internal error when the argument is an unpacked union (or a struct/array containing one). The compiler's own `isValidForRaw` check accepts these arguments, so the input elaborates and constant-evaluates without any diagnostic, then aborts.

### Reproducer

```systemverilog
module m;
  typedef union { byte a; byte b; } u_t;
  function automatic string f();
    u_t u; u.a = 8'h41;
    return $sformatf("%u", u);
  endfunction
  localparam string s = f();
endmodule
```

```
internal compiler error: std::get: wrong index for variant
```

`%z` fails the same way, as does a struct that contains a union member.

### Cause

`isValidForRaw` (`FmtHelpers.cpp`) deliberately accepts an unpacked union whose members are all raw-able, so no diagnostic is emitted. At evaluation an unpacked-union constant is stored as the `ConstantValue` `Union` variant, but `formatRaw2` / `formatRaw4` (`SFormat.cpp`) only special-case the `Elements` variant (unpacked struct/array) and then call `value.integer()` — a `std::get<SVInt>` that throws on the `Union` variant.

### Fix

Handle the `Union` variant in both `formatRaw2` and `formatRaw4` by recursing into the union's active member (`unionVal()->value`), mirroring the existing unpacked struct/array recursion just above. Per IEEE 1800-2017 §7.3.2 an unpacked union holds exactly one member at a time, which is what slang stores, so this emits that member's raw representation — the same bytes `%u` / `%z` produce for the member directly.

### Testing

- New unit test `Raw format specifiers (%u/%z) on an unpacked union` in `tests/unittests/ast/EvalTests.cpp`. It checks the crash is gone **and** that the output is correct: `%u` / `%z` on the union equal `%u` / `%z` on the equivalent `byte`, and a struct containing the union formats identically to the same struct with the union replaced by that member.
- Full unit test suite passes (2482 test cases, 22861 assertions).

Disclosure: this contribution was authored with an AI coding assistant (Claude) and reviewed before submission.