### PR TITLE
Fix instance cache key ignoring arrayed interface port connections

### DIFF
--- a/source/ast/InstanceCacheKey.cpp
+++ b/source/ast/InstanceCacheKey.cpp
@@ -38,7 +38,7 @@ InstanceCacheKey::InstanceCacheKey(const InstanceSymbol& symbol, bool& valid,
             auto [iface, modport] = conn->getIfaceConn();
             while (iface && iface->kind == SymbolKind::InstanceArray) {
                 auto& arr = iface->as<InstanceArraySymbol>();
-                if (arr.empty())
+                if (arr.elements.empty())
                     iface = nullptr;
                 else
                     iface = arr.elements[0];

--- a/tests/unittests/ast/InterfaceTests.cpp
+++ b/tests/unittests/ast/InterfaceTests.cpp
@@ -1326,3 +1326,37 @@ endclass
     compilation.addSyntaxTree(tree);
     NO_COMPILATION_ERRORS;
 }
+
+TEST_CASE("Arrayed interface port cache regress -- GH #1947") {
+    // NoAck has no 'ack', so on_no_ack is in error. It is written second because that is
+    // the instance a shared body would hide.
+    auto tree = SyntaxTree::fromText(R"(
+interface HasAck;
+    logic req;
+    logic ack;
+endinterface
+
+interface NoAck;
+    logic req;
+endinterface
+
+module Reader (interface a[2]);
+    initial $display("%b", a[0].ack);
+endmodule
+
+module top;
+    HasAck has_ack [2] ();
+    NoAck no_ack [2] ();
+
+    Reader on_has_ack (.a(has_ack));
+    Reader on_no_ack (.a(no_ack));
+endmodule
+)");
+
+    Compilation compilation;
+    compilation.addSyntaxTree(tree);
+
+    auto& diags = compilation.getAllDiagnostics();
+    REQUIRE(diags.size() == 1);
+    CHECK(diags[0].code == diag::CouldNotResolveHierarchicalPath);
+}


### PR DESCRIPTION
## Summary

Fixes #1947. Two instances of a module whose interface port carries a range were cached together even when connected to arrays of different interfaces, so the second one's body was never visited and errors in it were dropped. Which instance got checked depended on the order they were written in. The issue has the full background; this PR is the one-line fix plus a test.

## Design

- `InstanceCacheKey` guarded its descent with `arr.empty()`, which resolves to `Scope::empty()` -- whether the symbol has members, not whether it has elements. The array a port connection carries comes from `rewireIfaceArrayIndices`, which fills `elements` and adds no members, since that array is only handed to `PortConnection` and never placed in a scope for anything to traverse. So the guard fired, the descent bailed out to null, the interface contributed nothing to the key, and both instances hashed to just the definition pointer and compared equal.
- Every other place that asks this question already tests `elements`. `Lookup.cpp` (`selectChild`, `selectChildRange`), `Expression.cpp` and `MiscStatements.cpp` all use `array.elements.empty()`, and this was the only `arr.empty()`.

## Testing

New test in `InterfaceTests.cpp`, with one module taking an arrayed generic interface port and instantiated against two interfaces where only one declares the member the module reads. The error is reported with the offending instance written second, where before the change that case produced no diagnostics at all. The full suite passes.

## AI disclosure

Per the project's CONTRIBUTING.md: parts of this patch were drafted with assistance from Claude. I reviewed every line and am fully accountable for the change.
