### PR TITLE
Fix internal error on integer/char formatting of a null handle

### DIFF
--- a/source/ast/SFormat.cpp
+++ b/source/ast/SFormat.cpp
@@ -545,21 +545,34 @@ void formatPattern(std::string& result, const ConstantValue& arg, const Type& ty
     result += visitor.buffer.str();
 }
 
+// A class handle, a chandle, or the null literal has no integer value:
+// convertToInt() yields an invalid ConstantValue for them. The format-string
+// checker (checkArgType) permits these types for the integer/char specifiers
+// (%h %x %d %o %b %c), so instead of dereferencing the missing value (which does
+// std::get<SVInt> on the wrong variant and aborts with an internal error) format
+// them as their numeric value, which is zero for a null handle.
+static SVInt toFormatInt(const ConstantValue& arg) {
+    auto cv = arg.convertToInt();
+    if (cv.bad())
+        return SVInt::Zero;
+    return cv.integer();
+}
+
 void formatArg(std::string& result, const ConstantValue& arg, const Type& type, char specifier,
                const FormatOptions& options, bool isStringLiteral) {
     switch (charToLower(specifier)) {
         case 'h':
         case 'x':
-            formatInt(result, arg.convertToInt().integer(), LiteralBase::Hex, options);
+            formatInt(result, toFormatInt(arg), LiteralBase::Hex, options);
             return;
         case 'd':
-            formatInt(result, arg.convertToInt().integer(), LiteralBase::Decimal, options);
+            formatInt(result, toFormatInt(arg), LiteralBase::Decimal, options);
             return;
         case 'o':
-            formatInt(result, arg.convertToInt().integer(), LiteralBase::Octal, options);
+            formatInt(result, toFormatInt(arg), LiteralBase::Octal, options);
             return;
         case 'b':
-            formatInt(result, arg.convertToInt().integer(), LiteralBase::Binary, options);
+            formatInt(result, toFormatInt(arg), LiteralBase::Binary, options);
             return;
         case 'u':
             formatRaw2(result, arg);
@@ -576,11 +589,11 @@ void formatArg(std::string& result, const ConstantValue& arg, const Type& type, 
             auto timeOptions = options;
             if (!timeOptions.width)
                 timeOptions.width = 20;
-            formatInt(result, arg.convertToInt().integer(), LiteralBase::Decimal, timeOptions);
+            formatInt(result, toFormatInt(arg), LiteralBase::Decimal, timeOptions);
             return;
         }
         case 'c':
-            formatChar(result, arg.convertToInt().integer());
+            formatChar(result, toFormatInt(arg));
             return;
         case 'v':
             formatStrength(result, arg.integer());

--- a/tests/unittests/ast/EvalTests.cpp
+++ b/tests/unittests/ast/EvalTests.cpp
@@ -1297,6 +1297,29 @@ endfunction
     NO_SESSION_ERRORS;
 }
 
+TEST_CASE("Integer format specifiers on null literal or chandle") {
+    // Regression: %d/%h/%x/%o/%b/%c on the null literal or a chandle previously aborted
+    // with an internal error (std::get on an invalid ConstantValue variant). The
+    // format-string checker permits these types for the integer specifiers, so they
+    // must format as their numeric value (zero for a null handle).
+    ScriptSession session;
+    CHECK(session.eval("$sformatf(\"%0d\", null)"s).str() == "0");
+    CHECK(session.eval("$sformatf(\"%0x\", null)"s).str() == "0");
+    CHECK(session.eval("$sformatf(\"%0o\", null)"s).str() == "0");
+    CHECK(session.eval("$sformatf(\"%0b\", null)"s).str() == "0");
+    CHECK(session.eval("$sformatf(\"%0h\", null)"s).str() == "0");
+    CHECK(session.eval("$sformatf(\"%c\", null)"s).str() == std::string(1, '\0'));
+
+    session.eval(R"(
+function automatic string f_chandle();
+    chandle ch = null;
+    return $sformatf("%0x", ch);
+endfunction
+)");
+    CHECK(session.eval("f_chandle()").str() == "0");
+    NO_SESSION_ERRORS;
+}
+
 TEST_CASE("Concat assignments") {
     ScriptSession session;
     session.eval("logic [2:0] foo;");


### PR DESCRIPTION
The integer and char format specifiers (`%h` `%x` `%d` `%o` `%b` `%c`) accept a class handle, a `chandle`, or the `null` literal — `checkArgType()` explicitly permits those types. In a constant context, though, `formatArg` formatted them via `arg.convertToInt().integer()`, and `convertToInt()` returns an invalid (`bad`) `ConstantValue` for a null handle, so `integer()` does `std::get<SVInt>` on the wrong variant and aborts with `internal compiler error: std::get: wrong index for variant`.

### Repro

```sv
module m; localparam string S = $sformatf("%d", null); endmodule
```

Also crashes with `%x` / `%o` / `%b` / `%h` / `%c`, and with a `chandle` in a constant function:

```sv
module m;
  function automatic string f(); chandle c = null; return $sformatf("%x", c); endfunction
  localparam string S = f();
endmodule
```

### Fix

Guard the conversion in a small helper: when `convertToInt()` produces no usable integer, format the null handle as its numeric value of zero (`SVInt::Zero`) instead of dereferencing the missing value. This mirrors the variant-aware fix in #1916 for the `%u`/`%z` specifiers and matches how a null handle formats numerically. (A class handle is already rejected earlier in a constant context, so the `null` literal and a `chandle` are the values that actually reach `formatArg`.)

Added a regression test in `EvalTests.cpp`; the full unit test suite passes (22972 assertions in 2487 test cases).

Disclosure: this contribution was authored with an AI coding assistant (Claude) and reviewed before submission.
