### PR TITLE
numeric: fix SVInt::set dropping high words when promoting to 4-state

### DIFF
--- a/source/numeric/SVInt.cpp
+++ b/source/numeric/SVInt.cpp
@@ -1516,7 +1516,7 @@ void SVInt::set(int32_t msb, int32_t lsb, const SVInt& value) {
 
     if (!hasUnknown() && value.hasUnknown()) {
         uint64_t* newData = new uint64_t[getNumWords(bitWidth, true)]();
-        memcpy(newData, getRawData(), getNumWords());
+        memcpy(newData, getRawData(), getNumWords() * WORD_SIZE);
 
         if (!isSingleWord())
             delete[] pVal;

--- a/tests/unittests/util/NumericTests.cpp
+++ b/tests/unittests/util/NumericTests.cpp
@@ -627,6 +627,22 @@ TEST_CASE("Slicing") {
           "215'h728560c56c16d0b0be23da38038624767ffffffffffffffffffffd");
 }
 
+TEST_CASE("SVInt set promoting a known value to 4-state preserves high words") {
+    // Assigning an x/z into a bit/part-select of a known (2-state) value promotes
+    // it to 4-state; the promotion must copy every word of the old value, not just
+    // its low byte. Regression: the copy used a word count as a byte count, so any
+    // bit set above bit 7 was dropped when the value was widened.
+    SVInt v1 = "16'hff00"_si;
+    v1.set(0, 0, "1'bx"_si);
+    CHECK_THAT(v1, exactlyEquals("16'b111111110000000x"_si));
+
+    // Multi-word case: the high word must survive the promotion too.
+    SVInt v2(96, 0, false);
+    v2.set(95, 64, "32'hdeadbeef"_si);
+    v2.set(0, 0, "1'bx"_si);
+    CHECK_THAT(v2.slice(95, 64), exactlyEquals("32'hdeadbeef"_si));
+}
+
 TEST_CASE("SVInt misc functions") {
     CHECK("100'b111"_si.countLeadingZeros() == 97);
     CHECK("128'hffff000000000000ffff000000000000"_si.countLeadingOnes() == 16);


### PR DESCRIPTION
### Problem

`SVInt::set(msb, lsb, value)` promotes a known (2-state) target to 4-state when the assigned `value` has `x`/`z` bits. The promotion allocates a larger buffer and copies the old value in:

```cpp
uint64_t* newData = new uint64_t[getNumWords(bitWidth, true)]();
memcpy(newData, getRawData(), getNumWords());
```

`memcpy`'s third argument is a **byte** count, but `getNumWords()` is a **word** count. So only `getNumWords()` bytes are copied instead of `getNumWords() * WORD_SIZE`. The new buffer is zero-initialized, so every bit above bit 7 of the old value is silently dropped. This is the only `memcpy`/`memset` in `SVInt.cpp` that doesn't multiply the word count by `WORD_SIZE`.

### Reproducer

```systemverilog
module m;
  function automatic logic [15:0] f();
    logic [15:0] a;
    a = 16'hFF00;   // known 2-state, high byte = 0xFF
    a[0] = 1'bx;    // assign x into a bit-select -> promotes to 4-state
    return a;
  endfunction
  localparam logic [15:0] R = f();
endmodule
```

Built from a clean tree, `slang repro.sv --ast-json ...` evaluates `R` to `16'b0x` (the high byte `0xFF` is wrongly zeroed). Expected `16'b111111110000000x`. A control that assigns `1'b0` instead of `1'bx` (no promotion) correctly yields `16'hFF00`. This hits any procedural bit/part-select `x`/`z` assignment to a wider-than-8-bit known value during constant evaluation (constant functions, `localparam`s, static-initializer code).

### Fix

Copy `getNumWords() * WORD_SIZE` bytes, matching every other copy in the file. After the fix the reproducer evaluates `R` to `16'b111111110000000x`.

### Testing

Added a regression test in `NumericTests.cpp` (single-word 16-bit case and a multi-word 96-bit case where a high word must survive the promotion). Built and ran the unit tests: the new test and the existing `Slicing` test pass; the new test fails on the unpatched code.

Disclosure: this contribution was authored with an AI coding assistant (Claude) and reviewed and validated before submission.
