### PR TITLE
slang-lit: derive the default job count from the process CPU affinity

### DIFF
--- a/scripts/slang-lit.py
+++ b/scripts/slang-lit.py
@@ -52,7 +52,7 @@ Options
   --define KEY=VALUE    Define a custom substitution; %KEY in RUN lines is
                         replaced with VALUE. Can be specified multiple times.
   --verbose, -v         Print each test command as it runs.
-  --jobs, -j <N>        Run N tests in parallel (default: 1).
+  --jobs, -j <N>        Run N tests in parallel (default: one per usable CPU).
   --filter <regex>      Run only tests whose paths match <regex>.
   --no-color            Disable ANSI colour output.
 
@@ -783,8 +783,23 @@ def maybe_wrap_wasm_launcher(slang_bin: str) -> tuple[str, bool]:
 # ---------------------------------------------------------------------------
 
 
+def usable_cpu_count() -> int:
+    """Return the number of CPUs this process may actually run on.
+
+    os.cpu_count() reports the CPUs of the machine and ignores any restriction
+    placed on the process, so a run pinned to a couple of cores would still
+    start a job per CPU of the host.
+    """
+    process_cpu_count = getattr(os, "process_cpu_count", None)
+    if process_cpu_count is not None:  # Python 3.13+
+        return process_cpu_count() or 1
+    if hasattr(os, "sched_getaffinity"):
+        return len(os.sched_getaffinity(0)) or 1
+    return os.cpu_count() or 1
+
+
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
-    _default_jobs = os.cpu_count() or 1
+    _default_jobs = usable_cpu_count()
 
     p = argparse.ArgumentParser(
         description=__doc__ or "",


### PR DESCRIPTION
`slang-lit` sizes its default job count with `os.cpu_count()`, which reports the CPUs of the machine rather than the ones this process may run on, so `taskset -c 0-3 scripts/slang-lit.py ...` still starts one job per host CPU. That also oversubscribes quadratically, since every lit job runs a driver that sizes its own thread pool from `hardware_concurrency()` - on a 256-core host, 256 jobs  x 256 threads, which is enough to make `pthread_create` fail with `EAGAIN` in a container and surface as a confusing `internal compiler error: Resource temporarily unavailable`. Use `os.process_cpu_count()` when available (Python 3.13+), fall back to `sched_getaffinity()`, and keep `os.cpu_count()` otherwise. The default is unchanged on an unrestricted machine, while under `taskset -c 0-3` it now reports 4 instead of 28. 