### PR TITLE
Add lints for naming of coverage.

### DIFF
--- a/tools/tidy/CMakeLists.txt
+++ b/tools/tidy/CMakeLists.txt
@@ -33,7 +33,10 @@ add_library(
   src/style/NoCaseX.cpp
   src/style/NoDefParam.cpp
   src/style/TypedefEnums.cpp
-  src/style/TypedefStructUnion.cpp)
+  src/style/TypedefStructUnion.cpp
+  src/style/CovergroupName.cpp
+  src/style/CoverpointName.cpp
+  src/style/CrossName.cpp)
 
 target_include_directories(slang_tidy_obj_lib PUBLIC include)
 target_link_libraries(slang_tidy_obj_lib PUBLIC slang::slang fmt::fmt)

--- a/tools/tidy/README.md
+++ b/tools/tidy/README.md
@@ -78,6 +78,9 @@ The available options are:
 |     **outputPortPrefix**      | [string] |       []           |
 |      **inoutPortPrefix**      | [string] |       []           |
 |      **allowNestedAnon**      |   bool   |       false        |
+|   **covergroupRegexString**   |  string  |     \"cg_\\S*\"    |
+|   **coverpointRegexString**   |  string  |    \"cp_\\S*\"     |
+|     **crossRegexString**      |  string  |   "cross_\\S*\"    |
 
 An example of a possible configuration file:
 

--- a/tools/tidy/include/TidyConfig.h
+++ b/tools/tidy/include/TidyConfig.h
@@ -39,6 +39,12 @@ public:
         std::vector<std::string> outputPortPrefix;
         std::vector<std::string> inoutPortPrefix;
         bool allowNestedAnon;
+        std::string covergroupRegexString;
+        boost::regex covergroupRegexPattern;
+        std::string coverpointRegexString;
+        boost::regex coverpointRegexPattern;
+        std::string crossRegexString;
+        boost::regex crossRegexPattern;
     };
 
     /// Default TidyConfig constructor which will set the default check's configuration values
@@ -88,6 +94,9 @@ public:
             {"outputPortPrefix", joinVec(cfg.outputPortPrefix)},
             {"inoutPortPrefix", joinVec(cfg.inoutPortPrefix)},
             {"allowNestedAnon", cfg.allowNestedAnon ? "true" : "false"},
+            {"covergroupRegexString", cfg.covergroupRegexString},
+            {"coverpointRegexString", cfg.coverpointRegexString},
+            {"crossRegexString", cfg.crossRegexString},
         };
     }
 
@@ -179,6 +188,21 @@ private:
         }
         else if (configName == "allowNestedAnon") {
             visit(checkConfigs.allowNestedAnon);
+            return;
+        }
+        else if (configName == "covergroupRegexString") {
+            visit(checkConfigs.covergroupRegexString);
+            checkConfigs.covergroupRegexPattern = boost::regex(checkConfigs.covergroupRegexString);
+            return;
+        }
+        else if (configName == "coverpointRegexString") {
+            visit(checkConfigs.coverpointRegexString);
+            checkConfigs.coverpointRegexPattern = boost::regex(checkConfigs.coverpointRegexString);
+            return;
+        }
+        else if (configName == "crossRegexString") {
+            visit(checkConfigs.crossRegexString);
+            checkConfigs.crossRegexPattern = boost::regex(checkConfigs.crossRegexString);
             return;
         }
         SLANG_THROW(std::invalid_argument(fmt::format("The check: {} does not exist", configName)));

--- a/tools/tidy/include/TidyDiags.h
+++ b/tools/tidy/include/TidyDiags.h
@@ -37,5 +37,8 @@ inline constexpr DiagCode NoCaseX(DiagSubsystem::Tidy, 22);
 inline constexpr DiagCode NoDefParam(DiagSubsystem::Tidy, 23);
 inline constexpr DiagCode TypedefEnums(DiagSubsystem::Tidy, 24);
 inline constexpr DiagCode TypedefStructUnion(DiagSubsystem::Tidy, 25);
+inline constexpr DiagCode CovergroupName(DiagSubsystem::Tidy, 26);
+inline constexpr DiagCode CoverpointName(DiagSubsystem::Tidy, 27);
+inline constexpr DiagCode CrossName(DiagSubsystem::Tidy, 28);
 
 } // namespace slang::diag

--- a/tools/tidy/src/TidyConfig.cpp
+++ b/tools/tidy/src/TidyConfig.cpp
@@ -22,6 +22,12 @@ TidyConfig::TidyConfig() {
     checkConfigs.outputPortPrefix = {""};
     checkConfigs.inoutPortPrefix = {""};
     checkConfigs.allowNestedAnon = false;
+    checkConfigs.covergroupRegexString = "^cg_\\S*";
+    checkConfigs.covergroupRegexPattern = boost::regex(checkConfigs.covergroupRegexString);
+    checkConfigs.coverpointRegexString = "^cp_\\S*";
+    checkConfigs.coverpointRegexPattern = boost::regex(checkConfigs.coverpointRegexString);
+    checkConfigs.crossRegexString = "^cross_\\S*";
+    checkConfigs.crossRegexPattern = boost::regex(checkConfigs.crossRegexString);
 
     auto styleChecks = std::unordered_map<std::string, CheckOptions>();
     styleChecks.emplace("AlwaysCombNonBlocking", CheckOptions());
@@ -41,6 +47,9 @@ TidyConfig::TidyConfig() {
     styleChecks.emplace("NoDefParam", CheckOptions());
     styleChecks.emplace("TypedefEnums", CheckOptions());
     styleChecks.emplace("TypedefStructUnion", CheckOptions());
+    styleChecks.emplace("CovergroupName", CheckOptions{CheckStatus::DISABLED});
+    styleChecks.emplace("CoverpointName", CheckOptions{CheckStatus::DISABLED});
+    styleChecks.emplace("CrossName", CheckOptions{CheckStatus::DISABLED});
     checkKinds.insert({slang::TidyKind::Style, styleChecks});
 
     auto synthesisChecks = std::unordered_map<std::string, CheckOptions>();

--- a/tools/tidy/src/style/CovergroupName.cpp
+++ b/tools/tidy/src/style/CovergroupName.cpp
@@ -1,0 +1,64 @@
+// SPDX-FileCopyrightText: Michael Popoloski
+// SPDX-License-Identifier: MIT
+
+#include "ASTHelperVisitors.h"
+#include "TidyDiags.h"
+#include <boost_regex.hpp>
+
+#include "slang/syntax/SyntaxTree.h"
+#include "slang/syntax/SyntaxVisitor.h"
+
+using namespace slang;
+using namespace slang::ast;
+using namespace slang::syntax;
+
+namespace covergroup_name {
+struct MainVisitor : public TidyVisitor, SyntaxVisitor<MainVisitor> {
+    explicit MainVisitor(Diagnostics& diagnostics) : TidyVisitor(diagnostics) {}
+
+    void handle(const CovergroupDeclarationSyntax& node) {
+        NEEDS_SKIP_NODE(node)
+
+        if (!boost::regex_match(std::string(node.name.valueText()),
+                                config.getCheckConfigs().covergroupRegexPattern)) {
+            diags.add(diag::CovergroupName, node.name.location())
+                << config.getCheckConfigs().covergroupRegexString;
+        }
+    }
+};
+} // namespace covergroup_name
+
+using namespace covergroup_name;
+
+class CovergroupName : public TidyCheck {
+public:
+    [[maybe_unused]] explicit CovergroupName(TidyKind kind,
+                                             std::optional<slang::DiagnosticSeverity> severity) :
+        TidyCheck(kind, severity) {}
+
+    bool check(const RootSymbol& root, const slang::analysis::AnalysisManager&) override {
+        MainVisitor visitor(diagnostics);
+        for (auto& tree : root.getCompilation().getSyntaxTrees())
+            tree->root().visit(visitor);
+        return diagnostics.empty();
+    }
+
+    DiagCode diagCode() const override { return diag::CovergroupName; }
+
+    std::string diagString() const override {
+        return "name must match supplied covergroup pattern '{}'";
+    }
+
+    DiagnosticSeverity diagDefaultSeverity() const override { return DiagnosticSeverity::Warning; }
+
+    std::string name() const override { return "CovergroupName"; }
+
+    std::string description() const override { return shortDescription(); }
+
+    std::string shortDescription() const override {
+        return "Enforces naming style for covergroups "
+               "configured with covergroupRegexString e.g. \"cg_.*\"";
+    }
+};
+
+REGISTER(CovergroupName, CovergroupName, TidyKind::Style)

--- a/tools/tidy/src/style/CoverpointName.cpp
+++ b/tools/tidy/src/style/CoverpointName.cpp
@@ -1,0 +1,70 @@
+// SPDX-FileCopyrightText: Michael Popoloski
+// SPDX-License-Identifier: MIT
+
+#include "ASTHelperVisitors.h"
+#include "TidyDiags.h"
+#include <boost_regex.hpp>
+
+#include "slang/syntax/SyntaxTree.h"
+#include "slang/syntax/SyntaxVisitor.h"
+
+using namespace slang;
+using namespace slang::ast;
+using namespace slang::syntax;
+
+namespace coverpoint_name {
+struct MainVisitor : public TidyVisitor, SyntaxVisitor<MainVisitor> {
+    explicit MainVisitor(Diagnostics& diagnostics) : TidyVisitor(diagnostics) {}
+
+    void handle(const CoverpointSyntax& node) {
+        NEEDS_SKIP_NODE(node)
+
+        if (!node.label) {
+            diags.add(diag::CoverpointName, node.coverpoint.location())
+                << "coverpoint must be named and the name must match the pattern"sv
+                << config.getCheckConfigs().coverpointRegexString;
+            return;
+        }
+
+        if (!boost::regex_match(std::string(node.label->name.valueText()),
+                                config.getCheckConfigs().coverpointRegexPattern)) {
+            diags.add(diag::CoverpointName, node.label->name.location())
+                << "name must match supplied coverpoint pattern"sv
+                << config.getCheckConfigs().coverpointRegexString;
+        }
+    }
+};
+} // namespace coverpoint_name
+
+using namespace coverpoint_name;
+
+class CoverpointName : public TidyCheck {
+public:
+    [[maybe_unused]] explicit CoverpointName(TidyKind kind,
+                                             std::optional<slang::DiagnosticSeverity> severity) :
+        TidyCheck(kind, severity) {}
+
+    bool check(const RootSymbol& root, const slang::analysis::AnalysisManager&) override {
+        MainVisitor visitor(diagnostics);
+        for (auto& tree : root.getCompilation().getSyntaxTrees())
+            tree->root().visit(visitor);
+        return diagnostics.empty();
+    }
+
+    DiagCode diagCode() const override { return diag::CoverpointName; }
+
+    std::string diagString() const override { return "'{}' '{}'"; }
+
+    DiagnosticSeverity diagDefaultSeverity() const override { return DiagnosticSeverity::Warning; }
+
+    std::string name() const override { return "CoverpointName"; }
+
+    std::string description() const override { return shortDescription(); }
+
+    std::string shortDescription() const override {
+        return "Enforces naming style for coverpoints "
+               "configured with coverpointRegexString e.g. \"cg_.*\"";
+    }
+};
+
+REGISTER(CoverpointName, CoverpointName, TidyKind::Style)

--- a/tools/tidy/src/style/CrossName.cpp
+++ b/tools/tidy/src/style/CrossName.cpp
@@ -1,0 +1,70 @@
+// SPDX-FileCopyrightText: Michael Popoloski
+// SPDX-License-Identifier: MIT
+
+#include "ASTHelperVisitors.h"
+#include "TidyDiags.h"
+#include <boost_regex.hpp>
+
+#include "slang/syntax/SyntaxTree.h"
+#include "slang/syntax/SyntaxVisitor.h"
+
+using namespace slang;
+using namespace slang::ast;
+using namespace slang::syntax;
+
+namespace cross_name {
+struct MainVisitor : public TidyVisitor, SyntaxVisitor<MainVisitor> {
+    explicit MainVisitor(Diagnostics& diagnostics) : TidyVisitor(diagnostics) {}
+
+    void handle(const CoverCrossSyntax& node) {
+        NEEDS_SKIP_NODE(node)
+
+        if (!node.label) {
+            diags.add(diag::CrossName, node.cross.location())
+                << "cross must be named and the name must match the pattern"sv
+                << config.getCheckConfigs().crossRegexString;
+            return;
+        }
+
+        if (!boost::regex_match(std::string(node.label->name.valueText()),
+                                config.getCheckConfigs().crossRegexPattern)) {
+            diags.add(diag::CrossName, node.label->name.location())
+                << "name must match supplied cross pattern"sv
+                << config.getCheckConfigs().crossRegexString;
+        }
+    }
+};
+} // namespace cross_name
+
+using namespace cross_name;
+
+class CrossName : public TidyCheck {
+public:
+    [[maybe_unused]] explicit CrossName(TidyKind kind,
+                                        std::optional<slang::DiagnosticSeverity> severity) :
+        TidyCheck(kind, severity) {}
+
+    bool check(const RootSymbol& root, const slang::analysis::AnalysisManager&) override {
+        MainVisitor visitor(diagnostics);
+        for (auto& tree : root.getCompilation().getSyntaxTrees())
+            tree->root().visit(visitor);
+        return diagnostics.empty();
+    }
+
+    DiagCode diagCode() const override { return diag::CrossName; }
+
+    std::string diagString() const override { return "'{}' '{}'"; }
+
+    DiagnosticSeverity diagDefaultSeverity() const override { return DiagnosticSeverity::Warning; }
+
+    std::string name() const override { return "CrossName"; }
+
+    std::string description() const override { return shortDescription(); }
+
+    std::string shortDescription() const override {
+        return "Enforces naming style for crosss "
+               "configured with crossRegexString e.g. \"cg_.*\"";
+    }
+};
+
+REGISTER(CrossName, CrossName, TidyKind::Style)

--- a/tools/tidy/tests/CMakeLists.txt
+++ b/tools/tidy/tests/CMakeLists.txt
@@ -34,7 +34,8 @@ add_executable(
   NoCaseXTest.cpp
   NoDefParamTest.cpp
   TypedefEnumsTest.cpp
-  TypedefStructUnionTest.cpp)
+  TypedefStructUnionTest.cpp
+  CoverageNameTest.cpp)
 
 target_link_libraries(tidy_unittests PRIVATE Catch2::Catch2 slang_tidy_obj_lib)
 target_compile_definitions(tidy_unittests PRIVATE UNITTESTS)

--- a/tools/tidy/tests/CoverageNameTest.cpp
+++ b/tools/tidy/tests/CoverageNameTest.cpp
@@ -1,0 +1,103 @@
+// SPDX-FileCopyrightText: Michael Popoloski
+// SPDX-License-Identifier: MIT
+
+#include "TidyTest.h"
+
+static TidyConfig names() {
+    TidyConfig config;
+    auto& c = config.getCheckConfigs();
+    c.covergroupRegexString = "cg_.*";
+    c.covergroupRegexPattern = boost::regex(c.covergroupRegexString);
+    c.coverpointRegexString = "cp_.*";
+    c.coverpointRegexPattern = boost::regex(c.coverpointRegexString);
+    c.crossRegexString = "cross_.*";
+    c.crossRegexPattern = boost::regex(c.crossRegexString);
+    return config;
+}
+
+static std::string mod(std::string_view body) {
+    return "module top;\nlogic a, b, clk, en;\n" + std::string(body) + "\nendmodule\n";
+}
+
+static bool cg(std::string_view body) {
+    return runCheckTest("CovergroupName", mod(body), names());
+}
+
+static bool cp(std::string_view body) {
+    return runCheckTest("CoverpointName", mod(body), names());
+}
+
+static bool cr(std::string_view body) {
+    return runCheckTest("CrossName", mod(body), names());
+}
+
+TEST_CASE("CovergroupName: matching name") {
+    CHECK(cg("covergroup cg_g; endgroup"));
+}
+
+TEST_CASE("CovergroupName: mismatched name") {
+    CHECK_FALSE(cg("covergroup g; endgroup"));
+}
+
+TEST_CASE("CovergroupName: ports and clocking event") {
+    CHECK(cg("covergroup cg_g(int w) @(posedge clk); endgroup"));
+    CHECK_FALSE(cg("covergroup g(int w) @(posedge clk); endgroup"));
+}
+
+TEST_CASE("CovergroupName: in class") {
+    CHECK(runCheckTest("CovergroupName", R"(
+class C;
+    covergroup cg_g; endgroup
+endclass
+)",
+                       names()));
+}
+
+TEST_CASE("CoverpointName: unnamed") {
+    CHECK_FALSE(cp("covergroup g; coverpoint a; endgroup"));
+    CHECK_FALSE(cp("covergroup g; coverpoint a { bins x = {0}; } endgroup"));
+}
+
+TEST_CASE("CoverpointName: matching label") {
+    CHECK(cp("covergroup g; cp_a: coverpoint a; endgroup"));
+}
+
+TEST_CASE("CoverpointName: mismatched label") {
+    CHECK_FALSE(cp("covergroup g; a: coverpoint a; endgroup"));
+}
+
+TEST_CASE("CoverpointName: iff and bins") {
+    CHECK(cp("covergroup g; cp_a: coverpoint a iff (en) { bins z = {0}; } endgroup"));
+    CHECK_FALSE(cp("covergroup g; a: coverpoint a iff (en); endgroup"));
+}
+
+TEST_CASE("CoverpointName: typed coverpoint") {
+    CHECK(cp("covergroup g; bit [7:0] cp_d: coverpoint a; endgroup"));
+    CHECK_FALSE(cp("covergroup g; bit [7:0] d: coverpoint a; endgroup"));
+}
+
+TEST_CASE("CrossName: unnamed") {
+    CHECK_FALSE(cr("covergroup g; cross a, b; endgroup"));
+}
+
+TEST_CASE("CrossName: matching label") {
+    CHECK(cr("covergroup g; cross_ab: cross a, b; endgroup"));
+}
+
+TEST_CASE("CrossName: mismatched label") {
+    CHECK_FALSE(cr("covergroup g; ab: cross a, b; endgroup"));
+}
+
+TEST_CASE("CrossName: iff and body") {
+    CHECK(cr("covergroup g; cross_ab: cross a, b iff (en) { option.weight = 1; } endgroup"));
+    CHECK_FALSE(cr("covergroup g; cross a, b iff (en); endgroup"));
+}
+
+TEST_CASE("Coverage names: default regex") {
+    CHECK(runCheckTest("CovergroupName", mod("covergroup cg_g; endgroup")));
+    CHECK_FALSE(runCheckTest("CovergroupName", mod("covergroup g; endgroup")));
+    CHECK(runCheckTest("CoverpointName", mod("covergroup g; cp_a: coverpoint a; endgroup")));
+    CHECK_FALSE(runCheckTest("CoverpointName", mod("covergroup g; a: coverpoint a; endgroup")));
+    CHECK(runCheckTest("CrossName", mod("covergroup g; cross_ab: cross a, b; endgroup")));
+    CHECK_FALSE(runCheckTest("CrossName", mod("covergroup g; ab: cross a, b; endgroup")));
+}

--- a/tools/tidy/tests/TidyConfigParserTest.cpp
+++ b/tools/tidy/tests/TidyConfigParserTest.cpp
@@ -109,7 +109,10 @@ TEST_CASE("TidyParser: Set check config") {
     clkNameRegexString: "clock\S.*",
     resetIsActiveHigh: false,
     inputPortSuffix: _k,
-    inputPortSuffix: _p)");
+    inputPortSuffix: _p,
+    covergroupRegexString: "^covergroup_\S*",
+    coverpointRegexString: "^coverpoint_\S*",
+    crossRegexString: "^cross_coverpoint_\S*")");
     TidyConfigParser parser(config_str);
 
     auto config = parser.getConfig();
@@ -119,6 +122,9 @@ TEST_CASE("TidyParser: Set check config") {
     CHECK(config.getCheckConfigs().clkNameRegexString == "clock\\S.*");
     CHECK_FALSE(config.getCheckConfigs().resetIsActiveHigh);
     CHECK(config.getCheckConfigs().inputPortSuffix == std::vector<std::string>{"_p"});
+    CHECK(config.getCheckConfigs().covergroupRegexString == "^covergroup_\\S*");
+    CHECK(config.getCheckConfigs().coverpointRegexString == "^coverpoint_\\S*");
+    CHECK(config.getCheckConfigs().crossRegexString == "^cross_coverpoint_\\S*");
 }
 
 TEST_CASE("TidyParser: CheckConfigs and Checks") {


### PR DESCRIPTION
Covergroups, coverpoints and cross coverpoints.
All configurable via regex and off by default.

LLM used for the tests, reviewed by me.