### PR TITLE
Updated the get_git_head_revision to fix the bare worktree bug. 

### DIFF
--- a/cmake/gitversion.cmake
+++ b/cmake/gitversion.cmake
@@ -15,48 +15,20 @@ set(__get_git_version YES)
 # find the path to this module rather than the path to a calling list file
 get_filename_component(_gitversionmoddir ${CMAKE_CURRENT_LIST_FILE} PATH)
 
-# Function _git_find_closest_git_dir finds the next closest .git directory that
-# is part of any directory in the path defined by _start_dir. The result is
-# returned in the parent scope variable whose name is passed as variable
-# _git_dir_var. If no .git directory can be found, the function returns an empty
-# string via _git_dir_var.
-#
-# Example: Given a path C:/bla/foo/bar and assuming C:/bla/.git exists and
-# neither foo nor bar contain a file/directory .git. This wil return C:/bla/.git
-#
-function(_git_find_closest_git_dir _start_dir _git_dir_var)
-  set(cur_dir "${_start_dir}")
-  set(git_dir "${_start_dir}/.git")
-  while(NOT EXISTS "${git_dir}")
-    # .git dir not found, search parent directories
-    set(git_previous_parent "${cur_dir}")
-    get_filename_component(cur_dir "${cur_dir}" DIRECTORY)
-    if(cur_dir STREQUAL git_previous_parent)
-      # We have reached the root directory, we are not in git
-      set(${_git_dir_var}
-          ""
-          PARENT_SCOPE)
-      return()
-    endif()
-    set(git_dir "${cur_dir}/.git")
-  endwhile()
-  set(${_git_dir_var}
-      "${git_dir}"
-      PARENT_SCOPE)
-endfunction()
-
+# Update variables set in _refspecvar and _hashvar to the current git HEAD's ref and hash
+# If we are not operating in a standard repo, worktree, or sub-module these will be set to:
+#   'GITDIR-NOTFOUND'. This allows the upstream CMake to opt not to use this functionality.
 function(get_git_head_revision _refspecvar _hashvar)
-  _git_find_closest_git_dir("${CMAKE_CURRENT_SOURCE_DIR}" GIT_DIR)
+  # Start by checking we are operating in a git setup for slang
+  # This is equivalent to the previous check that the GIT_DIR begin relative to CMAKE_SOURCE_DIR
+  execute_process(
+      COMMAND "${GIT_EXECUTABLE}" rev-parse --show-toplevel
+      WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
+      OUTPUT_VARIABLE _git_toplevel RESULT_VARIABLE _result
+      ERROR_QUIET OUTPUT_STRIP_TRAILING_WHITESPACE)
 
-  if(NOT "${GIT_DIR}" STREQUAL "")
-    file(RELATIVE_PATH _relative_to_source_dir "${CMAKE_SOURCE_DIR}"
-         "${GIT_DIR}")
-    if("${_relative_to_source_dir}" MATCHES "[.][.]")
-      # We've gone above the CMake root dir.
-      set(GIT_DIR "")
-    endif()
-  endif()
-  if("${GIT_DIR}" STREQUAL "")
+  # We are not in a git project
+  if (NOT _result EQUAL 0)
     set(${_refspecvar}
         "GITDIR-NOTFOUND"
         PARENT_SCOPE)
@@ -66,51 +38,68 @@ function(get_git_head_revision _refspecvar _hashvar)
     return()
   endif()
 
-  # Check if the current source dir is a git submodule or a worktree. In both
-  # cases .git is a file instead of a directory.
-  #
-  if(NOT IS_DIRECTORY ${GIT_DIR})
-    # The following git command will return a non empty string that points to
-    # the super project working tree if the current source dir is inside a git
-    # submodule. Otherwise the command will return an empty string.
-    #
-    execute_process(
-      COMMAND "${GIT_EXECUTABLE}" rev-parse --show-superproject-working-tree
-      WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
-      OUTPUT_VARIABLE out
-      ERROR_QUIET OUTPUT_STRIP_TRAILING_WHITESPACE)
-    if(NOT "${out}" STREQUAL "")
-      # If out is empty, GIT_DIR/CMAKE_CURRENT_SOURCE_DIR is in a submodule
-      file(READ ${GIT_DIR} submodule)
-      string(REGEX REPLACE "gitdir: (.*)$" "\\1" GIT_DIR_RELATIVE ${submodule})
-      string(STRIP ${GIT_DIR_RELATIVE} GIT_DIR_RELATIVE)
-      get_filename_component(SUBMODULE_DIR ${GIT_DIR} PATH)
-      get_filename_component(GIT_DIR ${SUBMODULE_DIR}/${GIT_DIR_RELATIVE}
-                             ABSOLUTE)
-      set(HEAD_SOURCE_FILE "${GIT_DIR}/HEAD")
-    else()
-      # GIT_DIR/CMAKE_CURRENT_SOURCE_DIR is in a worktree
-      file(READ ${GIT_DIR} worktree_ref)
-      # The .git directory contains a path to the worktree information directory
-      # inside the parent git repo of the worktree.
-      #
-      string(REGEX REPLACE "gitdir: (.*)$" "\\1" git_worktree_dir
-                           ${worktree_ref})
-      string(STRIP ${git_worktree_dir} git_worktree_dir)
-      _git_find_closest_git_dir("${git_worktree_dir}" GIT_DIR)
-      set(HEAD_SOURCE_FILE "${git_worktree_dir}/HEAD")
-    endif()
-  else()
-    set(HEAD_SOURCE_FILE "${GIT_DIR}/HEAD")
+  # If we are in a vendored project
+  # Must be done after the return-value check to avoid RELATIVE_PATH erroring 
+  #   out when there is no _git_toplevel
+  file(RELATIVE_PATH _relative_to_source_dir "${CMAKE_SOURCE_DIR}"
+       "${_git_toplevel}")
+  if ("${_relative_to_source_dir}" MATCHES "[.][.]")
+    set(${_refspecvar}
+        "GITDIR-NOTFOUND"
+        PARENT_SCOPE)
+    set(${_hashvar}
+        "GITDIR-NOTFOUND"
+        PARENT_SCOPE)
+    return()
   endif()
+
+  # Directly use git rev-parse to get the head file for the current branch
+  # Works in plain repos, worktrees, and submodules
+  execute_process(
+      COMMAND "${GIT_EXECUTABLE}" rev-parse --git-path HEAD
+      WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
+      OUTPUT_VARIABLE HEAD_SOURCE_FILE RESULT_VARIABLE _result
+      ERROR_QUIET OUTPUT_STRIP_TRAILING_WHITESPACE)
+
+  # Check the command found a valid HEAD file
+  if (NOT _result EQUAL 0 OR NOT EXISTS "${HEAD_SOURCE_FILE}")
+    set(${_refspecvar}
+        "GITDIR-NOTFOUND"
+        PARENT_SCOPE)
+    set(${_hashvar}
+        "GITDIR-NOTFOUND"
+        PARENT_SCOPE)
+    return()
+  endif()
+
+  # Now find the GIT_DIR using rev-parse
+  execute_process(
+      COMMAND "${GIT_EXECUTABLE}" rev-parse --git-common-dir
+      WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
+      OUTPUT_VARIABLE GIT_DIR RESULT_VARIABLE _result
+      ERROR_QUIET OUTPUT_STRIP_TRAILING_WHITESPACE)
+
+  if(NOT _result EQUAL 0 OR "${GIT_DIR}" STREQUAL "")
+    set(${_refspecvar}
+        "GITDIR-NOTFOUND"
+        PARENT_SCOPE)
+    set(${_hashvar}
+        "GITDIR-NOTFOUND"
+        PARENT_SCOPE)
+    return()
+  endif()
+
+  # Absolutize the GIT_DIR and HEAD_SOURCE_FILE
+  get_filename_component(GIT_DIR "${GIT_DIR}" ABSOLUTE
+                         BASE_DIR "${CMAKE_CURRENT_SOURCE_DIR}")
+  get_filename_component(HEAD_SOURCE_FILE "${HEAD_SOURCE_FILE}" ABSOLUTE
+                         BASE_DIR "${CMAKE_CURRENT_SOURCE_DIR}")
+
   set(GIT_DATA "${CMAKE_CURRENT_BINARY_DIR}/CMakeFiles/git-data")
   if(NOT EXISTS "${GIT_DATA}")
     file(MAKE_DIRECTORY "${GIT_DATA}")
   endif()
 
-  if(NOT EXISTS "${HEAD_SOURCE_FILE}")
-    return()
-  endif()
   set(HEAD_FILE "${GIT_DATA}/HEAD")
   configure_file("${HEAD_SOURCE_FILE}" "${HEAD_FILE}" COPYONLY)
 

--- a/cmake/gitversion.cmake
+++ b/cmake/gitversion.cmake
@@ -15,20 +15,23 @@ set(__get_git_version YES)
 # find the path to this module rather than the path to a calling list file
 get_filename_component(_gitversionmoddir ${CMAKE_CURRENT_LIST_FILE} PATH)
 
-# Update variables set in _refspecvar and _hashvar to the current git HEAD's ref and hash
-# If we are not operating in a standard repo, worktree, or sub-module these will be set to:
-#   'GITDIR-NOTFOUND'. This allows the upstream CMake to opt not to use this functionality.
+# Update variables set in _refspecvar and _hashvar to the current git HEAD's ref
+# and hash If we are not operating in a standard repo, worktree, or sub-module
+# these will be set to: 'GITDIR-NOTFOUND'. This allows the upstream CMake to opt
+# not to use this functionality.
 function(get_git_head_revision _refspecvar _hashvar)
-  # Start by checking we are operating in a git setup for slang
-  # This is equivalent to the previous check that the GIT_DIR begin relative to CMAKE_SOURCE_DIR
+  # Start by checking we are operating in a git setup for slang This is
+  # equivalent to the previous check that the GIT_DIR begin relative to
+  # CMAKE_SOURCE_DIR
   execute_process(
-      COMMAND "${GIT_EXECUTABLE}" rev-parse --show-toplevel
-      WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
-      OUTPUT_VARIABLE _git_toplevel RESULT_VARIABLE _result
-      ERROR_QUIET OUTPUT_STRIP_TRAILING_WHITESPACE)
+    COMMAND "${GIT_EXECUTABLE}" rev-parse --show-toplevel
+    WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
+    OUTPUT_VARIABLE _git_toplevel
+    RESULT_VARIABLE _result
+    ERROR_QUIET OUTPUT_STRIP_TRAILING_WHITESPACE)
 
   # We are not in a git project
-  if (NOT _result EQUAL 0)
+  if(NOT _result EQUAL 0)
     set(${_refspecvar}
         "GITDIR-NOTFOUND"
         PARENT_SCOPE)
@@ -38,12 +41,11 @@ function(get_git_head_revision _refspecvar _hashvar)
     return()
   endif()
 
-  # If we are in a vendored project
-  # Must be done after the return-value check to avoid RELATIVE_PATH erroring 
-  #   out when there is no _git_toplevel
+  # If we are in a vendored project Must be done after the return-value check to
+  # avoid RELATIVE_PATH erroring out when there is no _git_toplevel
   file(RELATIVE_PATH _relative_to_source_dir "${CMAKE_SOURCE_DIR}"
        "${_git_toplevel}")
-  if ("${_relative_to_source_dir}" MATCHES "[.][.]")
+  if("${_relative_to_source_dir}" MATCHES "[.][.]")
     set(${_refspecvar}
         "GITDIR-NOTFOUND"
         PARENT_SCOPE)
@@ -53,16 +55,17 @@ function(get_git_head_revision _refspecvar _hashvar)
     return()
   endif()
 
-  # Directly use git rev-parse to get the head file for the current branch
-  # Works in plain repos, worktrees, and submodules
+  # Directly use git rev-parse to get the head file for the current branch Works
+  # in plain repos, worktrees, and submodules
   execute_process(
-      COMMAND "${GIT_EXECUTABLE}" rev-parse --git-path HEAD
-      WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
-      OUTPUT_VARIABLE HEAD_SOURCE_FILE RESULT_VARIABLE _result
-      ERROR_QUIET OUTPUT_STRIP_TRAILING_WHITESPACE)
+    COMMAND "${GIT_EXECUTABLE}" rev-parse --git-path HEAD
+    WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
+    OUTPUT_VARIABLE HEAD_SOURCE_FILE
+    RESULT_VARIABLE _result
+    ERROR_QUIET OUTPUT_STRIP_TRAILING_WHITESPACE)
 
   # Check the command found a valid HEAD file
-  if (NOT _result EQUAL 0 OR NOT EXISTS "${HEAD_SOURCE_FILE}")
+  if(NOT _result EQUAL 0 OR NOT EXISTS "${HEAD_SOURCE_FILE}")
     set(${_refspecvar}
         "GITDIR-NOTFOUND"
         PARENT_SCOPE)
@@ -74,10 +77,11 @@ function(get_git_head_revision _refspecvar _hashvar)
 
   # Now find the GIT_DIR using rev-parse
   execute_process(
-      COMMAND "${GIT_EXECUTABLE}" rev-parse --git-common-dir
-      WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
-      OUTPUT_VARIABLE GIT_DIR RESULT_VARIABLE _result
-      ERROR_QUIET OUTPUT_STRIP_TRAILING_WHITESPACE)
+    COMMAND "${GIT_EXECUTABLE}" rev-parse --git-common-dir
+    WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
+    OUTPUT_VARIABLE GIT_DIR
+    RESULT_VARIABLE _result
+    ERROR_QUIET OUTPUT_STRIP_TRAILING_WHITESPACE)
 
   if(NOT _result EQUAL 0 OR "${GIT_DIR}" STREQUAL "")
     set(${_refspecvar}
@@ -90,8 +94,8 @@ function(get_git_head_revision _refspecvar _hashvar)
   endif()
 
   # Absolutize the GIT_DIR and HEAD_SOURCE_FILE
-  get_filename_component(GIT_DIR "${GIT_DIR}" ABSOLUTE
-                         BASE_DIR "${CMAKE_CURRENT_SOURCE_DIR}")
+  get_filename_component(GIT_DIR "${GIT_DIR}" ABSOLUTE BASE_DIR
+                         "${CMAKE_CURRENT_SOURCE_DIR}")
   get_filename_component(HEAD_SOURCE_FILE "${HEAD_SOURCE_FILE}" ABSOLUTE
                          BASE_DIR "${CMAKE_CURRENT_SOURCE_DIR}")
 


### PR DESCRIPTION
**Overview**
The previous implementation of this file worked in a majority of cases, however did not work in Git work trees where the base root tree was a bare repo. This caused a crash in that use-case. Additionally, since the original implementation did not use the git plumbing commands, it was prone to potential errors whereas git plumbing commands are known good and maintained by Git.

**Changes**
1. Change how to detect we are not in a Git repo submodule or work tree
    - Now uses `git rev-parse --show-toplevel`
    - This will error if we are not in a git tracked repo at all (such as when building from a source tar)
    - This will produce a top-level which is above the current source dir if we are vendored (not submoduled) into a project
2. Change how we find the git head source file
   - Now uses `git rev-parse --git-path HEAD`
   - This will find the HEAD file (if it exists) for the current HEAD of a repo, worktree, or submodule regardless of how the user sets up their project structure
3. Change how we find the GIT_DIR
   - Now uses `git rev-parse --git-common-dir`
   - Always points back to the GIT_COMMON_DIR area of the git repo regardless of how the user sets up their project structure

**Validation**
I have built using this script on the following configurations and checked build/CMakeFiles/git-data/
- Standard Repo
- From Source (Cloned out then delete the `.git/` dir)
- Submodule
- Vendored (Submoduled into a repo and then delete the `.git` file from the submodule)
- Worktree (both a bare root and a empty commit root) 

**Issues Addressed**
#1950 

**AI Usage Disclosure**
AI was used to assist with debugging the original issue and finding a root cause. It was also used to review the changes made. It is not responsible for any code or git command used.