### PR TITLE
Add TypedefStructUnion lint

### DIFF
--- a/tools/tidy/CMakeLists.txt
+++ b/tools/tidy/CMakeLists.txt
@@ -32,7 +32,8 @@ add_library(
   src/synthesis/LoopBeforeResetCheck.cpp
   src/style/NoCaseX.cpp
   src/style/NoDefParam.cpp
-  src/style/TypedefEnums.cpp)
+  src/style/TypedefEnums.cpp
+  src/style/TypedefStructUnion.cpp)
 
 target_include_directories(slang_tidy_obj_lib PUBLIC include)
 target_link_libraries(slang_tidy_obj_lib PUBLIC slang::slang fmt::fmt)

--- a/tools/tidy/README.md
+++ b/tools/tidy/README.md
@@ -77,6 +77,7 @@ The available options are:
 |      **inputPortPrefix**      | [string] |       []           |
 |     **outputPortPrefix**      | [string] |       []           |
 |      **inoutPortPrefix**      | [string] |       []           |
+|      **allowNestedAnon**      |   bool   |       false        |
 
 An example of a possible configuration file:
 

--- a/tools/tidy/include/TidyConfig.h
+++ b/tools/tidy/include/TidyConfig.h
@@ -38,6 +38,7 @@ public:
         std::vector<std::string> inputPortPrefix;
         std::vector<std::string> outputPortPrefix;
         std::vector<std::string> inoutPortPrefix;
+        bool allowNestedAnon;
     };
 
     /// Default TidyConfig constructor which will set the default check's configuration values
@@ -86,6 +87,7 @@ public:
             {"inputPortPrefix", joinVec(cfg.inputPortPrefix)},
             {"outputPortPrefix", joinVec(cfg.outputPortPrefix)},
             {"inoutPortPrefix", joinVec(cfg.inoutPortPrefix)},
+            {"allowNestedAnon", cfg.allowNestedAnon ? "true" : "false"},
         };
     }
 
@@ -173,6 +175,10 @@ private:
         }
         else if (configName == "inoutPortPrefix") {
             visit(checkConfigs.inoutPortPrefix);
+            return;
+        }
+        else if (configName == "allowNestedAnon") {
+            visit(checkConfigs.allowNestedAnon);
             return;
         }
         SLANG_THROW(std::invalid_argument(fmt::format("The check: {} does not exist", configName)));

--- a/tools/tidy/include/TidyDiags.h
+++ b/tools/tidy/include/TidyDiags.h
@@ -36,5 +36,6 @@ inline constexpr DiagCode LoopBeforeResetCheck(DiagSubsystem::Tidy, 21);
 inline constexpr DiagCode NoCaseX(DiagSubsystem::Tidy, 22);
 inline constexpr DiagCode NoDefParam(DiagSubsystem::Tidy, 23);
 inline constexpr DiagCode TypedefEnums(DiagSubsystem::Tidy, 24);
+inline constexpr DiagCode TypedefStructUnion(DiagSubsystem::Tidy, 25);
 
 } // namespace slang::diag

--- a/tools/tidy/src/TidyConfig.cpp
+++ b/tools/tidy/src/TidyConfig.cpp
@@ -21,6 +21,7 @@ TidyConfig::TidyConfig() {
     checkConfigs.inputPortPrefix = {""};
     checkConfigs.outputPortPrefix = {""};
     checkConfigs.inoutPortPrefix = {""};
+    checkConfigs.allowNestedAnon = false;
 
     auto styleChecks = std::unordered_map<std::string, CheckOptions>();
     styleChecks.emplace("AlwaysCombNonBlocking", CheckOptions());
@@ -39,6 +40,7 @@ TidyConfig::TidyConfig() {
     styleChecks.emplace("NoCaseX", CheckOptions());
     styleChecks.emplace("NoDefParam", CheckOptions());
     styleChecks.emplace("TypedefEnums", CheckOptions());
+    styleChecks.emplace("TypedefStructUnion", CheckOptions());
     checkKinds.insert({slang::TidyKind::Style, styleChecks});
 
     auto synthesisChecks = std::unordered_map<std::string, CheckOptions>();

--- a/tools/tidy/src/style/TypedefStructUnion.cpp
+++ b/tools/tidy/src/style/TypedefStructUnion.cpp
@@ -1,0 +1,68 @@
+// SPDX-FileCopyrightText: Michael Popoloski
+// SPDX-License-Identifier: MIT
+
+#include "ASTHelperVisitors.h"
+#include "TidyDiags.h"
+
+#include "slang/syntax/SyntaxTree.h"
+#include "slang/syntax/SyntaxVisitor.h"
+
+using namespace slang;
+using namespace slang::ast;
+using namespace slang::syntax;
+
+namespace typedef_struct_union {
+struct MainVisitor : public TidyVisitor, SyntaxVisitor<MainVisitor> {
+    explicit MainVisitor(Diagnostics& diagnostics) : TidyVisitor(diagnostics) {}
+
+    void handle(const StructUnionTypeSyntax& node) {
+        NEEDS_SKIP_NODE(node)
+
+        if (auto parent = node.parent) {
+            bool isTypedef = parent->kind == SyntaxKind::TypedefDeclaration;
+            bool allowedNestedAnon = config.getCheckConfigs().allowNestedAnon &&
+                                     parent->kind == SyntaxKind::StructUnionMember;
+            if (!isTypedef && !allowedNestedAnon) {
+                diags.add(diag::TypedefStructUnion, node.keyword.location());
+            }
+        }
+
+        visitDefault(node);
+    }
+};
+} // namespace typedef_struct_union
+
+using namespace typedef_struct_union;
+
+class TypedefStructUnion : public TidyCheck {
+public:
+    [[maybe_unused]] explicit TypedefStructUnion(
+        TidyKind kind, std::optional<slang::DiagnosticSeverity> severity) :
+        TidyCheck(kind, severity) {}
+
+    bool check(const RootSymbol& root, const slang::analysis::AnalysisManager&) override {
+        MainVisitor visitor(diagnostics);
+        for (auto& tree : root.getCompilation().getSyntaxTrees())
+            tree->root().visit(visitor);
+        return diagnostics.empty();
+    }
+
+    DiagCode diagCode() const override { return diag::TypedefStructUnion; }
+
+    std::string diagString() const override {
+        return "struct/union declaration should be named using a typedef";
+    }
+
+    DiagnosticSeverity diagDefaultSeverity() const override { return DiagnosticSeverity::Warning; }
+
+    std::string name() const override { return "TypedefStructUnion"; }
+
+    std::string description() const override { return shortDescription(); }
+
+    std::string shortDescription() const override {
+        return "Enforces that all struct and union declarations are named using a typedef "
+               "unless allowNestedAnon is set in the config";
+    }
+};
+
+REGISTER(TypedefStructUnion, TypedefStructUnion, TidyKind::Style)

--- a/tools/tidy/tests/CMakeLists.txt
+++ b/tools/tidy/tests/CMakeLists.txt
@@ -33,7 +33,8 @@ add_executable(
   LoopBeforeResetCheckTest.cpp
   NoCaseXTest.cpp
   NoDefParamTest.cpp
-  TypedefEnumsTest.cpp)
+  TypedefEnumsTest.cpp
+  TypedefStructUnionTest.cpp)
 
 target_link_libraries(tidy_unittests PRIVATE Catch2::Catch2 slang_tidy_obj_lib)
 target_compile_definitions(tidy_unittests PRIVATE UNITTESTS)

--- a/tools/tidy/tests/TypedefStructUnionTest.cpp
+++ b/tools/tidy/tests/TypedefStructUnionTest.cpp
@@ -1,0 +1,164 @@
+// SPDX-FileCopyrightText: Michael Popoloski
+// SPDX-License-Identifier: MIT
+
+#include "TidyConfigParser.h"
+#include "TidyTest.h"
+
+TEST_CASE("TypedefStructUnion: struct without typedef") {
+    auto result = runCheckTest("TypedefStructUnion", R"(
+module top;
+    struct {
+        bit a;
+    } a_s;
+endmodule
+)");
+    CHECK_FALSE(result);
+}
+
+TEST_CASE("TypedefStructUnion: packed struct without typedef") {
+    auto result = runCheckTest("TypedefStructUnion", R"(
+module top;
+    struct packed {
+        bit a;
+    } a_s;
+endmodule
+)");
+    CHECK_FALSE(result);
+}
+
+TEST_CASE("TypedefStructUnion: union without typedef") {
+    auto result = runCheckTest("TypedefStructUnion", R"(
+module top;
+    union {
+        bit a;
+    } a_u;
+endmodule
+)");
+    CHECK_FALSE(result);
+}
+
+TEST_CASE("TypedefStructUnion: tagged union without typedef") {
+    auto result = runCheckTest("TypedefStructUnion", R"(
+module top;
+    union tagged {
+        bit a;
+    } a_u;
+endmodule
+)");
+    CHECK_FALSE(result);
+}
+
+TEST_CASE("TypedefStructUnion: struct with typedef") {
+    auto result = runCheckTest("TypedefStructUnion", R"(
+module top;
+    typedef struct {
+        bit a;
+    } a_s;
+    typedef struct packed {
+        bit a;
+    } b_s;
+endmodule
+)");
+    CHECK(result);
+}
+
+TEST_CASE("TypedefStructUnion: union with typedef") {
+    auto result = runCheckTest("TypedefStructUnion", R"(
+module top;
+    typedef union {
+        bit a;
+    } a_u;
+    typedef union tagged {
+        bit a;
+    } b_u;
+endmodule
+)");
+    CHECK(result);
+}
+
+TEST_CASE("TypedefStructUnion: allow nested anon struct") {
+    auto config_str = std::string(R"(CheckConfigs:
+    allowNestedAnon: true)");
+    TidyConfigParser parser(config_str);
+    auto config = parser.getConfig();
+    auto result = runCheckTest("TypedefStructUnion", R"(
+module top;
+    typedef struct {
+        bit a;
+        struct {
+            logic c;
+        } b;
+    } abc_s;
+endmodule
+)",
+                               config);
+    CHECK(result);
+}
+
+TEST_CASE("TypedefStructUnion: deny nested anon struct") {
+    auto result = runCheckTest("TypedefStructUnion", R"(
+module top;
+    typedef struct {
+        bit a;
+        struct {
+            logic c;
+        } b;
+    } abc_s;
+endmodule
+)");
+    CHECK_FALSE(result);
+}
+
+TEST_CASE("TypedefStructUnion: allow nested anon union") {
+    auto config_str = std::string(R"(CheckConfigs:
+    allowNestedAnon: true)");
+    TidyConfigParser parser(config_str);
+    auto config = parser.getConfig();
+    auto result = runCheckTest("TypedefStructUnion", R"(
+module top;
+    typedef struct {
+        bit a;
+        union {
+            logic c;
+        } b;
+    } abc_s;
+endmodule
+)",
+                               config);
+    CHECK(result);
+}
+
+TEST_CASE("TypedefStructUnion: deny nested anon union") {
+    auto result = runCheckTest("TypedefStructUnion", R"(
+module top;
+    typedef struct {
+        bit a;
+        union {
+            logic c;
+        } b;
+    } abc_s;
+endmodule
+)");
+    CHECK_FALSE(result);
+}
+
+TEST_CASE("TypedefStructUnion: nested struct errors") {
+    std::string output;
+    auto result = runCheckTest("TypedefStructUnion", R"(
+module top;
+    struct {
+        struct { logic a; } b;
+    } ab_s;
+endmodule
+)",
+                               {}, &output);
+    CHECK_FALSE(result);
+    CHECK("\n" + output == R"(
+source:3:5: warning: [STYLE-25] struct/union declaration should be named using a typedef
+    struct {
+    ^
+source:4:9: warning: [STYLE-25] struct/union declaration should be named using a typedef
+        struct { logic a; } b;
+        ^
+)");
+}


### PR DESCRIPTION
Lint to ensure all struct and union declarations
use a typedef.

Allow nested anonymous struct/union using
new CheckConfig allowNestedAnon.