### PR TITLE
Naming style lints for user defined types

### DIFF
--- a/tools/tidy/CMakeLists.txt
+++ b/tools/tidy/CMakeLists.txt
@@ -39,7 +39,8 @@ add_library(
   src/style/CrossName.cpp
   src/style/EnumName.cpp
   src/style/StructName.cpp
-  src/style/UnionName.cpp)
+  src/style/UnionName.cpp
+  src/style/TypedefName.cpp)
 
 target_include_directories(slang_tidy_obj_lib PUBLIC include)
 target_link_libraries(slang_tidy_obj_lib PUBLIC slang::slang fmt::fmt)

--- a/tools/tidy/CMakeLists.txt
+++ b/tools/tidy/CMakeLists.txt
@@ -36,7 +36,8 @@ add_library(
   src/style/TypedefStructUnion.cpp
   src/style/CovergroupName.cpp
   src/style/CoverpointName.cpp
-  src/style/CrossName.cpp)
+  src/style/CrossName.cpp
+  src/style/EnumName.cpp)
 
 target_include_directories(slang_tidy_obj_lib PUBLIC include)
 target_link_libraries(slang_tidy_obj_lib PUBLIC slang::slang fmt::fmt)

--- a/tools/tidy/CMakeLists.txt
+++ b/tools/tidy/CMakeLists.txt
@@ -37,7 +37,9 @@ add_library(
   src/style/CovergroupName.cpp
   src/style/CoverpointName.cpp
   src/style/CrossName.cpp
-  src/style/EnumName.cpp)
+  src/style/EnumName.cpp
+  src/style/StructName.cpp
+  src/style/UnionName.cpp)
 
 target_include_directories(slang_tidy_obj_lib PUBLIC include)
 target_link_libraries(slang_tidy_obj_lib PUBLIC slang::slang fmt::fmt)

--- a/tools/tidy/README.md
+++ b/tools/tidy/README.md
@@ -84,6 +84,11 @@ The available options are:
 |      **enumRegexString**      |  string  | \"[a-z_0-9]+_e\"   |
 |     **structRegexString**     |  string  | \"[a-z_0-9]+_t\"   |
 |     **unionRegexString**      |  string  | \"[a-z_0-9]+_t\"   |
+|    **typedefRegexString**     |  string  | \"[a-z_0-9]+_t\"   |
+
+`style-typedef-name` applies to all typedefs. If `style-enum-name`, `style-struct-name`,
+or `style-union-name` are enabled, those checks take precedence for the corresponding
+typedefs.
 
 An example of a possible configuration file:
 

--- a/tools/tidy/README.md
+++ b/tools/tidy/README.md
@@ -81,6 +81,7 @@ The available options are:
 |   **covergroupRegexString**   |  string  |     \"cg_\\S*\"    |
 |   **coverpointRegexString**   |  string  |    \"cp_\\S*\"     |
 |     **crossRegexString**      |  string  |   "cross_\\S*\"    |
+|      **enumRegexString**      |  string  | \"[a-z_0-9]+_e\"   |
 
 An example of a possible configuration file:
 

--- a/tools/tidy/README.md
+++ b/tools/tidy/README.md
@@ -82,6 +82,8 @@ The available options are:
 |   **coverpointRegexString**   |  string  |    \"cp_\\S*\"     |
 |     **crossRegexString**      |  string  |   "cross_\\S*\"    |
 |      **enumRegexString**      |  string  | \"[a-z_0-9]+_e\"   |
+|     **structRegexString**     |  string  | \"[a-z_0-9]+_t\"   |
+|     **unionRegexString**      |  string  | \"[a-z_0-9]+_t\"   |
 
 An example of a possible configuration file:
 

--- a/tools/tidy/include/TidyConfig.h
+++ b/tools/tidy/include/TidyConfig.h
@@ -47,6 +47,10 @@ public:
         boost::regex crossRegexPattern;
         std::string enumRegexString;
         boost::regex enumRegexPattern;
+        std::string structRegexString;
+        boost::regex structRegexPattern;
+        std::string unionRegexString;
+        boost::regex unionRegexPattern;
     };
 
     /// Default TidyConfig constructor which will set the default check's configuration values
@@ -100,6 +104,8 @@ public:
             {"coverpointRegexString", cfg.coverpointRegexString},
             {"crossRegexString", cfg.crossRegexString},
             {"enumRegexString", cfg.enumRegexString},
+            {"structRegexString", cfg.structRegexString},
+            {"unionRegexString", cfg.unionRegexString},
         };
     }
 
@@ -211,6 +217,16 @@ private:
         else if (configName == "enumRegexString") {
             visit(checkConfigs.enumRegexString);
             checkConfigs.enumRegexPattern = boost::regex(checkConfigs.enumRegexString);
+            return;
+        }
+        else if (configName == "structRegexString") {
+            visit(checkConfigs.structRegexString);
+            checkConfigs.structRegexPattern = boost::regex(checkConfigs.structRegexString);
+            return;
+        }
+        else if (configName == "unionRegexString") {
+            visit(checkConfigs.unionRegexString);
+            checkConfigs.unionRegexPattern = boost::regex(checkConfigs.unionRegexString);
             return;
         }
         SLANG_THROW(std::invalid_argument(fmt::format("The check: {} does not exist", configName)));

--- a/tools/tidy/include/TidyConfig.h
+++ b/tools/tidy/include/TidyConfig.h
@@ -51,6 +51,8 @@ public:
         boost::regex structRegexPattern;
         std::string unionRegexString;
         boost::regex unionRegexPattern;
+        std::string typedefRegexString;
+        boost::regex typedefRegexPattern;
     };
 
     /// Default TidyConfig constructor which will set the default check's configuration values
@@ -106,6 +108,7 @@ public:
             {"enumRegexString", cfg.enumRegexString},
             {"structRegexString", cfg.structRegexString},
             {"unionRegexString", cfg.unionRegexString},
+            {"typedefRegexString", cfg.typedefRegexString},
         };
     }
 
@@ -227,6 +230,11 @@ private:
         else if (configName == "unionRegexString") {
             visit(checkConfigs.unionRegexString);
             checkConfigs.unionRegexPattern = boost::regex(checkConfigs.unionRegexString);
+            return;
+        }
+        else if (configName == "typedefRegexString") {
+            visit(checkConfigs.typedefRegexString);
+            checkConfigs.typedefRegexPattern = boost::regex(checkConfigs.typedefRegexString);
             return;
         }
         SLANG_THROW(std::invalid_argument(fmt::format("The check: {} does not exist", configName)));

--- a/tools/tidy/include/TidyConfig.h
+++ b/tools/tidy/include/TidyConfig.h
@@ -45,6 +45,8 @@ public:
         boost::regex coverpointRegexPattern;
         std::string crossRegexString;
         boost::regex crossRegexPattern;
+        std::string enumRegexString;
+        boost::regex enumRegexPattern;
     };
 
     /// Default TidyConfig constructor which will set the default check's configuration values
@@ -97,6 +99,7 @@ public:
             {"covergroupRegexString", cfg.covergroupRegexString},
             {"coverpointRegexString", cfg.coverpointRegexString},
             {"crossRegexString", cfg.crossRegexString},
+            {"enumRegexString", cfg.enumRegexString},
         };
     }
 
@@ -203,6 +206,11 @@ private:
         else if (configName == "crossRegexString") {
             visit(checkConfigs.crossRegexString);
             checkConfigs.crossRegexPattern = boost::regex(checkConfigs.crossRegexString);
+            return;
+        }
+        else if (configName == "enumRegexString") {
+            visit(checkConfigs.enumRegexString);
+            checkConfigs.enumRegexPattern = boost::regex(checkConfigs.enumRegexString);
             return;
         }
         SLANG_THROW(std::invalid_argument(fmt::format("The check: {} does not exist", configName)));

--- a/tools/tidy/include/TidyDiags.h
+++ b/tools/tidy/include/TidyDiags.h
@@ -40,5 +40,6 @@ inline constexpr DiagCode TypedefStructUnion(DiagSubsystem::Tidy, 25);
 inline constexpr DiagCode CovergroupName(DiagSubsystem::Tidy, 26);
 inline constexpr DiagCode CoverpointName(DiagSubsystem::Tidy, 27);
 inline constexpr DiagCode CrossName(DiagSubsystem::Tidy, 28);
+inline constexpr DiagCode EnumName(DiagSubsystem::Tidy, 29);
 
 } // namespace slang::diag

--- a/tools/tidy/include/TidyDiags.h
+++ b/tools/tidy/include/TidyDiags.h
@@ -41,5 +41,7 @@ inline constexpr DiagCode CovergroupName(DiagSubsystem::Tidy, 26);
 inline constexpr DiagCode CoverpointName(DiagSubsystem::Tidy, 27);
 inline constexpr DiagCode CrossName(DiagSubsystem::Tidy, 28);
 inline constexpr DiagCode EnumName(DiagSubsystem::Tidy, 29);
+inline constexpr DiagCode StructName(DiagSubsystem::Tidy, 30);
+inline constexpr DiagCode UnionName(DiagSubsystem::Tidy, 31);
 
 } // namespace slang::diag

--- a/tools/tidy/include/TidyDiags.h
+++ b/tools/tidy/include/TidyDiags.h
@@ -43,5 +43,6 @@ inline constexpr DiagCode CrossName(DiagSubsystem::Tidy, 28);
 inline constexpr DiagCode EnumName(DiagSubsystem::Tidy, 29);
 inline constexpr DiagCode StructName(DiagSubsystem::Tidy, 30);
 inline constexpr DiagCode UnionName(DiagSubsystem::Tidy, 31);
+inline constexpr DiagCode TypedefName(DiagSubsystem::Tidy, 32);
 
 } // namespace slang::diag

--- a/tools/tidy/src/TidyConfig.cpp
+++ b/tools/tidy/src/TidyConfig.cpp
@@ -30,6 +30,10 @@ TidyConfig::TidyConfig() {
     checkConfigs.crossRegexPattern = boost::regex(checkConfigs.crossRegexString);
     checkConfigs.enumRegexString = "[a-z_0-9]+_e";
     checkConfigs.enumRegexPattern = boost::regex(checkConfigs.enumRegexString);
+    checkConfigs.structRegexString = "[a-z_0-9]+_t";
+    checkConfigs.structRegexPattern = boost::regex(checkConfigs.structRegexString);
+    checkConfigs.unionRegexString = "[a-z_0-9]+_t";
+    checkConfigs.unionRegexPattern = boost::regex(checkConfigs.unionRegexString);
 
     auto styleChecks = std::unordered_map<std::string, CheckOptions>();
     styleChecks.emplace("AlwaysCombNonBlocking", CheckOptions());
@@ -53,6 +57,8 @@ TidyConfig::TidyConfig() {
     styleChecks.emplace("CoverpointName", CheckOptions{CheckStatus::DISABLED});
     styleChecks.emplace("CrossName", CheckOptions{CheckStatus::DISABLED});
     styleChecks.emplace("EnumName", CheckOptions());
+    styleChecks.emplace("StructName", CheckOptions());
+    styleChecks.emplace("UnionName", CheckOptions());
     checkKinds.insert({slang::TidyKind::Style, styleChecks});
 
     auto synthesisChecks = std::unordered_map<std::string, CheckOptions>();

--- a/tools/tidy/src/TidyConfig.cpp
+++ b/tools/tidy/src/TidyConfig.cpp
@@ -34,6 +34,8 @@ TidyConfig::TidyConfig() {
     checkConfigs.structRegexPattern = boost::regex(checkConfigs.structRegexString);
     checkConfigs.unionRegexString = "[a-z_0-9]+_t";
     checkConfigs.unionRegexPattern = boost::regex(checkConfigs.unionRegexString);
+    checkConfigs.typedefRegexString = "[a-z_0-9]+_t";
+    checkConfigs.typedefRegexPattern = boost::regex(checkConfigs.typedefRegexString);
 
     auto styleChecks = std::unordered_map<std::string, CheckOptions>();
     styleChecks.emplace("AlwaysCombNonBlocking", CheckOptions());
@@ -59,6 +61,7 @@ TidyConfig::TidyConfig() {
     styleChecks.emplace("EnumName", CheckOptions());
     styleChecks.emplace("StructName", CheckOptions());
     styleChecks.emplace("UnionName", CheckOptions());
+    styleChecks.emplace("TypedefName", CheckOptions());
     checkKinds.insert({slang::TidyKind::Style, styleChecks});
 
     auto synthesisChecks = std::unordered_map<std::string, CheckOptions>();

--- a/tools/tidy/src/TidyConfig.cpp
+++ b/tools/tidy/src/TidyConfig.cpp
@@ -28,6 +28,8 @@ TidyConfig::TidyConfig() {
     checkConfigs.coverpointRegexPattern = boost::regex(checkConfigs.coverpointRegexString);
     checkConfigs.crossRegexString = "^cross_\\S*";
     checkConfigs.crossRegexPattern = boost::regex(checkConfigs.crossRegexString);
+    checkConfigs.enumRegexString = "[a-z_0-9]+_e";
+    checkConfigs.enumRegexPattern = boost::regex(checkConfigs.enumRegexString);
 
     auto styleChecks = std::unordered_map<std::string, CheckOptions>();
     styleChecks.emplace("AlwaysCombNonBlocking", CheckOptions());
@@ -50,6 +52,7 @@ TidyConfig::TidyConfig() {
     styleChecks.emplace("CovergroupName", CheckOptions{CheckStatus::DISABLED});
     styleChecks.emplace("CoverpointName", CheckOptions{CheckStatus::DISABLED});
     styleChecks.emplace("CrossName", CheckOptions{CheckStatus::DISABLED});
+    styleChecks.emplace("EnumName", CheckOptions());
     checkKinds.insert({slang::TidyKind::Style, styleChecks});
 
     auto synthesisChecks = std::unordered_map<std::string, CheckOptions>();

--- a/tools/tidy/src/TidyConfigParser.cpp
+++ b/tools/tidy/src/TidyConfigParser.cpp
@@ -331,7 +331,7 @@ void TidyConfigParser::parseCheckConfigs() {
         auto isRegexMeta = [](char c) {
             return c == '.' || c == '^' || c == '$' || c == '*' || c == '+' || c == '?' ||
                    c == '{' || c == '}' || c == '[' || c == ']' || c == '\\' || c == '|' ||
-                   c == '(' || c == ')';
+                   c == '(' || c == ')' || c == '-';
         };
 
         auto isOptionValueChar = [](char c) { return isalnum(c) || c == '_'; };

--- a/tools/tidy/src/style/EnumName.cpp
+++ b/tools/tidy/src/style/EnumName.cpp
@@ -1,0 +1,79 @@
+// SPDX-FileCopyrightText: Michael Popoloski
+// SPDX-License-Identifier: MIT
+
+#include "ASTHelperVisitors.h"
+#include "TidyDiags.h"
+#include <boost_regex.hpp>
+
+#include "slang/syntax/SyntaxTree.h"
+#include "slang/syntax/SyntaxVisitor.h"
+
+using namespace slang;
+using namespace slang::ast;
+using namespace slang::syntax;
+
+namespace enum_name {
+struct MainVisitor : public TidyVisitor, SyntaxVisitor<MainVisitor> {
+    explicit MainVisitor(Diagnostics& diagnostics) : TidyVisitor(diagnostics) {}
+
+    void checkName(const parsing::Token& name) {
+        if (!boost::regex_match(std::string(name.valueText()),
+                                config.getCheckConfigs().enumRegexPattern)) {
+            diags.add(diag::EnumName, name.location()) << config.getCheckConfigs().enumRegexString;
+        }
+    }
+
+    void handle(const TypedefDeclarationSyntax& node) {
+        NEEDS_SKIP_NODE(node)
+
+        if (node.type->kind != SyntaxKind::EnumType)
+            return;
+
+        checkName(node.name);
+    }
+
+    void handle(const ForwardTypedefDeclarationSyntax& node) {
+        NEEDS_SKIP_NODE(node)
+
+        if (node.typeRestriction && SemanticFacts::getTypeRestriction(*node.typeRestriction) ==
+                                        ForwardTypeRestriction::Enum) {
+            checkName(node.name);
+        }
+    }
+};
+} // namespace enum_name
+
+using namespace enum_name;
+
+class EnumName : public TidyCheck {
+public:
+    [[maybe_unused]] explicit EnumName(TidyKind kind,
+                                       std::optional<slang::DiagnosticSeverity> severity) :
+        TidyCheck(kind, severity) {}
+
+    bool check(const RootSymbol& root, const slang::analysis::AnalysisManager&) override {
+        MainVisitor visitor(diagnostics);
+        for (auto& tree : root.getCompilation().getSyntaxTrees())
+            tree->root().visit(visitor);
+        return diagnostics.empty();
+    }
+
+    DiagCode diagCode() const override { return diag::EnumName; }
+
+    std::string diagString() const override {
+        return "enum type name must match supplied pattern '{}'";
+    }
+
+    DiagnosticSeverity diagDefaultSeverity() const override { return DiagnosticSeverity::Warning; }
+
+    std::string name() const override { return "EnumName"; }
+
+    std::string description() const override { return shortDescription(); }
+
+    std::string shortDescription() const override {
+        return "Enforces naming style for enum types "
+               "configured with enumRegexString e.g. \"[a-z_0-9]+_e\"";
+    }
+};
+
+REGISTER(EnumName, EnumName, TidyKind::Style)

--- a/tools/tidy/src/style/StructName.cpp
+++ b/tools/tidy/src/style/StructName.cpp
@@ -1,0 +1,80 @@
+// SPDX-FileCopyrightText: Michael Popoloski
+// SPDX-License-Identifier: MIT
+
+#include "ASTHelperVisitors.h"
+#include "TidyDiags.h"
+#include <boost_regex.hpp>
+
+#include "slang/syntax/SyntaxTree.h"
+#include "slang/syntax/SyntaxVisitor.h"
+
+using namespace slang;
+using namespace slang::ast;
+using namespace slang::syntax;
+
+namespace struct_name {
+struct MainVisitor : public TidyVisitor, SyntaxVisitor<MainVisitor> {
+    explicit MainVisitor(Diagnostics& diagnostics) : TidyVisitor(diagnostics) {}
+
+    void checkName(const parsing::Token& name) {
+        if (!boost::regex_match(std::string(name.valueText()),
+                                config.getCheckConfigs().structRegexPattern)) {
+            diags.add(diag::StructName, name.location())
+                << config.getCheckConfigs().structRegexString;
+        }
+    }
+
+    void handle(const TypedefDeclarationSyntax& node) {
+        NEEDS_SKIP_NODE(node)
+
+        if (node.type->kind != SyntaxKind::StructType)
+            return;
+
+        checkName(node.name);
+    }
+
+    void handle(const ForwardTypedefDeclarationSyntax& node) {
+        NEEDS_SKIP_NODE(node)
+
+        if (node.typeRestriction && SemanticFacts::getTypeRestriction(*node.typeRestriction) ==
+                                        ForwardTypeRestriction::Struct) {
+            checkName(node.name);
+        }
+    }
+};
+} // namespace struct_name
+
+using namespace struct_name;
+
+class StructName : public TidyCheck {
+public:
+    [[maybe_unused]] explicit StructName(TidyKind kind,
+                                         std::optional<slang::DiagnosticSeverity> severity) :
+        TidyCheck(kind, severity) {}
+
+    bool check(const RootSymbol& root, const slang::analysis::AnalysisManager&) override {
+        MainVisitor visitor(diagnostics);
+        for (auto& tree : root.getCompilation().getSyntaxTrees())
+            tree->root().visit(visitor);
+        return diagnostics.empty();
+    }
+
+    DiagCode diagCode() const override { return diag::StructName; }
+
+    std::string diagString() const override {
+        return "struct type name must match supplied pattern '{}'";
+    }
+
+    DiagnosticSeverity diagDefaultSeverity() const override { return DiagnosticSeverity::Warning; }
+
+    std::string name() const override { return "StructName"; }
+
+    std::string description() const override { return shortDescription(); }
+
+    std::string shortDescription() const override {
+        return "Enforces naming style for struct types "
+               "configured with structRegexString e.g. \"[a-z_0-9]+_t\"";
+    }
+};
+
+REGISTER(StructName, StructName, TidyKind::Style)

--- a/tools/tidy/src/style/TypedefName.cpp
+++ b/tools/tidy/src/style/TypedefName.cpp
@@ -1,0 +1,108 @@
+// SPDX-FileCopyrightText: Michael Popoloski
+// SPDX-License-Identifier: MIT
+
+#include "ASTHelperVisitors.h"
+#include "TidyDiags.h"
+#include <boost_regex.hpp>
+
+#include "slang/syntax/SyntaxTree.h"
+#include "slang/syntax/SyntaxVisitor.h"
+
+using namespace slang;
+using namespace slang::ast;
+using namespace slang::syntax;
+
+namespace typedef_name {
+struct MainVisitor : public TidyVisitor, SyntaxVisitor<MainVisitor> {
+    explicit MainVisitor(Diagnostics& diagnostics) : TidyVisitor(diagnostics) {}
+
+    bool specializedCheckTakesPrecedence(SyntaxKind typeKind) const {
+        switch (typeKind) {
+            case SyntaxKind::EnumType:
+                return config.isCheckEnabled(TidyKind::Style, "EnumName");
+            case SyntaxKind::StructType:
+                return config.isCheckEnabled(TidyKind::Style, "StructName");
+            case SyntaxKind::UnionType:
+                return config.isCheckEnabled(TidyKind::Style, "UnionName");
+            default:
+                return false;
+        }
+    }
+
+    bool specializedCheckTakesPrecedence(ForwardTypeRestriction restriction) const {
+        switch (restriction) {
+            case ForwardTypeRestriction::Enum:
+                return config.isCheckEnabled(TidyKind::Style, "EnumName");
+            case ForwardTypeRestriction::Struct:
+                return config.isCheckEnabled(TidyKind::Style, "StructName");
+            case ForwardTypeRestriction::Union:
+                return config.isCheckEnabled(TidyKind::Style, "UnionName");
+            default:
+                return false;
+        }
+    }
+
+    void checkName(const parsing::Token& name) {
+        if (!boost::regex_match(std::string(name.valueText()),
+                                config.getCheckConfigs().typedefRegexPattern)) {
+            diags.add(diag::TypedefName, name.location())
+                << config.getCheckConfigs().typedefRegexString;
+        }
+    }
+
+    void handle(const TypedefDeclarationSyntax& node) {
+        NEEDS_SKIP_NODE(node)
+
+        if (specializedCheckTakesPrecedence(node.type->kind))
+            return;
+
+        checkName(node.name);
+    }
+
+    void handle(const ForwardTypedefDeclarationSyntax& node) {
+        NEEDS_SKIP_NODE(node)
+
+        if (node.typeRestriction && specializedCheckTakesPrecedence(
+                                        SemanticFacts::getTypeRestriction(*node.typeRestriction)))
+            return;
+
+        checkName(node.name);
+    }
+};
+} // namespace typedef_name
+
+using namespace typedef_name;
+
+class TypedefName : public TidyCheck {
+public:
+    [[maybe_unused]] explicit TypedefName(TidyKind kind,
+                                          std::optional<slang::DiagnosticSeverity> severity) :
+        TidyCheck(kind, severity) {}
+
+    bool check(const RootSymbol& root, const slang::analysis::AnalysisManager&) override {
+        MainVisitor visitor(diagnostics);
+        for (auto& tree : root.getCompilation().getSyntaxTrees())
+            tree->root().visit(visitor);
+        return diagnostics.empty();
+    }
+
+    DiagCode diagCode() const override { return diag::TypedefName; }
+
+    std::string diagString() const override {
+        return "typedef name must match supplied pattern '{}'";
+    }
+
+    DiagnosticSeverity diagDefaultSeverity() const override { return DiagnosticSeverity::Warning; }
+
+    std::string name() const override { return "TypedefName"; }
+
+    std::string description() const override { return shortDescription(); }
+
+    std::string shortDescription() const override {
+        return "Enforces naming style for typedefs "
+               "configured with typedefRegexString e.g. \"[a-z_0-9]+_t\". "
+               "EnumName, StructName, and UnionName take precedence when enabled.";
+    }
+};
+
+REGISTER(TypedefName, TypedefName, TidyKind::Style)

--- a/tools/tidy/src/style/UnionName.cpp
+++ b/tools/tidy/src/style/UnionName.cpp
@@ -1,0 +1,80 @@
+// SPDX-FileCopyrightText: Michael Popoloski
+// SPDX-License-Identifier: MIT
+
+#include "ASTHelperVisitors.h"
+#include "TidyDiags.h"
+#include <boost_regex.hpp>
+
+#include "slang/syntax/SyntaxTree.h"
+#include "slang/syntax/SyntaxVisitor.h"
+
+using namespace slang;
+using namespace slang::ast;
+using namespace slang::syntax;
+
+namespace union_name {
+struct MainVisitor : public TidyVisitor, SyntaxVisitor<MainVisitor> {
+    explicit MainVisitor(Diagnostics& diagnostics) : TidyVisitor(diagnostics) {}
+
+    void checkName(const parsing::Token& name) {
+        if (!boost::regex_match(std::string(name.valueText()),
+                                config.getCheckConfigs().unionRegexPattern)) {
+            diags.add(diag::UnionName, name.location())
+                << config.getCheckConfigs().unionRegexString;
+        }
+    }
+
+    void handle(const TypedefDeclarationSyntax& node) {
+        NEEDS_SKIP_NODE(node)
+
+        if (node.type->kind != SyntaxKind::UnionType)
+            return;
+
+        checkName(node.name);
+    }
+
+    void handle(const ForwardTypedefDeclarationSyntax& node) {
+        NEEDS_SKIP_NODE(node)
+
+        if (node.typeRestriction && SemanticFacts::getTypeRestriction(*node.typeRestriction) ==
+                                        ForwardTypeRestriction::Union) {
+            checkName(node.name);
+        }
+    }
+};
+} // namespace union_name
+
+using namespace union_name;
+
+class UnionName : public TidyCheck {
+public:
+    [[maybe_unused]] explicit UnionName(TidyKind kind,
+                                        std::optional<slang::DiagnosticSeverity> severity) :
+        TidyCheck(kind, severity) {}
+
+    bool check(const RootSymbol& root, const slang::analysis::AnalysisManager&) override {
+        MainVisitor visitor(diagnostics);
+        for (auto& tree : root.getCompilation().getSyntaxTrees())
+            tree->root().visit(visitor);
+        return diagnostics.empty();
+    }
+
+    DiagCode diagCode() const override { return diag::UnionName; }
+
+    std::string diagString() const override {
+        return "union type name must match supplied pattern '{}'";
+    }
+
+    DiagnosticSeverity diagDefaultSeverity() const override { return DiagnosticSeverity::Warning; }
+
+    std::string name() const override { return "UnionName"; }
+
+    std::string description() const override { return shortDescription(); }
+
+    std::string shortDescription() const override {
+        return "Enforces naming style for union types "
+               "configured with unionRegexString e.g. \"[a-z_0-9]+_t\"";
+    }
+};
+
+REGISTER(UnionName, UnionName, TidyKind::Style)

--- a/tools/tidy/tests/CMakeLists.txt
+++ b/tools/tidy/tests/CMakeLists.txt
@@ -35,7 +35,8 @@ add_executable(
   NoDefParamTest.cpp
   TypedefEnumsTest.cpp
   TypedefStructUnionTest.cpp
-  CoverageNameTest.cpp)
+  CoverageNameTest.cpp
+  EnumNameTest.cpp)
 
 target_link_libraries(tidy_unittests PRIVATE Catch2::Catch2 slang_tidy_obj_lib)
 target_compile_definitions(tidy_unittests PRIVATE UNITTESTS)

--- a/tools/tidy/tests/CMakeLists.txt
+++ b/tools/tidy/tests/CMakeLists.txt
@@ -36,7 +36,9 @@ add_executable(
   TypedefEnumsTest.cpp
   TypedefStructUnionTest.cpp
   CoverageNameTest.cpp
-  EnumNameTest.cpp)
+  EnumNameTest.cpp
+  StructNameTest.cpp
+  UnionNameTest.cpp)
 
 target_link_libraries(tidy_unittests PRIVATE Catch2::Catch2 slang_tidy_obj_lib)
 target_compile_definitions(tidy_unittests PRIVATE UNITTESTS)

--- a/tools/tidy/tests/CMakeLists.txt
+++ b/tools/tidy/tests/CMakeLists.txt
@@ -38,7 +38,8 @@ add_executable(
   CoverageNameTest.cpp
   EnumNameTest.cpp
   StructNameTest.cpp
-  UnionNameTest.cpp)
+  UnionNameTest.cpp
+  TypedefNameTest.cpp)
 
 target_link_libraries(tidy_unittests PRIVATE Catch2::Catch2 slang_tidy_obj_lib)
 target_compile_definitions(tidy_unittests PRIVATE UNITTESTS)

--- a/tools/tidy/tests/EnumNameTest.cpp
+++ b/tools/tidy/tests/EnumNameTest.cpp
@@ -1,0 +1,45 @@
+// SPDX-FileCopyrightText: Michael Popoloski
+// SPDX-License-Identifier: MIT
+
+#include "TidyTest.h"
+
+static TidyConfig enumNames(std::string_view regex) {
+    TidyConfig config;
+    auto& c = config.getCheckConfigs();
+    c.enumRegexString = regex;
+    c.enumRegexPattern = boost::regex(c.enumRegexString);
+    return config;
+}
+
+TEST_CASE("EnumName: matching name") {
+    CHECK(runCheckTest("EnumName", "typedef enum { RED, BLUE } color_e;", enumNames(".*_e")));
+}
+
+TEST_CASE("EnumName: mismatched name") {
+    CHECK_FALSE(runCheckTest("EnumName", "typedef enum { RED, BLUE } color_t;", enumNames(".*_e")));
+}
+
+TEST_CASE("EnumName: ignores non-enum typedefs") {
+    CHECK(runCheckTest("EnumName", "typedef struct { int value; } color_t;", enumNames(".*_e")));
+}
+
+TEST_CASE("EnumName: enum in class") {
+    CHECK(runCheckTest("EnumName", R"(
+class C;
+    typedef enum { RED, BLUE } color_e;
+endclass
+)",
+                       enumNames(".*_e")));
+}
+
+TEST_CASE("EnumName: forward declaration") {
+    CHECK(runCheckTest("EnumName", "typedef enum color_e;", enumNames(".*_e")));
+    CHECK_FALSE(runCheckTest("EnumName", "typedef enum color_t;", enumNames(".*_e")));
+}
+
+TEST_CASE("EnumName: default regex") {
+    CHECK(runCheckTest("EnumName", "typedef enum { RED, BLUE } color_e;"));
+    CHECK(runCheckTest("EnumName", "typedef enum { RED, BLUE } color_mode_2_e;"));
+    CHECK_FALSE(runCheckTest("EnumName", "typedef enum { RED, BLUE } color_t;"));
+    CHECK_FALSE(runCheckTest("EnumName", "typedef enum { RED, BLUE } Color_e;"));
+}

--- a/tools/tidy/tests/StructNameTest.cpp
+++ b/tools/tidy/tests/StructNameTest.cpp
@@ -1,0 +1,47 @@
+// SPDX-FileCopyrightText: Michael Popoloski
+// SPDX-License-Identifier: MIT
+
+#include "TidyTest.h"
+
+static TidyConfig structNames(std::string_view regex) {
+    TidyConfig config;
+    auto& c = config.getCheckConfigs();
+    c.structRegexString = regex;
+    c.structRegexPattern = boost::regex(c.structRegexString);
+    return config;
+}
+
+TEST_CASE("StructName: matching name") {
+    CHECK(
+        runCheckTest("StructName", "typedef struct { int value; } color_s;", structNames(".*_s")));
+}
+
+TEST_CASE("StructName: mismatched name") {
+    CHECK_FALSE(
+        runCheckTest("StructName", "typedef struct { int value; } color_t;", structNames(".*_s")));
+}
+
+TEST_CASE("StructName: ignores non-struct typedefs") {
+    CHECK(runCheckTest("StructName", "typedef union { int value; } color_t;", structNames(".*_s")));
+}
+
+TEST_CASE("StructName: packed struct in class") {
+    CHECK(runCheckTest("StructName", R"(
+class C;
+    typedef struct packed { int value; } color_s;
+endclass
+)",
+                       structNames(".*_s")));
+}
+
+TEST_CASE("StructName: forward declaration") {
+    CHECK(runCheckTest("StructName", "typedef struct color_s;", structNames(".*_s")));
+    CHECK_FALSE(runCheckTest("StructName", "typedef struct color_t;", structNames(".*_s")));
+}
+
+TEST_CASE("StructName: default regex") {
+    CHECK(runCheckTest("StructName", "typedef struct { int value; } color_t;"));
+    CHECK(runCheckTest("StructName", "typedef struct { int value; } color_mode_2_t;"));
+    CHECK_FALSE(runCheckTest("StructName", "typedef struct { int value; } color_s;"));
+    CHECK_FALSE(runCheckTest("StructName", "typedef struct { int value; } Color_t;"));
+}

--- a/tools/tidy/tests/TidyConfigParserTest.cpp
+++ b/tools/tidy/tests/TidyConfigParserTest.cpp
@@ -113,7 +113,9 @@ TEST_CASE("TidyParser: Set check config") {
     covergroupRegexString: "^covergroup_\S*",
     coverpointRegexString: "^coverpoint_\S*",
     crossRegexString: "^cross_coverpoint_\S*",
-    enumRegexString: "[a-z_0-9]+_e")");
+    enumRegexString: "[a-z_0-9]+_e",
+    structRegexString: "[a-z_0-9]+_s",
+    unionRegexString: "[a-z_0-9]+_u")");
     TidyConfigParser parser(config_str);
 
     auto config = parser.getConfig();
@@ -127,6 +129,8 @@ TEST_CASE("TidyParser: Set check config") {
     CHECK(config.getCheckConfigs().coverpointRegexString == "^coverpoint_\\S*");
     CHECK(config.getCheckConfigs().crossRegexString == "^cross_coverpoint_\\S*");
     CHECK(config.getCheckConfigs().enumRegexString == "[a-z_0-9]+_e");
+    CHECK(config.getCheckConfigs().structRegexString == "[a-z_0-9]+_s");
+    CHECK(config.getCheckConfigs().unionRegexString == "[a-z_0-9]+_u");
 }
 
 TEST_CASE("TidyParser: CheckConfigs and Checks") {

--- a/tools/tidy/tests/TidyConfigParserTest.cpp
+++ b/tools/tidy/tests/TidyConfigParserTest.cpp
@@ -112,7 +112,8 @@ TEST_CASE("TidyParser: Set check config") {
     inputPortSuffix: _p,
     covergroupRegexString: "^covergroup_\S*",
     coverpointRegexString: "^coverpoint_\S*",
-    crossRegexString: "^cross_coverpoint_\S*")");
+    crossRegexString: "^cross_coverpoint_\S*",
+    enumRegexString: "[a-z_0-9]+_e")");
     TidyConfigParser parser(config_str);
 
     auto config = parser.getConfig();
@@ -125,6 +126,7 @@ TEST_CASE("TidyParser: Set check config") {
     CHECK(config.getCheckConfigs().covergroupRegexString == "^covergroup_\\S*");
     CHECK(config.getCheckConfigs().coverpointRegexString == "^coverpoint_\\S*");
     CHECK(config.getCheckConfigs().crossRegexString == "^cross_coverpoint_\\S*");
+    CHECK(config.getCheckConfigs().enumRegexString == "[a-z_0-9]+_e");
 }
 
 TEST_CASE("TidyParser: CheckConfigs and Checks") {

--- a/tools/tidy/tests/TidyConfigParserTest.cpp
+++ b/tools/tidy/tests/TidyConfigParserTest.cpp
@@ -115,7 +115,8 @@ TEST_CASE("TidyParser: Set check config") {
     crossRegexString: "^cross_coverpoint_\S*",
     enumRegexString: "[a-z_0-9]+_e",
     structRegexString: "[a-z_0-9]+_s",
-    unionRegexString: "[a-z_0-9]+_u")");
+    unionRegexString: "[a-z_0-9]+_u",
+    typedefRegexString: "[a-z_0-9]+_t")");
     TidyConfigParser parser(config_str);
 
     auto config = parser.getConfig();
@@ -131,6 +132,7 @@ TEST_CASE("TidyParser: Set check config") {
     CHECK(config.getCheckConfigs().enumRegexString == "[a-z_0-9]+_e");
     CHECK(config.getCheckConfigs().structRegexString == "[a-z_0-9]+_s");
     CHECK(config.getCheckConfigs().unionRegexString == "[a-z_0-9]+_u");
+    CHECK(config.getCheckConfigs().typedefRegexString == "[a-z_0-9]+_t");
 }
 
 TEST_CASE("TidyParser: CheckConfigs and Checks") {

--- a/tools/tidy/tests/TypedefNameTest.cpp
+++ b/tools/tidy/tests/TypedefNameTest.cpp
@@ -1,0 +1,109 @@
+// SPDX-FileCopyrightText: Michael Popoloski
+// SPDX-License-Identifier: MIT
+
+#include "TidyConfigParser.h"
+#include "TidyTest.h"
+
+static TidyConfig typedefNames(std::string_view regex) {
+    TidyConfig config;
+    auto& c = config.getCheckConfigs();
+    c.typedefRegexString = regex;
+    c.typedefRegexPattern = boost::regex(c.typedefRegexString);
+    return config;
+}
+
+static TidyConfig typedefNamesNoSpecialized(std::string_view regex) {
+    std::string configStr = R"(Checks:
+    -style-enum-name,
+    -style-struct-name,
+    -style-union-name
+CheckConfigs:
+    typedefRegexString: ")";
+    configStr += regex;
+    configStr += "\"\n";
+    return TidyConfigParser(configStr).getConfig();
+}
+
+static TidyConfig typedefNamesDisable(std::string_view regex, std::string_view disabledChecks) {
+    std::string configStr = "Checks:\n    ";
+    configStr += disabledChecks;
+    configStr += "\nCheckConfigs:\n    typedefRegexString: \"";
+    configStr += regex;
+    configStr += "\"\n";
+    return TidyConfigParser(configStr).getConfig();
+}
+
+TEST_CASE("TypedefName: matching name") {
+    CHECK(runCheckTest("TypedefName", "typedef logic my_type_t;", typedefNames(".*_t")));
+}
+
+TEST_CASE("TypedefName: mismatched name") {
+    CHECK_FALSE(runCheckTest("TypedefName", "typedef logic my_type;", typedefNames(".*_t")));
+}
+
+TEST_CASE("TypedefName: alias of another type") {
+    CHECK(runCheckTest("TypedefName", "typedef logic my_type_t; typedef my_type_t other_t;",
+                       typedefNames(".*_t")));
+    CHECK_FALSE(runCheckTest("TypedefName", "typedef logic my_type_t; typedef my_type_t other;",
+                             typedefNames(".*_t")));
+}
+
+TEST_CASE("TypedefName: typedef in class") {
+    CHECK(runCheckTest("TypedefName", R"(
+class C;
+    typedef logic my_type_t;
+endclass
+)",
+                       typedefNames(".*_t")));
+}
+
+TEST_CASE("TypedefName: forward declaration") {
+    CHECK(runCheckTest("TypedefName", "typedef my_type_t;", typedefNames(".*_t")));
+    CHECK_FALSE(runCheckTest("TypedefName", "typedef my_type;", typedefNames(".*_t")));
+}
+
+TEST_CASE("TypedefName: class forward declaration") {
+    CHECK(runCheckTest("TypedefName", "typedef class my_type_t;", typedefNames(".*_t")));
+    CHECK_FALSE(runCheckTest("TypedefName", "typedef class my_type;", typedefNames(".*_t")));
+}
+
+TEST_CASE("TypedefName: default regex") {
+    CHECK(runCheckTest("TypedefName", "typedef logic my_type_t;"));
+    CHECK(runCheckTest("TypedefName", "typedef logic my_type_2_t;"));
+    CHECK_FALSE(runCheckTest("TypedefName", "typedef logic my_type;"));
+    CHECK_FALSE(runCheckTest("TypedefName", "typedef logic My_type_t;"));
+}
+
+TEST_CASE("TypedefName: specialized checks take precedence when enabled") {
+    auto config = typedefNames(".*_t");
+    CHECK(runCheckTest("TypedefName", "typedef enum { RED, BLUE } color_e;", config));
+    CHECK(runCheckTest("TypedefName", "typedef struct { int value; } color_s;", config));
+    CHECK(runCheckTest("TypedefName", "typedef union { int value; } color_u;", config));
+    CHECK(runCheckTest("TypedefName", "typedef enum color_e;", config));
+    CHECK(runCheckTest("TypedefName", "typedef struct color_s;", config));
+    CHECK(runCheckTest("TypedefName", "typedef union color_u;", config));
+}
+
+TEST_CASE("TypedefName: still lints non-specialized typedefs when specialized checks are enabled") {
+    auto config = typedefNames(".*_t");
+    CHECK_FALSE(runCheckTest("TypedefName", "typedef logic color_e;", config));
+}
+
+TEST_CASE("TypedefName: applies to enum/struct/union when specialized checks are disabled") {
+    auto config = typedefNamesNoSpecialized(".*_t");
+    CHECK_FALSE(runCheckTest("TypedefName", "typedef enum { RED, BLUE } color_e;", config));
+    CHECK_FALSE(runCheckTest("TypedefName", "typedef struct { int value; } color_s;", config));
+    CHECK_FALSE(runCheckTest("TypedefName", "typedef union { int value; } color_u;", config));
+    CHECK(runCheckTest("TypedefName", "typedef enum { RED, BLUE } color_t;", config));
+    CHECK(runCheckTest("TypedefName", "typedef struct { int value; } color_t;", config));
+    CHECK(runCheckTest("TypedefName", "typedef union { int value; } color_t;", config));
+    CHECK_FALSE(runCheckTest("TypedefName", "typedef enum color_e;", config));
+    CHECK(runCheckTest("TypedefName", "typedef enum color_t;", config));
+}
+
+TEST_CASE("TypedefName: only enabled specialized checks take precedence") {
+    auto config = typedefNamesDisable(".*_t", "-style-enum-name");
+    CHECK_FALSE(runCheckTest("TypedefName", "typedef enum { RED, BLUE } color_e;", config));
+    CHECK(runCheckTest("TypedefName", "typedef struct { int value; } color_s;", config));
+    CHECK(runCheckTest("TypedefName", "typedef union { int value; } color_u;", config));
+}

--- a/tools/tidy/tests/UnionNameTest.cpp
+++ b/tools/tidy/tests/UnionNameTest.cpp
@@ -1,0 +1,46 @@
+// SPDX-FileCopyrightText: Michael Popoloski
+// SPDX-License-Identifier: MIT
+
+#include "TidyTest.h"
+
+static TidyConfig unionNames(std::string_view regex) {
+    TidyConfig config;
+    auto& c = config.getCheckConfigs();
+    c.unionRegexString = regex;
+    c.unionRegexPattern = boost::regex(c.unionRegexString);
+    return config;
+}
+
+TEST_CASE("UnionName: matching name") {
+    CHECK(runCheckTest("UnionName", "typedef union { int value; } color_u;", unionNames(".*_u")));
+}
+
+TEST_CASE("UnionName: mismatched name") {
+    CHECK_FALSE(
+        runCheckTest("UnionName", "typedef union { int value; } color_t;", unionNames(".*_u")));
+}
+
+TEST_CASE("UnionName: ignores non-union typedefs") {
+    CHECK(runCheckTest("UnionName", "typedef struct { int value; } color_t;", unionNames(".*_u")));
+}
+
+TEST_CASE("UnionName: tagged union in class") {
+    CHECK(runCheckTest("UnionName", R"(
+class C;
+    typedef union tagged { int value; } color_u;
+endclass
+)",
+                       unionNames(".*_u")));
+}
+
+TEST_CASE("UnionName: forward declaration") {
+    CHECK(runCheckTest("UnionName", "typedef union color_u;", unionNames(".*_u")));
+    CHECK_FALSE(runCheckTest("UnionName", "typedef union color_t;", unionNames(".*_u")));
+}
+
+TEST_CASE("UnionName: default regex") {
+    CHECK(runCheckTest("UnionName", "typedef union { int value; } color_t;"));
+    CHECK(runCheckTest("UnionName", "typedef union { int value; } color_mode_2_t;"));
+    CHECK_FALSE(runCheckTest("UnionName", "typedef union { int value; } color_u;"));
+    CHECK_FALSE(runCheckTest("UnionName", "typedef union { int value; } Color_t;"));
+}


### PR DESCRIPTION
Specific lints for:
Union, Struct, Enum.

General lint for all other typedef's

Enabled by default.