### PR TITLE
CMake: Check for system `mimalloc` before fetching

### DIFF
--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -96,26 +96,32 @@ if(SLANG_USE_MIMALLOC)
       FATAL_ERROR "mimalloc cannot be used with Windows shared lib builds")
   endif()
 
-  set(MI_BUILD_SHARED
-      OFF
-      CACHE INTERNAL "")
-  set(MI_BUILD_TESTS
-      OFF
-      CACHE INTERNAL "")
-  set(MI_SKIP_COLLECT_ON_EXIT
-      ON
-      CACHE INTERNAL "")
-  set(MI_USE_CXX
-      ON
-      CACHE INTERNAL "")
+  find_package(mimalloc 3.4 QUIET)
 
-  FetchContent_Declare(
-    mimalloc
-    GIT_REPOSITORY ${GITHUB_PREFIX}microsoft/mimalloc.git
-    GIT_TAG v3.4.5
-    GIT_SHALLOW ON
-    FIND_PACKAGE_ARGS 3.4)
-  FetchContent_MakeAvailable(mimalloc)
+  if(NOT mimalloc_FOUND)
+    message(STATUS "System mimalloc not found; fetching remote library...")
+
+    set(MI_BUILD_SHARED
+        OFF
+        CACHE INTERNAL "")
+    set(MI_BUILD_TESTS
+        OFF
+        CACHE INTERNAL "")
+    set(MI_SKIP_COLLECT_ON_EXIT
+        ON
+        CACHE INTERNAL "")
+    set(MI_USE_CXX
+        ON
+        CACHE INTERNAL "")
+
+    include(FetchContent)
+    FetchContent_Declare(
+      mimalloc
+      GIT_REPOSITORY ${GITHUB_PREFIX}microsoft/mimalloc.git
+      GIT_TAG v3.4.5
+      GIT_SHALLOW ON)
+    FetchContent_MakeAvailable(mimalloc)
+  endif()
 
   if(mimalloc_FOUND)
     if(TARGET mimalloc)


### PR DESCRIPTION
When `SLANG_USE_MIMALLOC` is true, this PR first checks for a system mimalloc, and if one is not found then it fetches it from github as before.

I also considered adding a `SLANG_USE_SYSTEM_MIMALLOC` but I thought that might create a confusion about which flags should be on, and whether they are conflicting, etc, etc.

An alternative is to set SLANG_USE_SYSTEM_MIMALLOC to have three possible values, `TRUE`, `FALSE` and `SYSTEM`. But again this might be more complicated than its worth.