### PR TITLE
Fix getDPIExports() dropping exports that share a C identifier

### DIFF
--- a/source/ast/Compilation.cpp
+++ b/source/ast/Compilation.cpp
@@ -2045,7 +2045,6 @@ void Compilation::checkDPIMethods(std::span<const SubroutineSymbol* const> dpiIm
 
             auto [nameIt, nameInserted] = nameMap.emplace(cId, &sub);
             if (!nameInserted) {
-                shouldRecordResolved = false;
                 if (!checkSignaturesMatch(sub, *nameIt->second)) {
                     auto& diag = scope->addDiag(diag::DPISignatureMismatch, syntax->name.range());
                     diag << cId;

--- a/tests/unittests/ast/SubroutineTests.cpp
+++ b/tests/unittests/ast/SubroutineTests.cpp
@@ -326,6 +326,36 @@ endmodule
     CHECK(exports[1].syntax->c_identifier.valueText() == "my_f2");
 }
 
+TEST_CASE("Compilation collects DPI exports from each instance") {
+    auto tree = SyntaxTree::fromText(R"(
+module Sub #(parameter int ID = 0);
+    int id;
+    export "DPI-C" function read_id;
+    function int read_id(); return id; endfunction
+    initial id = ID;
+endmodule
+
+module Top;
+    Sub #(.ID(10)) m0();
+    Sub #(.ID(20)) m1();
+endmodule
+)");
+
+    Compilation compilation;
+    compilation.addSyntaxTree(tree);
+    NO_COMPILATION_ERRORS;
+
+    // The single export directive elaborates into two distinct instances. Both
+    // are valid targets, selected at call time via svSetScope, so both must be
+    // reported even though they share a C identifier.
+    auto exports = compilation.getDPIExports();
+    REQUIRE(exports.size() == 2);
+    CHECK(exports[0].subroutine->getHierarchicalPath() == "Top.m0.read_id");
+    CHECK(exports[0].cIdentifier == "read_id");
+    CHECK(exports[1].subroutine->getHierarchicalPath() == "Top.m1.read_id");
+    CHECK(exports[1].cIdentifier == "read_id");
+}
+
 TEST_CASE("DPI signature checking") {
     auto tree = SyntaxTree::fromText(R"(
 import "DPI-C" function int foo(int a, output b);


### PR DESCRIPTION
## Summary

Fixes #1923. `getDPIExports()` returned only one entry when the same C identifier is exported from more than one scope, and silently dropped the rest. Each dropped entry is a valid, separate export target. After elaboration multiple instances of the export exist and `svSetScope` selects between them at call time (LRM 35.4 and 35.5.3), so the accessor should report all of them. The issue has the full background; this PR is the one-line fix plus a test.

## Design

- The drop was in `Compilation::checkDPIMethods`: when a C identifier repeated across scopes, the code set `shouldRecordResolved = false` and recorded only the first export. Removing that one line records every resolved directive; the adjacent signature check (`DPISignatureMismatch`) is unchanged.
- The same-scope duplicate case uses a separate `(C identifier, scope)` map and still reports `DPIExportDuplicateCId`, so this does not weaken that error.

## Testing

New test in `SubroutineTests.cpp`: one module instantiated twice, exporting the same C identifier. `getDPIExports()` now returns both `Top.m0.read_id` and `Top.m1.read_id`; it returns one before the change. No existing tests needed changes, and the full suite passes.

## AI disclosure

Per the project's CONTRIBUTING.md: parts of this patch were drafted with assistance from Claude. I reviewed every line and am fully accountable for the change.
