### PR TITLE
Diagnose runaway generic class specialization instead of crashing

### DIFF
--- a/include/slang/ast/symbols/ClassSymbols.h
+++ b/include/slang/ast/symbols/ClassSymbols.h
@@ -48,6 +48,11 @@ public:
     /// a pointer to that generic class definition.
     const GenericClassDefSymbol* genericClass = nullptr;
 
+    /// The depth of this specialization within a chain of specializations of
+    /// the same generic class. Used to bound runaway recursive specialization;
+    /// see GenericClassDefSymbol::getSpecializationImpl.
+    mutable uint32_t specializationDepth = 0;
+
     /// The list of generic parameters for this class specialization, if any.
     std::span<const Symbol* const> genericParameters;
 

--- a/source/ast/symbols/ClassSymbols.cpp
+++ b/source/ast/symbols/ClassSymbols.cpp
@@ -1030,10 +1030,39 @@ const Type* GenericClassDefSymbol::getSpecializationImpl(
         return &comp.getErrorType();
     }
 
+    // The recursionDepth guard above only catches specializations that nest
+    // directly on the call stack. A specialization can also request another
+    // specialization of the same generic class lazily -- for example when
+    // computing the bitstream width of a class property whose type is the
+    // class itself, parameterized by a decrementing value with no base case.
+    // That chain is driven from ClassType::computeSize rather than from a
+    // nested getSpecialization call, so recursionDepth returns to zero between
+    // links and never trips, and the unbounded chain overflows the stack.
+    // Bound it explicitly by tracking, for each specialization, its depth
+    // within a chain of specializations of this same generic class.
+    uint32_t specChainDepth = 0;
+    for (const Scope* s = context.scope; s;) {
+        auto& enclosingSym = s->asSymbol();
+        if (enclosingSym.kind == SymbolKind::ClassType) {
+            auto& enclosing = enclosingSym.as<ClassType>();
+            if (enclosing.genericClass == this) {
+                specChainDepth = enclosing.specializationDepth + 1;
+                break;
+            }
+        }
+        s = enclosingSym.getParentScope();
+    }
+
+    if (specChainDepth > comp.getOptions().maxRecursiveClassSpecialization) {
+        context.addDiag(diag::RecursiveClassSpecialization, instanceLoc) << name;
+        return &comp.getErrorType();
+    }
+
     // Create a class type instance to hold the parameters. If it turns out we already
     // have this specialization cached we'll throw it away, but that's not a big deal.
     auto classType = comp.emplace<ClassType>(comp, name, location);
     classType->genericClass = this;
+    classType->specializationDepth = specChainDepth;
     classType->isUninstantiated = forceInvalidParams || context.scope->isUninstantiated();
     classType->setParent(*scope, getIndex());
 

--- a/tests/unittests/ast/ClassTests.cpp
+++ b/tests/unittests/ast/ClassTests.cpp
@@ -2930,6 +2930,29 @@ endmodule
     CHECK(diags[1].code == diag::RecursiveClassSpecialization);
 }
 
+TEST_CASE("Recursive generic class specialization via property") {
+    // Regression test: a generic class with a property whose type is the
+    // class itself parameterized by a decrementing value with no base case
+    // used to recurse infinitely while computing its bitstream width and
+    // overflow the stack. It should be diagnosed instead.
+    auto tree = SyntaxTree::fromText(R"(
+class Tree #(int DEPTH = 3);
+    Tree #(DEPTH-1) child;
+endclass
+
+module top;
+    Tree #(2) t;
+endmodule
+)");
+
+    Compilation compilation;
+    compilation.addSyntaxTree(tree);
+
+    auto& diags = compilation.getAllDiagnostics();
+    REQUIRE(diags.size() == 1);
+    CHECK(diags[0].code == diag::RecursiveClassSpecialization);
+}
+
 TEST_CASE("Extend from final class") {
     auto options = optionsFor(LanguageVersion::v1800_2023);
     auto tree = SyntaxTree::fromText(R"(


### PR DESCRIPTION
### Problem

A generic class whose property type is the class itself, parameterized by a
value that changes with no base case, sends slang into unbounded recursion
and crashes with a stack-overflow `SIGSEGV`.

Minimal repro (`seg.sv`):

```systemverilog
class Tree #(int DEPTH = 3);
  Tree #(DEPTH-1) child;
endclass
module top; Tree #(2) t; endmodule
```

```
$ slang seg.sv
Segmentation fault (core dumped)   # exit 139
```

`slang --version`: `slang version 11.0.0+ed5621f26` (also reproduces on
current `master`).

### Root cause

`GenericClassDefSymbol::getSpecializationImpl` already has a `recursionDepth`
guard that emits `diag::RecursiveClassSpecialization` past
`maxRecursiveClassSpecialization` (default 8). But that guard only counts
specializations that nest *directly* on the call stack.

Here the chain is not created that way. Each `Tree#(k)` is a distinct
specialization (distinct parameter value → distinct `ClassType` →
distinct `cachedBitstreamWidth`), so the self-cycle guard in
`ClassType::computeSize` (which zeroes `cachedBitstreamWidth` to break a
class referring to *itself*) does not apply. The recursion is:

```
ClassType::computeSize(Tree#(k))
  -> prop.getType().getBitstreamWidth()   // property 'child' : Tree#(k-1)
  -> ClassType::computeSize(Tree#(k-1))
  -> ...
```

`getType()` lazily creates the next specialization, and `getBitstreamWidth()`
recurses into it. Because each `getSpecializationImpl` call returns before the
next one is entered (population is lazy; the recursion is driven from
`computeSize`, not from a nested `getSpecialization` call), `recursionDepth`
returns to zero between links and never trips. The chain is unbounded and
overflows the stack. Confirmed with a backtrace: a two-frame cycle of
`ClassType::computeSize` <-> `ClassType::getBitstreamWidth`.

Note a `computeSize`-only guard would not be enough: the `ElabVisitors`
finalize worklist would keep creating fresh specializations via
`declaredType->getType()`, turning the crash into an unbounded
specialization loop. The chain has to be bounded at *creation*.

### Fix

In `getSpecializationImpl`, in addition to the existing on-stack
`recursionDepth` guard, track each specialization's depth within a chain of
specializations of the same generic class. The depth is derived from the
requesting context (the enclosing `ClassType` of the same generic class),
stored on the new `ClassType::specializationDepth`, and checked against
`maxRecursiveClassSpecialization`. When the limit is exceeded we emit the
existing `RecursiveClassSpecialization` diagnostic and return the error type,
so no further link in the chain is ever requested.

### Verification

Built `RelWithDebInfo` locally (gcc 13.3) and confirmed:

- The repro (and the property-only variant) now report
  `error: potentially infinitely recursive specialization of class 'Tree'`
  and exit cleanly instead of `SIGSEGV`.
- No false positives: independent specializations (`Box#(4)`, `#(8)`,
  `#(16)`), a finite class-handle chain, and finite nested generic classes
  all still compile with 0 errors.
- The existing `Invalid recursive generic class specialization` test still
  produces exactly its two `RecursiveClassSpecialization` diagnostics.
- Added a regression unit test in `tests/unittests/ast/ClassTests.cpp`.
- The full `unittests` suite passes.

Disclosure: this contribution was authored with an AI coding assistant (Claude) and reviewed before submission.
